### PR TITLE
Deactivate constraint on account.account (unnecessary if Webkit reports are used)

### DIFF
--- a/account_financial_report_webkit/account.py
+++ b/account_financial_report_webkit/account.py
@@ -45,3 +45,16 @@ class AccountAccount(orm.Model):
     _defaults = {
         'centralized': False,
     }
+
+    # Related to WebKit reports: this constraint is not relevant anymore,
+    # since the initial balance of the partner reports
+    # (ledger, balance, open invoices) is computed on-the-fly, instead of
+    # using the opening journal entry data (hence the deferral method)
+    def _check_account_type(self, cr, uid, ids, context=None):
+        return True
+
+    _constraints = [
+        (_check_account_type,
+         '',
+         ['user_type', 'type']),
+    ]


### PR DESCRIPTION
This PR is to deactivate the constraint _check_account_type on account.account; since the initial balance of partner reports is computed on-the-fly, we must allow payables & receivables accounts to use another type than "unreconciled".
