### PR TITLE
Add context to account browse() methods (for translation)

### DIFF
--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -278,9 +278,8 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
 
         to_display = dict.fromkeys(account_ids, True)
         objects = []
-        for account in self.pool.get('account.account').browse(self.cursor,
-                                                               self.uid,
-                                                               account_ids):
+        for account in self.pool.get('account.account').browse(
+                self.cursor, self.uid, account_ids, context=self.localcontext):
             if not account.parent_id:  # hide top level account
                 continue
             if account.type == 'consolidation':

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -280,9 +280,8 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
                 comp_accounts_by_ids.append(comparison_result)
         objects = []
 
-        for account in self.pool.get('account.account').browse(self.cursor,
-                                                               self.uid,
-                                                               account_ids):
+        for account in self.pool.get('account.account').browse(
+                self.cursor, self.uid, account_ids, context=self.localcontext):
             if not account.parent_id:  # hide top level account
                 continue
             account.debit = accounts_by_ids[account.id]['debit']

--- a/account_financial_report_webkit/report/general_ledger.py
+++ b/account_financial_report_webkit/report/general_ledger.py
@@ -120,9 +120,8 @@ class GeneralLedgerWebkit(report_sxw.rml_parse, CommonReportHeaderWebkit):
             accounts, init_balance_memoizer, main_filter, target_move, start,
             stop)
         objects = []
-        for account in self.pool.get('account.account').browse(self.cursor,
-                                                               self.uid,
-                                                               accounts):
+        for account in self.pool.get('account.account').browse(
+                self.cursor, self.uid, accounts, context=self.localcontext):
             if do_centralize and account.centralized \
                     and ledger_lines_memoizer.get(account.id):
                 account.ledger_lines = self._centralize_lines(

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -146,9 +146,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             account_ids, main_filter, target_move, start, stop, date_until,
             partner_filter=partner_ids)
         objects = []
-        for account in self.pool.get('account.account').browse(self.cursor,
-                                                               self.uid,
-                                                               account_ids):
+        for account in self.pool.get('account.account').browse(
+                self.cursor, self.uid, account_ids, self.localcontext):
             account.ledger_lines = ledger_lines_memoizer.get(account.id, {})
             account.init_balance = init_balance_memoizer.get(account.id, {})
             # we have to compute partner order based on inital balance

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -147,9 +147,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
             accounts, main_filter, target_move, start, stop,
             partner_filter=partner_ids)
         objects = []
-        for account in self.pool.get('account.account').browse(self.cursor,
-                                                               self.uid,
-                                                               accounts):
+        for account in self.pool.get('account.account').browse(
+                self.cursor, self.uid, accounts, context=self.localcontext):
             account.ledger_lines = ledger_lines.get(account.id, {})
             account.init_balance = initial_balance_lines.get(account.id, {})
             # we have to compute partner order based on inital balance


### PR DESCRIPTION
This PR is to add `self.localcontext` to the account's `browse()`.
This is in particular to have the translated values of the accounts (for exemple, the name if set as `translate=True` ) in the Webkit reports.
