### PR TITLE
Correct Pylint warnings

### DIFF
--- a/account_export_csv/wizard/account_export_csv.py
+++ b/account_export_csv/wizard/account_export_csv.py
@@ -93,8 +93,6 @@ class AccountCSVExport(orm.TransientModel):
             'journal_id',
             'Journals',
             help='If empty, use all journals, only used for journal entries'),
-        'fiscalyear_id': fields.many2one('account.fiscalyear', 'Fiscalyear',
-                                         required=True),
         'export_filename': fields.char('Export CSV Filename', size=128),
     }
 

--- a/account_financial_report/report/parser.py
+++ b/account_financial_report/report/parser.py
@@ -379,7 +379,6 @@ class account_balance(report_sxw.rml_parse):
 
         res = []
         am_obj = self.pool.get('account.move')
-        print 'AM OBJ ', am_obj
         if account['type'] in ('other', 'liquidity', 'receivable', 'payable'):
             # ~ TODO: CUANDO EL PERIODO ESTE VACIO LLENARLO CON LOS PERIODOS
             # DEL EJERCICIO
@@ -415,8 +414,6 @@ class account_balance(report_sxw.rml_parse):
                     'period': det['periodo'],
                     'obj': am_obj.browse(self.cr, self.uid, det['am_id'])
                 })
-                print 'ACCOUNT NAME', am_obj.browse(self.cr, self.uid,
-                                                    det['am_id']).name
         return res
 
     def lines(self, form, level=0):

--- a/account_financial_report_horizontal/report/account_balance_sheet.py
+++ b/account_financial_report_horizontal/report/account_balance_sheet.py
@@ -28,7 +28,7 @@ from openerp.report import report_sxw
 from openerp.addons.account_financial_report_horizontal.report import (
     account_profit_loss
 )
-from common_report_header import common_report_header
+from .common_report_header import common_report_header
 from openerp.tools.translate import _
 
 

--- a/account_financial_report_horizontal/report/account_profit_loss.py
+++ b/account_financial_report_horizontal/report/account_profit_loss.py
@@ -23,7 +23,7 @@
 
 import time
 from openerp.report import report_sxw
-from common_report_header import common_report_header
+from .common_report_header import common_report_header
 from openerp.tools.translate import _
 
 

--- a/account_financial_report_horizontal/wizard/account_report_balance_sheet.py
+++ b/account_financial_report_horizontal/wizard/account_report_balance_sheet.py
@@ -29,6 +29,7 @@ class account_bs_report(orm.TransientModel):
     This wizard will provide the account balance sheet report by periods,
     between any two dates.
     """
+
     _name = 'account.bs.report'
     _inherit = "account_financial_report_horizontal.common.account.report"
     _description = 'Account Balance Sheet Report'

--- a/account_financial_report_horizontal/wizard/account_report_common.py
+++ b/account_financial_report_horizontal/wizard/account_report_common.py
@@ -43,7 +43,7 @@ class account_common_report(orm.TransientModel):
         'filter': fields.selection([
             ('filter_no', 'No Filters'), ('filter_date', 'Date'),
             ('filter_period', 'Periods')
-            ],
+        ],
             "Filter by", required=True),
         'period_from': fields.many2one('account.period', 'Start period'),
         'period_to': fields.many2one('account.period', 'End period'),
@@ -55,7 +55,7 @@ class account_common_report(orm.TransientModel):
                                         ], 'Target Moves', required=True
                                         ),
 
-        }
+    }
 
     def fields_view_get(
         self, cr, uid, view_id=None, view_type='form', context=None,
@@ -87,13 +87,13 @@ class account_common_report(orm.TransientModel):
             res['value'] = {
                 'period_from': False, 'period_to': False,
                 'date_from': False, 'date_to': False
-                }
+            }
         if filter == 'filter_date':
             res['value'] = {
                 'period_from': False, 'period_to': False,
                 'date_from': time.strftime('%Y-01-01'),
                 'date_to': time.strftime('%Y-%m-%d')
-                }
+            }
         if filter == 'filter_period' and fiscalyear_id:
             start_period = end_period = False
             cr.execute('''
@@ -114,7 +114,7 @@ class account_common_report(orm.TransientModel):
                                ORDER BY p.date_stop DESC
                                LIMIT 1) AS period_stop''', (
                 fiscalyear_id, fiscalyear_id
-                )
+            )
             )
             periods = [i[0] for i in cr.fetchall()]
             if periods and len(periods) > 1:
@@ -123,7 +123,7 @@ class account_common_report(orm.TransientModel):
             res['value'] = {
                 'period_from': start_period, 'period_to': end_period,
                 'date_from': False, 'date_to': False
-                }
+            }
         return res
 
     def _get_account(self, cr, uid, context=None):
@@ -187,7 +187,7 @@ class account_common_report(orm.TransientModel):
         data['form'] = self.read(cr, uid, ids, [
             'date_from',  'date_to',  'fiscalyear_id', 'period_from',
             'period_to',  'filter',  'chart_account_id', 'target_move'
-            ])[0]
+        ])[0]
         used_context = self._build_contexts(
             cr, uid, ids, data, context=context)
         data['form']['periods'] = used_context.get(

--- a/account_financial_report_horizontal/wizard/account_report_common_account.py
+++ b/account_financial_report_horizontal/wizard/account_report_common_account.py
@@ -32,7 +32,7 @@ class account_common_account_report(orm.TransientModel):
         'display_account': fields.selection([
             ('bal_all', 'All'), ('bal_movement', 'With movements'),
             ('bal_solde', 'With balance is not equal to 0'),
-            ], 'Display accounts', required=True),
+        ], 'Display accounts', required=True),
 
     }
     _defaults = {

--- a/account_financial_report_horizontal/wizard/account_report_profit_loss.py
+++ b/account_financial_report_horizontal/wizard/account_report_profit_loss.py
@@ -29,6 +29,7 @@ class account_pl_report(orm.TransientModel):
     This wizard will provide the account profit and loss report by periods,
     between any two dates.
     """
