### PR TITLE
[IMP] Fix incompatibility with l10n_es_fiscal_year_closing

### DIFF
--- a/account_financial_report_webkit/__openerp__.py
+++ b/account_financial_report_webkit/__openerp__.py
@@ -169,7 +169,7 @@ an issue in wkhtmltopdf
 the header and footer are created as text with arguments passed to
 wkhtmltopdf. The texts are defined inside the report classes.
 """,
-    'version': '1.1.0',
+    'version': '7.0.1.1.0',
     'author': "Camptocamp,Odoo Community Association (OCA)",
     'license': 'AGPL-3',
     'category': 'Finance',

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -245,15 +245,32 @@ class CommonReportHeaderWebkit(common_report_header):
                                                      ['id', 'in', period_ids]])
 
     def get_included_opening_period(self, period):
-        """Return the opening included in normal period we use the assumption
-        that there is only one opening period per fiscal year"""
+        """Return the opening included in normal period only if
+        normal period is the first period on fiscal year"""
         period_obj = self.pool.get('account.period')
-        return period_obj.search(self.cursor, self.uid,
-                                 [('special', '=', True),
-                                  ('date_start', '>=', period.date_start),
-                                  ('date_stop', '<=', period.date_stop),
-                                  ('company_id', '=', period.company_id.id)],
-                                 limit=1)
+        # Get special period whit date in selected period
+        special_period_id = period_obj.search(
+            self.cursor, self.uid,
+            [('special', '=', True),
+             ('date_start', '>=', period.date_start),
+             ('date_stop', '<=', period.date_stop),
+             ('company_id', '=', period.company_id.id)],
+            limit=1
+        )
+        # Get first not special period from selected period fiscal year
+        first_period_id = period_obj.search(
+            self.cursor, self.uid,
+            [('special', '!=', True),
+             ('fiscalyear_id', '=', period.fiscalyear_id.id),
+             ('company_id', '=', period.company_id.id)],
+            order='date_stop asc', limit=1
+        )
+        # If first period of fiscal year is equal to selected period and
+        # there is a special_period we return special period else return False
+        if period.id in first_period_id and special_period_id:
+            return special_period_id
+
+        return False
 
     def periods_contains_move_lines(self, period_ids):
         if not period_ids:

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -258,7 +258,7 @@ class CommonReportHeaderWebkit(common_report_header):
             limit=1
         )
         # Get first not special period from selected period fiscal year
-        first_period_id = period_obj.search(
+        first_period_ids = period_obj.search(
             self.cursor, self.uid,
             [('special', '!=', True),
              ('fiscalyear_id', '=', period.fiscalyear_id.id),
@@ -267,7 +267,7 @@ class CommonReportHeaderWebkit(common_report_header):
         )
         # If first period of fiscal year is equal to selected period and
         # there is a special_period we return special period else return False
-        if period.id in first_period_id and special_period_id:
+        if period.id in first_period_ids and special_period_id:
             return special_period_id
 
         return False


### PR DESCRIPTION
At l10n_es_fiscal_year_closing you need to setup several special periods
at the end of the fiscal year for holding the profit & loss and close
account moves, this was causing that balance report for last period for a
given fiscal year were not using the calculated opening balance.
