### PR TITLE
Page break bug

### DIFF
--- a/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
@@ -91,7 +91,7 @@
                     ${account.code} - ${account.name}
                 </div>
                 <div class="act_as_thead">
-                    <div class="act_as_row labels">
+                    <div class="act_as_row labels" style="page-break-inside: avoid">
                         ## date
                         <div class="act_as_cell first_column" style="width: 50px;">${_('Date')}</div>
                         ## period
@@ -125,7 +125,7 @@
                     </div>
                 </div>
 
-                <div class="act_as_tbody">
+                <div class="act_as_tbody" style="page-break-inside: avoid">
                       %if display_initial_balance:
                         <%
                         cumul_debit = account.init_balance.get('debit') or 0.0
@@ -179,7 +179,7 @@
                         label = ' '.join(label_elements)
                         %>
 
-                      <div class="act_as_row lines">
+                      <div class="act_as_row lines" style="page-break-inside: avoid">
                           ## date
                           <div class="act_as_cell first_column">${formatLang(line.get('ldate') or '', date=True)}</div>
                           ## period
@@ -213,7 +213,7 @@
                       </div>
                       %endfor
                 </div>
-                <div class="act_as_table list_table">
+                <div class="act_as_table list_table" style="page-break-inside: avoid">
                     <div class="act_as_row labels" style="font-weight: bold;">
                         ## date
                         <div class="act_as_cell first_column" style="width: 615px;">${account.code} - ${account.name}</div>

--- a/account_financial_report_webkit/report/templates/account_report_open_invoices.mako
+++ b/account_financial_report_webkit/report/templates/account_report_open_invoices.mako
@@ -44,7 +44,7 @@
                 <div class="act_as_cell">${_('Target Moves')}</div>
 
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">

--- a/account_financial_report_webkit/report/templates/account_report_partner_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partner_balance.mako
@@ -40,7 +40,7 @@
         %>
 
         <div class="act_as_table data_table">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels"  style="page-break-inside: avoid">
                 <div class="act_as_cell">${_('Chart of Account')}</div>
                 <div class="act_as_cell">${_('Fiscal Year')}</div>
                 <div class="act_as_cell">
@@ -55,7 +55,7 @@
                 <div class="act_as_cell">${_('Target Moves')}</div>
                 <div class="act_as_cell">${_('Initial Balance')}</div>
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">
@@ -87,7 +87,7 @@
 
         %for index, params in enumerate(comp_params):
             <div class="act_as_table data_table">
-                <div class="act_as_row">
+                <div class="act_as_row" style="page-break-inside: avoid">
                     <div class="act_as_cell">${_('Comparison %s') % (index + 1,)} (${"C%s" % (index + 1,)})</div>
                     <div class="act_as_cell">
                         %if params['comparison_filter'] == 'filter_date':
@@ -135,10 +135,10 @@
 
             <div class="account_title bg" style="margin-top: 20px; font-size: 12px; width: 690px;">${current_account.code} - ${current_account.name}</div>
 
-            <div class="act_as_table list_table">
+            <div class="act_as_table list_table" style="page-break-inside: avoid">
 
                 <div class="act_as_thead">
-                    <div class="act_as_row labels">
+                        <div class="act_as_row labels" style="page-break-inside: avoid">
                         ## account name
                         <div class="act_as_cell" style="width: 80px;">${_('Account / Partner Name')}</div>
                         ## code
@@ -203,7 +203,7 @@
                         total_credit += partner.get('credit', 0.0)
                         total_balance += partner.get('balance', 0.0)
                         %>
-                        <div class="act_as_row lines">
+                        <div class="act_as_row lines" style="page-break-inside: avoid">
                             <div class="act_as_cell">${partner_name if partner_name else _('Unallocated') }</div>
                             <div class="act_as_cell first_column">${partner_ref if partner_ref else ''}</div>
                             %if comparison_mode == 'no_comparison':
@@ -244,7 +244,7 @@
 
                 </div>
                 <div class="act_as_tfoot" style="margin-top:5px;">
-                    <div class="act_as_row labels" style="font-weight: bold; font-size: 11x;">
+                    <div class="act_as_row labels" style="font-weight: bold; font-size: 11x; page-break-inside: avoid;">
                         ## account name
                         <div class="act_as_cell">${current_account.name}</div>
                         ## code

--- a/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
@@ -25,7 +25,7 @@
         %>
 
         <div class="act_as_table data_table">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels" style="page-break-inside: avoid">
                 <div class="act_as_cell">${_('Chart of Account')}</div>
                 <div class="act_as_cell">${_('Fiscal Year')}</div>
                 <div class="act_as_cell">
@@ -39,7 +39,7 @@
                 <div class="act_as_cell">${_('Target Moves')}</div>
                 <div class="act_as_cell">${_('Initial Balance')}</div>
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">
@@ -96,7 +96,7 @@
                         ${partner_name or _('No Partner')}
                     </div>
                     <div class="act_as_thead">
-                        <div class="act_as_row labels">
+                        <div class="act_as_row labels" style="page-break-inside: avoid">
                             ## date
                             <div class="act_as_cell first_column" style="width: 50px;">${_('Date')}</div>
                             ## period