+
     _inherit = "account_financial_report_horizontal.common.account.report"
     _name = "account.pl.report"
     _description = "Account Profit And Loss Report"
@@ -57,4 +58,4 @@ class account_pl_report(orm.TransientModel):
                 'type': 'ir.actions.report.xml',
                 'report_name': 'account.profit_loss',
                 'datas': data,
-                }
+            }

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -55,8 +55,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
         company = self.pool.get('res.users').browse(
             self.cr, uid, uid, context=context).company_id
         header_report_name = ' - '.join((_('OPEN INVOICES REPORT'),
-                                        company.name,
-                                        company.currency_id.name))
+                                         company.name,
+                                         company.currency_id.name))
 
         footer_date_time = self.formatLang(
             str(datetime.today()), date_time=True)

--- a/account_financial_report_webkit/report/partner_balance.py
+++ b/account_financial_report_webkit/report/partner_balance.py
@@ -42,8 +42,8 @@ class PartnerBalanceWebkit(report_sxw.rml_parse,
         company = self.pool.get('res.users').browse(
             self.cr, uid, uid, context=context).company_id
         header_report_name = ' - '.join((_('PARTNER BALANCE'),
-                                        company.name,
-                                        company.currency_id.name))
+                                         company.name,
+                                         company.currency_id.name))
 
         footer_date_time = self.formatLang(
             str(datetime.today()), date_time=True)

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -42,8 +42,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
         company = self.pool.get('res.users').browse(
             self.cr, uid, uid, context=context).company_id
         header_report_name = ' - '.join((_('PARTNER LEDGER'),
-                                        company.name,
-                                        company.currency_id.name))
+                                         company.name,
+                                         company.currency_id.name))
 
         footer_date_time = self.formatLang(
             str(datetime.today()), date_time=True)

--- a/account_financial_report_webkit/report/print_journal.py
+++ b/account_financial_report_webkit/report/print_journal.py
@@ -28,8 +28,8 @@ from openerp.tools.translate import _
 from openerp import pooler
 from datetime import datetime
 
-from common_reports import CommonReportHeaderWebkit
-from webkit_parser_header_fix import HeaderFooterTextWebKitParser
+from .common_reports import CommonReportHeaderWebkit
+from .webkit_parser_header_fix import HeaderFooterTextWebKitParser
 
 
 class PrintJournalWebkit(report_sxw.rml_parse, CommonReportHeaderWebkit):

