### PR TITLE
Fix sum of partner balance in foreign currency.

### DIFF
--- a/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
@@ -169,6 +169,8 @@
                                   <div class="act_as_cell sep_left amount">${formatLang(part_cumul_balance_curr) | amount }</div>
                                   ## curency code
                                   <div class="act_as_cell">${balance_forward_currency}</div>
+				  <!-- TODO:  What happens if there are differents currencies in the same group? -->
+				  <% cumul_balance_curr += line.get('amount_currency') or 0.0 %>
                              %endif
 
                           </div>


### PR DESCRIPTION
The bottom line of each partner's group in the ledger only shows the initial balance (if any).  This PR fixes this issue.

There's an outstanding issue:  What to do about different currencies.  Probably we should allow to filter/group by currency.