@@ -141,7 +141,7 @@
                               cumul_balance += part_cumul_balance
                               cumul_balance_curr += part_cumul_balance_curr
                             %>
-                            <div class="act_as_row initial_balance">
+                            <div class="act_as_row initial_balance" style="page-break-inside: avoid">
                               ## date
                               <div class="act_as_cell first_column"></div>
                               ## period
@@ -184,7 +184,7 @@
                             label_elements.append("(%s)" % (line['invoice_number'],))
                           label = ' '.join(label_elements)
                           %>
-                            <div class="act_as_row lines">
+                            <div class="act_as_row lines" style="page-break-inside: avoid">
                               ## date
                               <div class="act_as_cell first_column">${formatLang(line.get('ldate') or '', date=True)}</div>
                               ## period
@@ -216,7 +216,7 @@
                               %endif
                           </div>
                         %endfor
-                        <div class="act_as_row lines labels">
+                        <div class="act_as_row lines labels" style="page-break-inside: avoid">
                           ## date
                           <div class="act_as_cell first_column"></div>
                           ## period
@@ -261,7 +261,7 @@
                 %endfor
 
                 <div class="act_as_table list_table" style="margin-top:5px;">
-                    <div class="act_as_row labels" style="font-weight: bold; font-size: 12px;">
+                    <div class="act_as_row labels" style="font-weight: bold; font-size: 12px; page-break-inside: avoid">
                             <div class="act_as_cell first_column" style="width: 450px;">${account.code} - ${account.name}</div>
                             ## label
                             <div class="act_as_cell" style="width: 360px;">${_("Cumulated Balance on Account")}</div>

--- a/account_financial_report_webkit/report/templates/account_report_print_journal.mako
+++ b/account_financial_report_webkit/report/templates/account_report_print_journal.mako
@@ -20,7 +20,7 @@
         <%setLang(user.lang)%>
 
         <div class="act_as_table data_table">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels" style="page-break-inside: avoid">
                 <div class="act_as_cell">${_('Chart of Account')}</div>
                 <div class="act_as_cell">${_('Fiscal Year')}</div>
                 <div class="act_as_cell">
@@ -33,7 +33,7 @@
                 <div class="act_as_cell">${_('Journal Filter')}</div>
                 <div class="act_as_cell">${_('Target Moves')}</div>
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">
@@ -74,7 +74,7 @@
         <!-- we use div with css instead of table for tabular data because div do not cut rows at half at page breaks -->
         <div class="act_as_table list_table" style="margin-top: 5px;">
             <div class="act_as_thead">
-                <div class="act_as_row labels">
+                <div class="act_as_row labels" style="page-break-inside: avoid">
                     ## date
                     <div class="act_as_cell first_column">${_('Date')}</div>
                     ## move
@@ -110,7 +110,7 @@
                     account_total_debit += line.debit or 0.0
                     account_total_credit += line.credit or 0.0
                     %>
-                    <div class="act_as_row lines">
+                    <div class="act_as_row lines" style="page-break-inside: avoid">
                         ## date
                         <div class="act_as_cell first_column">${formatLang(move.date, date=True) if new_move else ''}</div>
                         ## move
@@ -140,7 +140,7 @@
                 </div>
                 %endfor
             %endfor
-            <div class="act_as_row lines labels">
+            <div class="act_as_row lines labels" style="page-break-inside: avoid">
                 ## date
                 <div class="act_as_cell first_column"></div>
                 ## move

--- a/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
@@ -49,7 +49,7 @@
         %>
 
         <div class="act_as_table data_table">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels" style="page-break-inside: avoid">
                 <div class="act_as_cell">${_('Chart of Account')}</div>
                 <div class="act_as_cell">${_('Fiscal Year')}</div>
                 <div class="act_as_cell">
@@ -63,7 +63,7 @@
                 <div class="act_as_cell">${_('Target Moves')}</div>
                 <div class="act_as_cell">${_('Initial Balance')}</div>
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">
@@ -94,7 +94,7 @@
 
         %for index, params in enumerate(comp_params):
             <div class="act_as_table data_table">
-                <div class="act_as_row">
+                <div class="act_as_row" style="page-break-inside: avoid">
                     <div class="act_as_cell">${_('Comparison %s') % (index + 1,)} (${"C%s" % (index + 1,)})</div>
                     <div class="act_as_cell">
                         %if params['comparison_filter'] == 'filter_date':
@@ -113,7 +113,7 @@
         <div class="act_as_table list_table" style="margin-top: 20px;">
 
             <div class="act_as_thead">
-                <div class="act_as_row labels">
+                <div class="act_as_row labels" style="page-break-inside: avoid">
                     ## code
                     <div class="act_as_cell first_column" style="width: 20px;">${_('Code')}</div>
                     ## account name
@@ -177,7 +177,7 @@
                         last_child_consol_ids = [child_consol_id.id for child_consol_id in current_account.child_consol_ids]
                         last_level = current_account.level
                     %>