--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -272,7 +272,7 @@ class HeaderFooterTextWebKitParser(webkit_report.WebKitParser):
                 _logger.error(msg)
                 raise except_osv(_('Webkit render'), msg)
             return (deb, 'html')
-        bin = self.get_lib(cursor, uid)
-        pdf = self.generate_pdf(bin, report_xml, head, foot, htmls,
+        binary = self.get_lib(cursor, uid)
+        pdf = self.generate_pdf(binary, report_xml, head, foot, htmls,
                                 parser_instance=parser_instance)
         return (pdf, 'pdf')

--- a/account_financial_report_webkit/wizard/balance_common.py
+++ b/account_financial_report_webkit/wizard/balance_common.py
@@ -131,7 +131,7 @@ class AccountBalanceCommonWizard(orm.TransientModel):
          periods or by date.', ['filter']),
     ]
 
-    def default_get(self, cr, uid, fields, context=None):
+    def default_get(self, cr, uid, fields_list, context=None):
         """
              To get default values for the object.
 
@@ -145,7 +145,7 @@ class AccountBalanceCommonWizard(orm.TransientModel):
 
         """
         res = super(AccountBalanceCommonWizard, self).default_get(
-            cr, uid, fields, context=context)
+            cr, uid, fields_list, context=context)
         for index in range(self.COMPARISON_LEVEL):
             field = "comp%s_filter" % (index,)
             if not res.get(field, False):

--- a/account_financial_report_webkit/wizard/balance_common.py
+++ b/account_financial_report_webkit/wizard/balance_common.py
@@ -160,7 +160,8 @@ class AccountBalanceCommonWizard(orm.TransientModel):
 
         res['fields'].update(self.fields_get(cr, uid,
                                              allfields=self.DYNAMIC_FIELDS,
-                                             context=context, write_access=True))
+                                             context=context,
+                                             write_access=True))
 
         eview = etree.fromstring(res['arch'])
         placeholder = eview.xpath("//page[@name='placeholder']")

--- a/account_financial_report_webkit/wizard/balance_common.py
+++ b/account_financial_report_webkit/wizard/balance_common.py
@@ -159,8 +159,8 @@ class AccountBalanceCommonWizard(orm.TransientModel):
             submenu=submenu)
 
         res['fields'].update(self.fields_get(cr, uid,
-                             allfields=self.DYNAMIC_FIELDS,
-                             context=context, write_access=True))
+                                             allfields=self.DYNAMIC_FIELDS,
+                                             context=context, write_access=True))
 
         eview = etree.fromstring(res['arch'])
         placeholder = eview.xpath("//page[@name='placeholder']")

