### PR TITLE
Aged balance report: the only sensible filter is by end period

### DIFF
--- a/account_financial_report_webkit/i18n/account_financial_report_webkit.pot
+++ b/account_financial_report_webkit/i18n/account_financial_report_webkit.pot
@@ -1516,3 +1516,8 @@ msgstr ""
 msgid "{'required': [('filter', '=', 'filter_opening')]}"
 msgstr ""
 
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""
+

--- a/account_financial_report_webkit/i18n/de.po
+++ b/account_financial_report_webkit/i18n/de.po
@@ -1320,3 +1320,8 @@ msgstr ""
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr ""
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""

--- a/account_financial_report_webkit/i18n/en_US.po
+++ b/account_financial_report_webkit/i18n/en_US.po
@@ -1320,3 +1320,8 @@ msgstr ""
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr ""
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""

--- a/account_financial_report_webkit/i18n/es.po
+++ b/account_financial_report_webkit/i18n/es.po
@@ -1371,4 +1371,4 @@ msgstr "Comparar por"
 #. module: account_financial_report_webkit
 #: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
 msgid "At the end of"
-msgstr ""
+msgstr "Al final de"

--- a/account_financial_report_webkit/i18n/es.po
+++ b/account_financial_report_webkit/i18n/es.po
@@ -1367,3 +1367,8 @@ msgstr "¡Valor haber o debe erróneo en el asiento contable!"
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr "Comparar por"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""

--- a/account_financial_report_webkit/i18n/fr.po
+++ b/account_financial_report_webkit/i18n/fr.po
@@ -1580,3 +1580,8 @@ msgstr ""
 #: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
 msgid "{'required': [('filter', '=', 'filter_opening')]}"
 msgstr ""
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr "À fin de"

--- a/account_financial_report_webkit/i18n/it.po
+++ b/account_financial_report_webkit/i18n/it.po
@@ -1366,3 +1366,8 @@ msgstr "Valore di credito o debito errato nella registrazione contabile!"
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr "Confronta per"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""

--- a/account_financial_report_webkit/i18n/nl.po
+++ b/account_financial_report_webkit/i18n/nl.po
@@ -1320,3 +1320,8 @@ msgstr ""
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr ""
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr ""

--- a/account_financial_report_webkit/tests/aged_trial_balance.yml
+++ b/account_financial_report_webkit/tests/aged_trial_balance.yml
@@ -42,19 +42,6 @@
         data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
                      'amount_currency': True, 'result_selection': 'customer_supplier',
-                     'filter': 'filter_period', 'period_from': ref('account.period_1'), 'period_to': ref('account.period_12')}
-        from openerp.tools import test_reports
-        test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
-
--
-  In order to test the PDF Aged Partner Balance Report webkit wizard I will print report with filters on dates
--
-    !python {model: account.account}: |
-        from datetime import datetime
-        ctx={}
-        data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
-                     'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
-                     'amount_currency': True, 'result_selection': 'customer_supplier',
-                     'filter': 'filter_date', 'date_from': '%s-01-01' %(datetime.now().year), 'date_to': '%s-12-31' %(datetime.now().year)}
+                     'filter': 'filter_period', 'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')

--- a/account_financial_report_webkit/tests/aged_trial_balance.yml
+++ b/account_financial_report_webkit/tests/aged_trial_balance.yml
@@ -4,7 +4,9 @@
     !python {model: account.account}: |
         from datetime import datetime
         ctx={}
-        data_dict = {'chart_account_id':ref('account.chart0'), 'until_date': '%s-12-31' %(datetime.now().year)}
+        data_dict = {'chart_account_id':ref('account.chart0'), 'until_date': '%s-12-31' %(datetime.now().year),
+                     'fiscalyear_id': ref('account.data_fiscalyear'),
+                     'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
 
@@ -16,7 +18,8 @@
         ctx={}
         data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
-                     'amount_currency': True, 'result_selection': 'customer_supplier'}
+                     'amount_currency': True, 'result_selection': 'customer_supplier',
+                     'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
 
@@ -29,7 +32,8 @@
         data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
                      'amount_currency': True, 'result_selection': 'customer_supplier',
-                     'partner_ids': [ref('base.res_partner_2'), ref('base.res_partner_1')]}
+                     'partner_ids': [ref('base.res_partner_2'), ref('base.res_partner_1')],
+                     'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
 

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
@@ -68,6 +68,12 @@ class AccountAgedTrialBalance(orm.TransientModel):
             [('filter_period', 'Periods')],
             "Filter by",
             required=True),
+        'fiscalyear_id': fields.many2one(
+            'account.fiscalyear',
+            'Fiscal Year', help='Keep empty for all open fiscal year',
+            required=True),
+        'period_to': fields.many2one('account.period', 'End Period',
+                                     required=True),
     }
 
     _defaults = {

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
@@ -70,7 +70,7 @@ class AccountAgedTrialBalance(orm.TransientModel):
             required=True),
         'fiscalyear_id': fields.many2one(
             'account.fiscalyear',
-            'Fiscal Year', help='Keep empty for all open fiscal year',
+            'Fiscal Year',
             required=True),
         'period_to': fields.many2one('account.period', 'End Period',
                                      required=True),

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
@@ -18,7 +18,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from openerp.osv import orm
+from openerp.osv import orm, fields
 
 
 class AccountAgedTrialBalance(orm.TransientModel):
@@ -30,6 +30,17 @@ class AccountAgedTrialBalance(orm.TransientModel):
     _inherit = "open.invoices.webkit"
     _name = "account.aged.trial.balance.webkit"
     _description = "Aged partner balanced"
+
+    _columns = {
+        'filter': fields.selection(
+            [('filter_period', 'Periods')],
+            "Filter by",
+            required=True),
+    }
+
+    _defaults = {
+        'filter': 'filter_period',
+    }
 
     def _print_report(self, cr, uid, ids, data, context=None):
         # we update form with display account value

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.xml
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.xml
@@ -42,14 +42,17 @@
           <field name="fiscalyear_id" position="attributes">
             <attribute name="on_change">onchange_fiscalyear(fiscalyear_id, period_to, date_to, until_date)</attribute>
           </field>
-          <field name="date_to" position="attributes">
-            <attribute name="on_change">onchange_date_to(fiscalyear_id, period_to, date_to, until_date)</attribute>
+          <field name="filter" position="attributes">
+            <attribute name="invisible">True</attribute>
+          </field>
+          <field name="period_from" position="attributes">
+            <attribute name="invisible">True</attribute>
           </field>
           <field name="period_to" position="attributes">
             <attribute name="on_change">onchange_period_to(fiscalyear_id, period_to, date_to, until_date)</attribute>
           </field>
-          <field name="period_from" position="attributes">
-            <attribute name="domain">[('fiscalyear_id', '=', fiscalyear_id), ('special', '=', False)]</attribute>
+          <field name="period_to" position="attributes">
+            <attribute name="String">At the end of</attribute>
           </field>
           <field name="period_to" position="attributes">
             <attribute name="domain">[('fiscalyear_id', '=', fiscalyear_id), ('special', '=', False)]</attribute>


### PR DESCRIPTION
The filters by date or by start period are meaningless for an aged partner
balance. Hide the choice of filters and let only the 'end period' available.