-                    <div class="act_as_row lines ${level_class} ${"%s_account_type" % (current_account.type,)}">
+                    <div class="act_as_row lines ${level_class} ${"%s_account_type" % (current_account.type,)}" style="page-break-inside: avoid">
                         ## code
                         <div class="act_as_cell first_column">${current_account.code}</div>
                         ## account name

--- a/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
+++ b/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
@@ -45,7 +45,7 @@
         <%setLang(user.lang)%>
 
         <div class="act_as_table data_table">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels" style="page-break-inside: avoid">
                 <div class="act_as_cell">${_('Chart of Account')}</div>
                 <div class="act_as_cell">${_('Fiscal Year')}</div>
                 <div class="act_as_cell">
@@ -60,7 +60,7 @@
                 <div class="act_as_cell">${_('Target Moves')}</div>
 
             </div>
-            <div class="act_as_row">
+            <div class="act_as_row" style="page-break-inside: avoid">
                 <div class="act_as_cell">${ chart_account.name }</div>
                 <div class="act_as_cell">${ fiscalyear.name if fiscalyear else '-' }</div>
                 <div class="act_as_cell">
@@ -96,7 +96,7 @@
 
                 <div class="act_as_table list_table" style="margin-top: 5px;">
                   <div class="act_as_thead">
-                    <div class="act_as_row labels">
+                    <div class="act_as_row labels" style="page-break-inside: avoid">
                       ## partner
                       <div class="act_as_cell first_column" style="width: 60px;">${_('Partner')}</div>
                       ## code
@@ -112,7 +112,7 @@
                   <div class="act_as_tbody">
                     %for partner_name, p_id, p_ref, p_name in acc.partners_order:
                        %if acc.aged_lines.get(p_id):
-                       <div class="act_as_row lines">
+                       <div class="act_as_row lines" style="page-break-inside: avoid">
                          <%line = acc.aged_lines[p_id]%>
                          <%percents = acc.aged_percents%>
                          <%totals = acc.aged_totals%>
@@ -128,7 +128,7 @@
                        </div>
                        %endif
                     %endfor
-                    <div class="act_as_row labels">
+                    <div class="act_as_row labels" style="page-break-inside: avoid">
                       <div class="act_as_cell total">${_('Total')}</div>
                       <div class="act_as_cell"></div>
                       <div class="act_as_cell amount classif total">${formatLang(totals['balance']) | amount}</div>
@@ -137,7 +137,7 @@
                       %endfor
                     </div>
 
-                    <div class="act_as_row">
+                    <div class="act_as_row" style="page-break-inside: avoid">
                       <div class="act_as_cell"><b>${_('Percents')}</b></div>
                       <div class="act_as_cell"></div>
                       <div class="act_as_cell"></div>

--- a/account_financial_report_webkit/report/templates/open_invoices_inclusion.mako.html
+++ b/account_financial_report_webkit/report/templates/open_invoices_inclusion.mako.html
@@ -25,7 +25,7 @@
             ${partner_name or _('No Partner')}
         </div>
         <div class="act_as_thead">
-            <div class="act_as_row labels">
+            <div class="act_as_row labels" style="page-break-inside: avoid">
                 ## date
                 <div class="act_as_cell first_column" style="width: 60px;">${_('Date')}</div>
                 ## period
@@ -77,7 +77,7 @@
                 label_elements.append("(%s)" % (line['invoice_number'],))
               label = ' '.join(label_elements)
               %>
-                <div class="act_as_row lines ${line.get('is_from_previous_periods') and 'open_invoice_previous_line' or ''} ${line.get('is_clearance_line') and 'clearance_line' or ''}">
+                <div class="act_as_row lines ${line.get('is_from_previous_periods') and 'open_invoice_previous_line' or ''} ${line.get('is_clearance_line') and 'clearance_line' or ''}" style="page-break-inside: avoid">
                   ## date
                   <div class="act_as_cell first_column">${formatLang(line.get('ldate') or '', date=True)}</div>
                   ## period
@@ -111,7 +111,7 @@
                   %endif
               </div>
             %endfor
-            <div class="act_as_row lines labels">
+            <div class="act_as_row lines labels" style="page-break-inside: avoid">
               ## date
               <div class="act_as_cell first_column"></div>
               ## period
@@ -157,7 +157,7 @@
     %>
     %endfor
     <div class="act_as_table list_table" style="margin-top:5px;">
-        <div class="act_as_row labels" style="font-weight: bold; font-size: 12px;">
+        <div class="act_as_row labels" style="font-weight: bold; font-size: 12px;" style="page-break-inside: avoid">
                 <div class="act_as_cell first_column" style="width: 520px;">${account.code} - ${account.name}</div>
                 ## label
                 <div class="act_as_cell" style="width: 320px;">${_("Cumulated Balance on Account")}</div>


### PR DESCRIPTION
Even with newest wkhtmltox on firefox the print of general ledger and other reports where cutting lines.
So, a little solution to the page break bug as oriented in
https://www.odoo.com/fr_FR/forum/help-1/question/how-to-get-webkit-reports-pagination-to-not-cut-a-line-in-half-11731