--- a/account_financial_report_webkit_xls/report/general_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/general_ledger_xls.py
@@ -71,8 +71,8 @@ class general_ledger_xls(report_xls):
         # Title
         cell_style = xlwt.easyxf(_xs['xls_title'])
         report_name = ' - '.join([_p.report_name.upper(),
-                                 _p.company.partner_id.name,
-                                 _p.company.currency_id.name])
+                                  _p.company.partner_id.name,
+                                  _p.company.currency_id.name])
         c_specs = [
             ('report_name', 1, 0, 'text', report_name),
         ]

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -132,8 +132,8 @@ class open_invoices_xls(report_xls):
     # print the first line "OPEN INVOICE REPORT - db name - Currency
     def print_title(self, _p, row_position):
         report_name = ' - '.join([_p.report_name.upper(),
-                                 _p.company.partner_id.name,
-                                 _p.company.currency_id.name])
+                                  _p.company.partner_id.name,
+                                  _p.company.currency_id.name])
         c_specs = [('report_name', self.nbr_columns, 0, 'text', report_name), ]
         row_data = self.xls_row_template(c_specs, [x[0] for x in c_specs])
         row_position = self.xls_write_row(

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -723,7 +723,8 @@ class open_invoices_xls(report_xls):
 
     # export the invoice AR/AP lines when the option currency regroup is
     # selected
-    def print_grouped_line_report(self, row_pos, account, _xs, xlwtlib, _p, data):
+    def print_grouped_line_report(
+            self, row_pos, account, _xs, xlwtlib, _p, data):
 
         if account.grouped_ledger_lines and account.partners_order:
             row_start_account = row_pos

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -34,7 +34,7 @@ from openerp.tools.translate import _
 class open_invoices_xls(report_xls):
     column_sizes = [12, 12, 20, 15, 30, 30, 14, 14, 14, 14, 14, 14, 10]
 
-    def global_initializations(self, wb, _p, xlwt, _xs, objects, data):
+    def global_initializations(self, wb, _p, xlwtlib, _xs, objects, data):
         # this procedure will initialise variables and Excel cell styles and
         # return them as global ones
         self.ws = wb.add_sheet(_p.report_name[:31])
@@ -62,70 +62,70 @@ class open_invoices_xls(report_xls):
             self.nbr_columns = 11
         # -------------------------------------------------------
         # cell style for report title
-        self.style_font12 = xlwt.easyxf(_xs['xls_title'])
+        self.style_font12 = xlwtlib.easyxf(_xs['xls_title'])
         # -------------------------------------------------------
-        self.style_default = xlwt.easyxf(_xs['borders_all'])
+        self.style_default = xlwtlib.easyxf(_xs['borders_all'])
         # -------------------------------------------------------
-        self.style_default_italic = xlwt.easyxf(
+        self.style_default_italic = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['italic'])
         # -------------------------------------------------------
-        self.style_bold = xlwt.easyxf(_xs['bold'] + _xs['borders_all'])
+        self.style_bold = xlwtlib.easyxf(_xs['bold'] + _xs['borders_all'])
         # -------------------------------------------------------
         # cell style for header titles: 'Chart of accounts' - 'Fiscal year' ...
-        self.style_bold_blue_center = xlwt.easyxf(
+        self.style_bold_blue_center = xlwtlib.easyxf(
             _xs['bold'] + _xs['fill_blue'] + _xs['borders_all'] +
             _xs['center'])
         # -------------------------------------------------------
         # cell style for header data: 'Chart of accounts' - 'Fiscal year' ...
-        self.style_center = xlwt.easyxf(
+        self.style_center = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['wrap'] + _xs['center'])
         # -------------------------------------------------------
         # cell style for columns titles 'Date'- 'Period' - 'Entry'...
-        self.style_yellow_bold = xlwt.easyxf(
+        self.style_yellow_bold = xlwtlib.easyxf(
             _xs['bold'] + _xs['fill'] + _xs['borders_all'])
         # -------------------------------------------------------
         # cell style for columns titles 'Date'- 'Period' - 'Entry'...
-        self.style_yellow_bold_right = xlwt.easyxf(
+        self.style_yellow_bold_right = xlwtlib.easyxf(
             _xs['bold'] + _xs['fill'] + _xs['borders_all'] + _xs['right'])
         # -------------------------------------------------------
-        self.style_right = xlwt.easyxf(_xs['borders_all'] + _xs['right'])
+        self.style_right = xlwtlib.easyxf(_xs['borders_all'] + _xs['right'])
         # -------------------------------------------------------
-        self.style_right_italic = xlwt.easyxf(
+        self.style_right_italic = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['right'] + _xs['italic'])
         # -------------------------------------------------------
-        self.style_decimal = xlwt.easyxf(
+        self.style_decimal = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['right'],
             num_format_str=report_xls.decimal_format)
         # -------------------------------------------------------
-        self.style_decimal_italic = xlwt.easyxf(
+        self.style_decimal_italic = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['right'] + _xs['italic'],
             num_format_str=report_xls.decimal_format)
         # -------------------------------------------------------
-        self.style_date = xlwt.easyxf(
+        self.style_date = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['left'],
             num_format_str=report_xls.date_format)
         # -------------------------------------------------------
-        self.style_date_italic = xlwt.easyxf(
+        self.style_date_italic = xlwtlib.easyxf(
             _xs['borders_all'] + _xs['left'] + _xs['italic'],
             num_format_str=report_xls.date_format)
         # -------------------------------------------------------
         cell_format = _xs['xls_title'] + _xs['bold'] + \
             _xs['fill'] + _xs['borders_all']
-        self.style_account_title = xlwt.easyxf(cell_format)
-        self.style_account_title_right = xlwt.easyxf(
+        self.style_account_title = xlwtlib.easyxf(cell_format)
+        self.style_account_title_right = xlwtlib.easyxf(
             cell_format + _xs['right'])
-        self.style_account_title_decimal = xlwt.easyxf(
+        self.style_account_title_decimal = xlwtlib.easyxf(
             cell_format + _xs['right'],
             num_format_str=report_xls.decimal_format)
         # -------------------------------------------------------
         cell_format = _xs['bold']
-        self.style_partner_row = xlwt.easyxf(cell_format)
+        self.style_partner_row = xlwtlib.easyxf(cell_format)
         # -------------------------------------------------------
         cell_format = _xs['bold'] + _xs['fill'] + _xs['borders_all']
-        self.style_partner_cumul = xlwt.easyxf(cell_format)
-        self.style_partner_cumul_right = xlwt.easyxf(
+        self.style_partner_cumul = xlwtlib.easyxf(cell_format)
+        self.style_partner_cumul_right = xlwtlib.easyxf(
             cell_format + _xs['right'])
-        self.style_partner_cumul_decimal = xlwt.easyxf(
+        self.style_partner_cumul_decimal = xlwtlib.easyxf(
             cell_format + _xs['right'],
             num_format_str=report_xls.decimal_format)
 
@@ -723,7 +723,7 @@ class open_invoices_xls(report_xls):
 
     # export the invoice AR/AP lines when the option currency regroup is
     # selected
-    def print_grouped_line_report(self, row_pos, account, _xs, xlwt, _p, data):
+    def print_grouped_line_report(self, row_pos, account, _xs, xlwtlib, _p, data):
 
         if account.grouped_ledger_lines and account.partners_order:
             row_start_account = row_pos
@@ -755,7 +755,7 @@ class open_invoices_xls(report_xls):
         return row_pos
 
     # export the invoice AR/AP lines
-    def print_ledger_lines(self, row_pos, account, _xs, xlwt, _p, data):
+    def print_ledger_lines(self, row_pos, account, _xs, xlwtlib, _p, data):
 
         if account.ledger_lines and account.partners_order:
             row_start_account = row_pos

--- a/account_financial_report_webkit_xls/report/partner_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/partner_ledger_xls.py
@@ -70,8 +70,8 @@ class partner_ledger_xls(report_xls):
         # Title
         cell_style = xlwt.easyxf(_xs['xls_title'])
         report_name = ' - '.join([_p.report_name.upper(),
-                                 _p.company.partner_id.name,
-                                 _p.company.currency_id.name])
+                                  _p.company.partner_id.name,
+                                  _p.company.currency_id.name])
         c_specs = [
             ('report_name', 1, 0, 'text', report_name),
         ]

--- a/account_financial_report_webkit_xls/report/partners_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/partners_balance_xls.py
@@ -40,8 +40,8 @@ class partners_balance_xls(report_xls):
     def print_title(self, ws, _p, row_position, xlwt, _xs):
         cell_style = xlwt.easyxf(_xs['xls_title'])
         report_name = ' - '.join([_p.report_name.upper(),
-                                 _p.company.partner_id.name,
-                                 _p.company.currency_id.name])
+                                  _p.company.partner_id.name,
+                                  _p.company.currency_id.name])
         c_specs = [
             ('report_name', 1, 0, 'text', report_name),
         ]

--- a/account_financial_report_webkit_xls/report/partners_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/partners_balance_xls.py
@@ -37,8 +37,8 @@ def display_line(all_comparison_lines):
 class partners_balance_xls(report_xls):
     column_sizes = [12, 40, 25, 17, 17, 17, 17, 17]
 
-    def print_title(self, ws, _p, row_position, xlwt, _xs):
-        cell_style = xlwt.easyxf(_xs['xls_title'])
+    def print_title(self, ws, _p, row_position, xlwtlib, _xs):
+        cell_style = xlwtlib.easyxf(_xs['xls_title'])
         report_name = ' - '.join([_p.report_name.upper(),
                                   _p.company.partner_id.name,
                                   _p.company.currency_id.name])
@@ -59,10 +59,10 @@ class partners_balance_xls(report_xls):
             ws, row_position, row_data, set_column_size=True)
         return row_position
 
-    def print_header_titles(self, ws, _p, data, row_position, xlwt, _xs):
+    def print_header_titles(self, ws, _p, data, row_position, xlwtlib, _xs):
         cell_format = _xs['bold'] + _xs['fill_blue'] + _xs['borders_all']
-        cell_style = xlwt.easyxf(cell_format)
-        cell_style_center = xlwt.easyxf(cell_format + _xs['center'])
+        cell_style = xlwtlib.easyxf(cell_format)
+        cell_style_center = xlwtlib.easyxf(cell_format + _xs['center'])
 
         c_specs = [
             ('fy', 1, 0, 'text', _('Fiscal Year'), None, cell_style_center),
@@ -84,11 +84,11 @@ class partners_balance_xls(report_xls):
             ws, row_position, row_data, row_style=cell_style)
         return row_position
 
-    def print_header_data(self, ws, _p, data, row_position, xlwt, _xs,
+    def print_header_data(self, ws, _p, data, row_position, xlwtlib, _xs,
                           initial_balance_text):
         cell_format = _xs['borders_all'] + _xs['wrap'] + _xs['top']
-        cell_style = xlwt.easyxf(cell_format)
-        cell_style_center = xlwt.easyxf(cell_format + _xs['center'])
+        cell_style = xlwtlib.easyxf(cell_format)
+        cell_style_center = xlwtlib.easyxf(cell_format + _xs['center'])
         c_specs = [
             ('fy', 1, 0, 'text', _p.fiscalyear.name if _p.fiscalyear else '-',
              None, cell_style_center),
@@ -122,16 +122,16 @@ class partners_balance_xls(report_xls):
             ws, row_position, row_data, row_style=cell_style)
         return row_position
 
-    def print_comparison_header(self, _xs, xlwt, row_position, _p, ws,
+    def print_comparison_header(self, _xs, xlwtlib, row_position, _p, ws,
                                 initial_balance_text):
         cell_format_ct = _xs['bold'] + _xs['fill_blue'] + _xs['borders_all']
-        cell_style_ct = xlwt.easyxf(cell_format_ct)
+        cell_style_ct = xlwtlib.easyxf(cell_format_ct)
         c_specs = [('ct', 7, 0, 'text', _('Comparisons'))]
         row_data = self.xls_row_template(c_specs, [x[0] for x in c_specs])
         row_position = self.xls_write_row(
             ws, row_position, row_data, row_style=cell_style_ct)
         cell_format = _xs['borders_all'] + _xs['wrap'] + _xs['top']
-        cell_style_center = xlwt.easyxf(cell_format)
+        cell_style_center = xlwtlib.easyxf(cell_format)
         for index, params in enumerate(_p.comp_params):
             c_specs = [
                 ('c', 2, 0, 'text', _('Comparison') + str(index + 1) +
@@ -155,12 +155,12 @@ class partners_balance_xls(report_xls):
                 ws, row_position, row_data, row_style=cell_style_center)
         return row_position
 
-    def print_account_header(self, ws, _p, _xs, xlwt, row_position):
+    def print_account_header(self, ws, _p, _xs, xlwtlib, row_position):
         cell_format = _xs['bold'] + _xs['fill'] + \
             _xs['borders_all'] + _xs['wrap'] + _xs['top']
-        cell_style = xlwt.easyxf(cell_format)
-        cell_style_right = xlwt.easyxf(cell_format + _xs['right'])
-        cell_style_center = xlwt.easyxf(cell_format + _xs['center'])
+        cell_style = xlwtlib.easyxf(cell_format)
+        cell_style_right = xlwtlib.easyxf(cell_format + _xs['right'])
+        cell_style_center = xlwtlib.easyxf(cell_format + _xs['center'])
         if len(_p.comp_params) == 2:
             account_span = 3
         else:
@@ -210,10 +210,10 @@ class partners_balance_xls(report_xls):
         return row_position
 
     def print_row_code_account(self, ws, current_account, row_position, _xs,
-                               xlwt):
+                               xlwtlib):
         cell_format = _xs['xls_title'] + _xs['bold'] + \
             _xs['fill'] + _xs['borders_all']
-        cell_style = xlwt.easyxf(cell_format)
+        cell_style = xlwtlib.easyxf(cell_format)
         c_specs = [
             ('acc_title', 7, 0, 'text', ' - '.join([current_account.code,
                                                     current_account.name])), ]
@@ -222,12 +222,12 @@ class partners_balance_xls(report_xls):
             ws, row_position, row_data, cell_style)
         return row_position
 
-    def print_account_totals(self, _xs, xlwt, ws, row_start_account,
+    def print_account_totals(self, _xs, xlwtlib, ws, row_start_account,
                              row_position, current_account, _p):
         cell_format = _xs['bold'] + _xs['fill'] + \
             _xs['borders_all'] + _xs['wrap'] + _xs['top']
-        cell_style = xlwt.easyxf(cell_format)
-        cell_style_decimal = xlwt.easyxf(
+        cell_style = xlwtlib.easyxf(cell_format)
+        cell_style_decimal = xlwtlib.easyxf(
             cell_format + _xs['right'],
             num_format_str=report_xls.decimal_format)
         c_specs = [

--- a/account_financial_report_webkit_xls/report/trial_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/trial_balance_xls.py
@@ -54,8 +54,8 @@ class trial_balance_xls(report_xls):
         # Title
         cell_style = xlwt.easyxf(_xs['xls_title'])
         report_name = ' - '.join([_p.report_name.upper(),
-                                 _p.company.partner_id.name,
-                                 _p.company.currency_id.name])
+                                  _p.company.partner_id.name,
+                                  _p.company.currency_id.name])
         c_specs = [
             ('report_name', 1, 0, 'text', report_name),
         ]

--- a/account_journal_report_xls/report/nov_account_journal.py
+++ b/account_journal_report_xls/report/nov_account_journal.py
@@ -88,22 +88,22 @@ class nov_journal_print(report_sxw.rml_parse):
         return translate(self.cr, _ir_translation_name, 'report', lang, src) \
             or src
 
-    def _title(self, object):
+    def _title(self, obj):
         return ((self.print_by == 'period' and self._('Period') or
-                 self._('Fiscal Year')) + ' ' + object[1].name, object[0].name)
+                 self._('Fiscal Year')) + ' ' + obj[1].name, obj[0].name)
 
     def _amount_title(self):
         return self.display_currency and \
             (self._('Amount'), self._('Currency')) or (
                 self._('Debit'), self._('Credit'))
 
-    def _lines(self, object):
+    def _lines(self, obj):
         j_obj = self.pool['account.journal']
         _ = self._
-        journal = object[0]
+        journal = obj[0]
         journal_id = journal.id
         if self.print_by == 'period':
-            period = object[1]
+            period = obj[1]
             period_id = period.id
             period_ids = [period_id]
             # update status period
@@ -129,7 +129,7 @@ class nov_journal_print(report_sxw.rml_parse):
                 has been fixed now !""",
                               period.name, journal.name)
         else:
-            fiscalyear = object[1]
+            fiscalyear = obj[1]
             period_ids = [x.id for x in fiscalyear.period_ids]
 
         select_extra, join_extra, where_extra = j_obj._report_xls_query_extra(
@@ -289,13 +289,13 @@ class nov_journal_print(report_sxw.rml_parse):
 
         return lines_out
 
-    def _tax_codes(self, object):
-        journal_id = object[0].id
+    def _tax_codes(self, obj):
+        journal_id = obj[0].id
         if self.print_by == 'period':
-            period_id = object[1].id
+            period_id = obj[1].id
             period_ids = [period_id]
         else:
-            fiscalyear = object[1]
+            fiscalyear = obj[1]
             period_ids = [x.id for x in fiscalyear.period_ids]
         self.cr.execute(
             "SELECT distinct tax_code_id FROM account_move_line l "
@@ -315,13 +315,13 @@ class nov_journal_print(report_sxw.rml_parse):
             self.cr, self.uid, tax_code_ids, self.context)
         return tax_codes
 
-    def _totals(self, field, object, tax_code_id=None):
-        journal_id = object[0].id
+    def _totals(self, field, obj, tax_code_id=None):
+        journal_id = obj[0].id
         if self.print_by == 'period':
-            period_id = object[1].id
+            period_id = obj[1].id
             period_ids = [period_id]
         else:
-            fiscalyear = object[1]
+            fiscalyear = obj[1]
             period_ids = [x.id for x in fiscalyear.period_ids]
         select = "SELECT sum(" + field + ") FROM account_move_line l " \
             "INNER JOIN account_move am ON l.move_id = am.id " \
@@ -332,17 +332,17 @@ class nov_journal_print(report_sxw.rml_parse):
             select, (tuple(period_ids), journal_id, tuple(self.move_states)))
         return self.cr.fetchone()[0] or 0.0
 
-    def _sum1(self, object):
-        return self._totals('debit', object)
+    def _sum1(self, obj):
+        return self._totals('debit', obj)
 
-    def _sum2(self, object):
+    def _sum2(self, obj):
         if self.display_currency:
             return ''
         else:
-            return self._totals('credit', object)
+            return self._totals('credit', obj)
 
-    def _sum_vat(self, object, tax_code):
-        return self._totals('tax_amount', object, tax_code.id)
+    def _sum_vat(self, obj, tax_code):
+        return self._totals('tax_amount', obj, tax_code.id)
 
     def formatLang(self, value, digits=None, date=False, date_time=False,
                    grouping=True, monetary=False, dp=False,

--- a/account_journal_report_xls/report/nov_account_journal.py
+++ b/account_journal_report_xls/report/nov_account_journal.py
@@ -207,11 +207,11 @@ class nov_journal_print(report_sxw.rml_parse):
         if journal.type in ('sale', 'sale_refund', 'purchase',
                             'purchase_refund'):
             [x.update({'docname': (_('Invoice') + ': ' + x['inv_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+                       or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         elif journal.type in ('bank', 'cash'):
             [x.update({'docname': (_('Statement') + ': ' + x['st_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+                       or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         else:
             code_string = j_obj._report_xls_document_extra(

--- a/account_journal_report_xls/report/nov_account_journal_xls.py
+++ b/account_journal_report_xls/report/nov_account_journal_xls.py
@@ -235,8 +235,8 @@ class account_journal_xls(report_xls):
                                self.aml_cell_style_decimal]},
         }
 
-    def _journal_title(self, o, ws, _p, row_pos, xlwt, _xs):
-        cell_style = xlwt.easyxf(_xs['xls_title'])
+    def _journal_title(self, o, ws, _p, row_pos, xlwtlib, _xs):
+        cell_style = xlwtlib.easyxf(_xs['xls_title'])
         report_name = (10 * ' ').join([
             _p.company.name,
             _p.title(o)[0],
@@ -251,7 +251,7 @@ class account_journal_xls(report_xls):
             ws, row_pos, row_data, row_style=cell_style)
         return row_pos + 1
 
-    def _journal_lines(self, o, ws, _p, row_pos, xlwt, _xs):
+    def _journal_lines(self, o, ws, _p, row_pos, xlwtlib, _xs):
 
         wanted_list = self.wanted_list
         debit_pos = self.debit_pos
@@ -305,12 +305,12 @@ class account_journal_xls(report_xls):
             ws, row_pos, row_data, row_style=self.rt_cell_style_right)
         return row_pos + 1
 
-    def _journal_vat_summary(self, o, ws, _p, row_pos, xlwt, _xs):
+    def _journal_vat_summary(self, o, ws, _p, row_pos, xlwtlib, _xs):
 
         if not _p.tax_codes(o):
             return row_pos
 
-        title_cell_style = xlwt.easyxf(_xs['bold'])
+        title_cell_style = xlwtlib.easyxf(_xs['bold'])
         c_specs = [('summary_title', 1, 0, 'text', _p._("VAT Declaration"))]
         row_data = self.xls_row_template(c_specs, [x[0] for x in c_specs])
         row_pos = self.xls_write_row(

--- a/account_journal_report_xls/wizard/print_journal_wizard.py
+++ b/account_journal_report_xls/wizard/print_journal_wizard.py
@@ -43,9 +43,11 @@ class account_print_journal_xls(orm.TransientModel):
         'group_entries': True,
     }
 
-    def fields_get(self, cr, uid, fields=None, context=None):
+    def fields_get(self, cr, uid, allfields=None, context=None,
+                   write_access=True):
         res = super(account_print_journal_xls, self).fields_get(
-            cr, uid, fields, context)
+            cr, uid, allfields=allfields, context=context,
+            write_access=write_access)
         if context.get('print_by') == 'fiscalyear':
             if 'fiscalyear_id' in res:
                 res['fiscalyear_id']['required'] = True


### PR DESCRIPTION
Supersedes this #27 with additional corrections:
- removed the extraneous line between class and docstring
- Fixed W0621 warnings and some W0622
- Removed print statements
- Removed a duplicated key in dictionary (_columns)
