### PR TITLE
[FIX] afr_webkit: fix aged partner balance test

### DIFF
--- a/account_financial_report_webkit/tests/aged_trial_balance.yml
+++ b/account_financial_report_webkit/tests/aged_trial_balance.yml
@@ -6,6 +6,7 @@
         ctx={}
         data_dict = {'chart_account_id':ref('account.chart0'), 'until_date': '%s-12-31' %(datetime.now().year),
                      'fiscalyear_id': ref('account.data_fiscalyear'),
+                     'period_from': ref('account.period_1'),
                      'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
@@ -19,6 +20,7 @@
         data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
                      'amount_currency': True, 'result_selection': 'customer_supplier',
+                     'period_from': ref('account.period_1'),
                      'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
@@ -33,6 +35,7 @@
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
                      'amount_currency': True, 'result_selection': 'customer_supplier',
                      'partner_ids': [ref('base.res_partner_2'), ref('base.res_partner_1')],
+                     'period_from': ref('account.period_1'),
                      'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')
@@ -46,6 +49,8 @@
         data_dict = {'chart_account_id':ref('account.chart0'), 'fiscalyear_id': ref('account.data_fiscalyear'),
                      'until_date': '%s-12-31' %(datetime.now().year), 'target_move': 'posted',
                      'amount_currency': True, 'result_selection': 'customer_supplier',
-                     'filter': 'filter_period', 'period_to': ref('account.period_12')}
+                     'filter': 'filter_period', 
+                     'period_from': ref('account.period_1'),
+                     'period_to': ref('account.period_12')}
         from openerp.tools import test_reports
         test_reports.try_report_action(cr, uid, 'action_account_aged_trial_balance_menu_webkit',wiz_data=data_dict, context=ctx, our_module='account_financial_report_webkit')


### PR DESCRIPTION
Even if period_from is not visible in the wizard
it is still necessary for the validation check to pass.

Fixes #67 
