### PR TITLE
[FIX] Use the migration machinery to initialize default values

### DIFF
--- a/account_financial_report_webkit/account_move_line.py
+++ b/account_financial_report_webkit/account_move_line.py
@@ -29,26 +29,6 @@ class AccountMoveLine(orm.Model):
     account move line"""
     _inherit = 'account.move.line'
 
-    def init(self, cr):
-        # We do not want to catch error as if sql is not run it will give
-        # invalid data
-        cr.execute("UPDATE account_move_line as acm "
-                   " SET last_rec_date ="
-                   "     (SELECT date from account_move_line"
-                   "          WHERE reconcile_id =  acm.reconcile_id"
-                   "              AND reconcile_id IS NOT NULL"
-                   "          ORDER BY date DESC LIMIT 1)"
-                   " WHERE last_rec_date is null;")
-
-        cr.execute("UPDATE account_move_line as acm "
-                   " SET last_rec_date ="
-                   "     (SELECT date from account_move_line"
-                   "          WHERE reconcile_partial_id"
-                   "                             = acm.reconcile_partial_id"
-                   "              AND reconcile_partial_id IS NOT NULL"
-                   "          ORDER BY date DESC LIMIT 1)"
-                   " WHERE last_rec_date is null;")
-
     def _get_move_line_from_line_rec(self, cr, uid, ids, context=None):
         moves = []
         for reconcile in self.pool['account.move.reconcile'].browse(

--- a/account_financial_report_webkit/migrations/7.0.1.0.2/post-migration.py
+++ b/account_financial_report_webkit/migrations/7.0.1.0.2/post-migration.py
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Author: Nicolas Bessi.
+#    Copyright Camptocamp SA 2011
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+def migrate(cr, version):
+    if not version:
+        # only run at first install
+        cr.execute("UPDATE account_move_line as acm "
+                   " SET last_rec_date ="
+                   "     (SELECT date from account_move_line"
+                   "          WHERE reconcile_id =  acm.reconcile_id"
+                   "              AND reconcile_id IS NOT NULL"
+                   "          ORDER BY date DESC LIMIT 1)"
+                   " WHERE last_rec_date is null;")
+
+        cr.execute("UPDATE account_move_line as acm "
+                   " SET last_rec_date ="
+                   "     (SELECT date from account_move_line"
+                   "          WHERE reconcile_partial_id"
+                   "                             = acm.reconcile_partial_id"
+                   "              AND reconcile_partial_id IS NOT NULL"
+                   "          ORDER BY date DESC LIMIT 1)"
+                   " WHERE last_rec_date is null;")


### PR DESCRIPTION
backported from https://code.launchpad.net/~acsone-openerp/account-financial-report/7.0-bug-1312732-lmi/+merge/217240

The proposal is valid for the 7.0 since the migration script is no more called on fresh install in 8.0. For 8.0 the migration script can be replaced by an install hook (https://github.com/odoo/odoo/commit/4105b5f0285821d8056c721b5fd50b9cae902988)
