### PR TITLE
[FIX][7.0] There was a missing parameter in the function formatLang in the Reports

### DIFF
--- a/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
@@ -153,14 +153,14 @@
                           ## counterpart
                           <div class="act_as_cell"></div>
                           ## debit
-                          <div class="act_as_cell amount">${formatLang(account.init_balance.get('debit')) | amount}</div>
+                          <div class="act_as_cell amount">${formatLang(account.init_balance.get('debit'), monetary=True) | amount}</div>
                           ## credit
-                          <div class="act_as_cell amount">${formatLang(account.init_balance.get('credit')) | amount}</div>
+                          <div class="act_as_cell amount">${formatLang(account.init_balance.get('credit'), monetary=True) | amount}</div>
                           ## balance cumulated
-                          <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                          <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance, monetary=True) | amount }</div>
                          %if amount_currency(data):
                               ## currency balance
-                              <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr) | amount }</div>
+                              <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr, monetary=True) | amount }</div>
                               ## curency code
                               <div class="act_as_cell amount"></div>
                          %endif
@@ -199,14 +199,14 @@
                           ## counterpart
                           <div class="act_as_cell">${line.get('counterparts') or ''}</div>
                           ## debit
-                          <div class="act_as_cell amount">${ formatLang(line.get('debit', 0.0)) | amount }</div>
+                          <div class="act_as_cell amount">${ formatLang(line.get('debit', 0.0), monetary=True) | amount }</div>
                           ## credit
-                          <div class="act_as_cell amount">${ formatLang(line.get('credit', 0.0)) | amount }</div>
+                          <div class="act_as_cell amount">${ formatLang(line.get('credit', 0.0), monetary=True) | amount }</div>
                           ## balance cumulated
-                          <div class="act_as_cell amount" style="padding-right: 1px;">${ formatLang(cumul_balance) | amount }</div>
+                          <div class="act_as_cell amount" style="padding-right: 1px;">${ formatLang(cumul_balance, monetary=True) | amount }</div>
                           %if amount_currency(data):
                               ## currency balance
-                              <div class="act_as_cell amount sep_left">${formatLang(line.get('amount_currency') or 0.0)  | amount }</div>
+                              <div class="act_as_cell amount sep_left">${formatLang(line.get('amount_currency') or 0.0, monetary=True)  | amount }</div>
                               ## curency code
                               <div class="act_as_cell amount" style="text-align: right;">${line.get('currency_code') or ''}</div>
                           %endif
@@ -219,15 +219,15 @@
                         <div class="act_as_cell first_column" style="width: 615px;">${account.code} - ${account.name}</div>
                         <div class="act_as_cell" style="width: 260px;">${_("Cumulated Balance on Account")}</div>
                         ## debit
-                        <div class="act_as_cell amount" style="width: 75px;">${ formatLang(cumul_debit) | amount }</div>
+                        <div class="act_as_cell amount" style="width: 75px;">${ formatLang(cumul_debit, monetary=True) | amount }</div>
                         ## credit
-                        <div class="act_as_cell amount" style="width: 75px;">${ formatLang(cumul_credit) | amount }</div>
+                        <div class="act_as_cell amount" style="width: 75px;">${ formatLang(cumul_credit, monetary=True) | amount }</div>
                         ## balance cumulated
-                        <div class="act_as_cell amount" style="width: 75px; padding-right: 1px;">${ formatLang(cumul_balance) | amount }</div>
+                        <div class="act_as_cell amount" style="width: 75px; padding-right: 1px;">${ formatLang(cumul_balance, monetary=True) | amount }</div>
                         %if amount_currency(data):
                             %if account.currency_id:
                                 ## currency balance
-                                <div class="act_as_cell amount sep_left" style="width: 75px;">${formatLang(cumul_balance_curr) | amount }</div>
+                                <div class="act_as_cell amount sep_left" style="width: 75px;">${formatLang(cumul_balance_curr, monetary=True) | amount }</div>
                             %else:
                                 <div class="act_as_cell amount sep_left" style="width: 75px;">-</div>
                             %endif

--- a/account_financial_report_webkit/report/templates/account_report_partner_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partner_balance.mako
@@ -208,12 +208,12 @@
                             <div class="act_as_cell first_column">${partner_ref if partner_ref else ''}</div>
                             %if comparison_mode == 'no_comparison':
                                 %if initial_balance_mode:
-                                    <div class="act_as_cell amount">${formatLang(partner.get('init_balance', 0.0)) | amount}</div>
+                                    <div class="act_as_cell amount">${formatLang(partner.get('init_balance', 0.0), monetary=True) | amount}</div>
                                 %endif
-                                <div class="act_as_cell amount">${formatLang(partner.get('debit', 0.0)) | amount}</div>
-                                <div class="act_as_cell amount">${formatLang(partner.get('credit', 0.0)) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(partner.get('debit', 0.0), monetary=True) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(partner.get('credit', 0.0), monetary=True) | amount}</div>
                             %endif
-                            <div class="act_as_cell amount">${formatLang(partner['balance'] if partner else 0.0) | amount}</div>
+                            <div class="act_as_cell amount">${formatLang(partner['balance'] if partner else 0.0, monetary=True) | amount}</div>
 
                             %if comparison_mode in ('single', 'multiple'):
                                 %for i, comp in enumerate(comparisons):
@@ -226,9 +226,9 @@
                                         percent_diff = comp_partners[partner_id]['percent_diff']
                                         comparison_total[i]['balance'] += balance
                                     %>
-                                    <div class="act_as_cell amount">${formatLang(balance) | amount}</div>
+                                    <div class="act_as_cell amount">${formatLang(balance, monetary=True) | amount}</div>
                                     %if comparison_mode == 'single':  ## no diff in multiple comparisons because it shows too data
-                                        <div class="act_as_cell amount">${formatLang(diff) | amount}</div>
+                                        <div class="act_as_cell amount">${formatLang(diff, monetary=True) | amount}</div>
                                         <div class="act_as_cell amount">
                                         %if percent_diff is False:
                                          ${ '-' }
@@ -252,15 +252,15 @@
                         %if comparison_mode == 'no_comparison':
                             %if initial_balance_mode:
                                 ## opening balance
-                                <div class="act_as_cell amount">${formatLang(total_initial_balance) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(total_initial_balance, monetary=True) | amount}</div>
                             %endif
                             ## debit
-                            <div class="act_as_cell amount">${formatLang(total_debit) | amount}</div>
+                            <div class="act_as_cell amount">${formatLang(total_debit, monetary=True) | amount}</div>
                             ## credit
-                            <div class="act_as_cell amount">${formatLang(total_credit and total_credit * -1 or 0.0) | amount}</div>
+                            <div class="act_as_cell amount">${formatLang(total_credit and total_credit * -1 or 0.0, monetary=True) | amount}</div>
                         %endif
                         ## balance
-                        <div class="act_as_cell amount">${formatLang(total_balance) | amount}</div>
+                        <div class="act_as_cell amount">${formatLang(total_balance, monetary=True) | amount}</div>
 
                         %if comparison_mode in ('single', 'multiple'):
                             %for i, comp in enumerate(comparisons):
@@ -268,9 +268,9 @@
                                 comp_account = comp['account']
                                 diffs = compute_diff(total_balance, comparison_total[i]['balance'])
                                 %>
-                                <div class="act_as_cell amount">${formatLang(comparison_total[i]['balance']) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(comparison_total[i]['balance'], monetary=True) | amount}</div>
                                 %if comparison_mode == 'single':  ## no diff in multiple comparisons because it shows too data
-                                    <div class="act_as_cell amount">${formatLang(diffs['diff']) | amount}</div>
+                                    <div class="act_as_cell amount">${formatLang(diffs['diff'], monetary=True) | amount}</div>
                                     <div class="act_as_cell amount">
                                     %if diffs['percent_diff'] is False:
                                      ${ '-' }

--- a/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
@@ -67,7 +67,6 @@
                 <div class="act_as_cell">${ initial_balance_text[initial_balance_mode] }</div>
             </div>
         </div>
-
         %for account in objects:
             %if account.ledger_lines or account.init_balance:
                 <%
@@ -159,14 +158,14 @@
                               ## reconcile
                               <div class="act_as_cell"></div>
                               ## debit
-                              <div class="act_as_cell amount">${formatLang(total_debit) | amount }</div>
+                              <div class="act_as_cell amount">${formatLang(total_debit, monetary=True) | amount }</div>
                               ## credit
-                              <div class="act_as_cell amount">${formatLang(total_credit) | amount }</div>
+                              <div class="act_as_cell amount">${formatLang(total_credit, monetary=True) | amount }</div>
                               ## balance cumulated
-                              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(part_cumul_balance) | amount }</div>
+                              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(part_cumul_balance, monetary=True) | amount }</div>
                              %if amount_currency(data):
                                   ## currency balance
-                                  <div class="act_as_cell sep_left amount">${formatLang(part_cumul_balance_curr) | amount }</div>
+                                  <div class="act_as_cell sep_left amount">${formatLang(part_cumul_balance_curr, monetary=True) | amount }</div>
                                   ## curency code
                                   <div class="act_as_cell">${balance_forward_currency}</div>
                              %endif
@@ -202,15 +201,15 @@
                               ## reconcile
                               <div class="act_as_cell">${line.get('rec_name') or ''}</div>
                               ## debit
-                              <div class="act_as_cell amount">${formatLang(line.get('debit') or 0.0) | amount }</div>
+                              <div class="act_as_cell amount">${formatLang(line.get('debit') or 0.0, monetary=True) | amount }</div>
                               ## credit
-                              <div class="act_as_cell amount">${formatLang(line.get('credit') or 0.0) | amount }</div>
+                              <div class="act_as_cell amount">${formatLang(line.get('credit') or 0.0, monetary=True) | amount }</div>
                               ## balance cumulated
                               <% cumul_balance += line.get('balance') or 0.0 %>
-                              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance, monetary=True) | amount }</div>
                               %if amount_currency(data):
                                   ## currency balance
-                                  <div class="act_as_cell sep_left amount">${formatLang(line.get('amount_currency') or 0.0) | amount }</div>
+                                  <div class="act_as_cell sep_left amount">${formatLang(line.get('amount_currency') or 0.0, monetary=True) | amount }</div>
                                   ## curency code
                                   <div class="act_as_cell" style="text-align: right; ">${line.get('currency_code') or ''}</div>
                               %endif
@@ -234,15 +233,15 @@
                           ## reconcile
                           <div class="act_as_cell"></div>
                           ## debit
-                          <div class="act_as_cell amount">${formatLang(total_debit) | amount }</div>
+                          <div class="act_as_cell amount">${formatLang(total_debit, monetary=True) | amount }</div>
                           ## credit
-                          <div class="act_as_cell amount">${formatLang(total_credit) | amount }</div>
+                          <div class="act_as_cell amount">${formatLang(total_credit, monetary=True) | amount }</div>
                           ## balance cumulated
-                          <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                          <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance, monetary=True) | amount }</div>
                           %if amount_currency(data):
                               ## currency balance
                               %if account.currency_id:
-                                  <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr) | amount }</div>
+                                  <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr, monetary=True) | amount }</div>
                               %else:
                                   <div class="act_as_cell sep_left amount">${ u'-' }</div>
                               %endif
@@ -266,15 +265,15 @@
                             ## label
                             <div class="act_as_cell" style="width: 360px;">${_("Cumulated Balance on Account")}</div>
                             ## debit
-                            <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_debit) | amount }</div>
+                            <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_debit, monetary=True) | amount }</div>
                             ## credit
-                            <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_credit) | amount }</div>
+                            <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_credit, monetary=True) | amount }</div>
                             ## balance cumulated
-                            <div class="act_as_cell amount" style="width: 80px; padding-right: 1px;">${ formatLang(account_balance_cumul) | amount }</div>
+                            <div class="act_as_cell amount" style="width: 80px; padding-right: 1px;">${ formatLang(account_balance_cumul, monetary=True) | amount }</div>
                             %if amount_currency(data):
                                 ## currency balance
                                 %if account.currency_id:
-                                    <div class="act_as_cell amount sep_left" style="width: 80px;">${ formatLang(account_balance_cumul_curr) | amount }</div>
+                                    <div class="act_as_cell amount sep_left" style="width: 80px;">${ formatLang(account_balance_cumul_curr, monetary=True) | amount }</div>
                                 %else:
                                     <div class="act_as_cell amount sep_left" style="width: 80px;">${ u'-' }</div>
                                 %endif

--- a/account_financial_report_webkit/report/templates/account_report_print_journal.mako
+++ b/account_financial_report_webkit/report/templates/account_report_print_journal.mako
@@ -124,12 +124,12 @@
                         ## label
                         <div class="act_as_cell overflow_ellipsis" style="width: 310px;">${line.name}</div>
                         ## debit
-                        <div class="act_as_cell amount">${formatLang(line.debit) if line.debit else ''}</div>
+                        <div class="act_as_cell amount">${formatLang(line.debit, monetary=True) if line.debit else ''}</div>
                         ## credit
-                        <div class="act_as_cell amount">${formatLang(line.credit) if line.credit else ''}</div>
+                        <div class="act_as_cell amount">${formatLang(line.credit, monetary=True) if line.credit else ''}</div>
                         %if amount_currency(data):
                             ## currency balance
-                            <div class="act_as_cell amount sep_left">${formatLang(line.amount_currency) if line.amount_currency else ''}</div>
+                            <div class="act_as_cell amount sep_left">${formatLang(line.amount_currency, monetary=True) if line.amount_currency else ''}</div>
                             ## curency code
                             <div class="act_as_cell amount" style="text-align: right;">${line.currency_id.symbol or ''}</div>
                         %endif
@@ -154,9 +154,9 @@
                 ## label
                 <div class="act_as_cell" style="width: 310px;"></div>
                 ## debit
-                <div class="act_as_cell amount">${formatLang(account_total_debit) | amount }</div>
+                <div class="act_as_cell amount">${formatLang(account_total_debit, monetary=True) | amount }</div>
                 ## credit
-                <div class="act_as_cell amount">${formatLang(account_total_credit) | amount }</div>
+                <div class="act_as_cell amount">${formatLang(account_total_credit, monetary=True) | amount }</div>
                 %if amount_currency(data):
                   ## currency balance
                   <div class="act_as_cell amount sep_left"></div>

--- a/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
@@ -185,21 +185,21 @@
                         %if comparison_mode == 'no_comparison':
                             %if initial_balance_mode:
                                 ## opening balance
-                                <div class="act_as_cell amount">${formatLang(current_account.init_balance) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(current_account.init_balance, monetary=True) | amount}</div>
                             %endif
                             ## debit
-                            <div class="act_as_cell amount">${formatLang(current_account.debit) | amount}</div>
+                            <div class="act_as_cell amount">${formatLang(current_account.debit, monetary=True) | amount}</div>
                             ## credit
-                            <div class="act_as_cell amount">${formatLang(current_account.credit) | amount}</div>
+                            <div class="act_as_cell amount">${formatLang(current_account.credit, monetary=True) | amount}</div>
                         %endif
                         ## balance
-                        <div class="act_as_cell amount">${formatLang(current_account.balance) | amount}</div>
+                        <div class="act_as_cell amount">${formatLang(current_account.balance, monetary=True) | amount}</div>
 
                         %if comparison_mode in ('single', 'multiple'):
                             %for comp_account in comparisons:
-                                <div class="act_as_cell amount">${formatLang(comp_account['balance']) | amount}</div>
+                                <div class="act_as_cell amount">${formatLang(comp_account['balance'], monetary=True) | amount}</div>
                                 %if comparison_mode == 'single':  ## no diff in multiple comparisons because it shows too data
-                                    <div class="act_as_cell amount">${formatLang(comp_account['diff']) | amount}</div>
+                                    <div class="act_as_cell amount">${formatLang(comp_account['diff'], monetary=True) | amount}</div>
                                     <div class="act_as_cell amount"> 
                                     %if comp_account['percent_diff'] is False:
                                      ${ '-' }

--- a/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
+++ b/account_financial_report_webkit/report/templates/aged_trial_webkit.mako
@@ -119,10 +119,10 @@
                            <div class="act_as_cell first_column">${partner_name}</div>
                            <div class="act_as_cell">${p_ref or ''}</div>
 
-                           <div class="act_as_cell amount">${formatLang(line.get('balance') or 0.0) | amount}</div>
+                           <div class="act_as_cell amount">${formatLang(line.get('balance') or 0.0, monetary=True) | amount}</div>
                             %for classif in ranges:
                               <div class="act_as_cell classif amount">
-                                ${formatLang(line['aged_lines'][classif] or 0.0) | amount}
+                                ${formatLang(line['aged_lines'][classif] or 0.0, monetary=True) | amount}
                               </div>
                             %endfor
                        </div>
@@ -131,9 +131,9 @@
                     <div class="act_as_row labels">
                       <div class="act_as_cell total">${_('Total')}</div>
                       <div class="act_as_cell"></div>
-                      <div class="act_as_cell amount classif total">${formatLang(totals['balance']) | amount}</div>
+                      <div class="act_as_cell amount classif total">${formatLang(totals['balance'], monetary=True) | amount}</div>
                       %for classif in ranges:
-                        <div class="act_as_cell amount classif total">${formatLang(totals[classif]) | amount}</div>
+                        <div class="act_as_cell amount classif total">${formatLang(totals[classif], monetary=True) | amount}</div>
                       %endfor
                     </div>
 
@@ -142,7 +142,7 @@
                       <div class="act_as_cell"></div>
                       <div class="act_as_cell"></div>
                       %for classif in ranges:
-                        <div class="act_as_cell amount percent_line  classif">${formatLang(percents[classif]) | amount}%</div>
+                        <div class="act_as_cell amount percent_line  classif">${formatLang(percents[classif], monetary=True) | amount}%</div>
                       %endfor
                     </div>
                   </div>

--- a/account_financial_report_webkit/report/templates/open_invoices_inclusion.mako.html
+++ b/account_financial_report_webkit/report/templates/open_invoices_inclusion.mako.html
@@ -97,15 +97,15 @@
                   ## maturity date
                   <div class="act_as_cell">${formatLang(line.get('date_maturity') or '', date=True)}</div>
                   ## debit
-                  <div class="act_as_cell amount">${formatLang(line.get('debit') or 0.0) | amount }</div>
+                  <div class="act_as_cell amount">${formatLang(line.get('debit') or 0.0, monetary=True) | amount }</div>
                   ## credit
-                  <div class="act_as_cell amount">${formatLang(line.get('credit') or 0.0) | amount }</div>
+                  <div class="act_as_cell amount">${formatLang(line.get('credit') or 0.0, monetary=True) | amount }</div>
                   ## balance cumulated
                   <% cumul_balance += line.get('balance') or 0.0 %>
-                  <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                  <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance, monetary=True) | amount }</div>
                   %if amount_currency(data):
                       ## currency balance
-                      <div class="act_as_cell sep_left amount">${formatLang(line.get('amount_currency') or 0.0) | amount }</div>
+                      <div class="act_as_cell sep_left amount">${formatLang(line.get('amount_currency') or 0.0, monetary=True) | amount }</div>
                       ## curency code
                       <div class="act_as_cell" style="text-align: right; ">${line.get('currency_code') or ''}</div>
                   %endif
@@ -131,15 +131,15 @@
               ## maturity date
               <div class="act_as_cell"></div>
               ## debit
-              <div class="act_as_cell amount">${formatLang(total_debit) | amount }</div>
+              <div class="act_as_cell amount">${formatLang(total_debit, monetary=True) | amount }</div>
               ## credit
-              <div class="act_as_cell amount">${formatLang(total_credit) | amount }</div>
+              <div class="act_as_cell amount">${formatLang(total_credit, monetary=True) | amount }</div>
               ## balance cumulated
-              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+              <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance, monetary=True) | amount }</div>
               %if amount_currency(data):
                   %if account.currency_id:
                       ## currency balance
-                      <div class="act_as_cell sep_left amount" style="padding-right: 1px;">${formatLang(cumul_balance_curr) | amount }</div>
+                      <div class="act_as_cell sep_left amount" style="padding-right: 1px;">${formatLang(cumul_balance_curr, monetary=True) | amount }</div>
                   %else:
                       <div class="act_as_cell sep_left amount" style="padding-right: 1px;">${ u'-' }</div>
                   %endif
@@ -162,15 +162,15 @@
                 ## label
                 <div class="act_as_cell" style="width: 320px;">${_("Cumulated Balance on Account")}</div>
                 ## debit
-                <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_debit) | amount }</div>
+                <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_debit, monetary=True) | amount }</div>
                 ## credit
-                <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_credit) | amount }</div>
+                <div class="act_as_cell amount" style="width: 80px;">${ formatLang(account_total_credit, monetary=True) | amount }</div>
                 ## balance cumulated
-                <div class="act_as_cell amount" style="width: 80px; ">${ formatLang(account_balance_cumul) | amount }</div>
+                <div class="act_as_cell amount" style="width: 80px; ">${ formatLang(account_balance_cumul, monetary=True) | amount }</div>
                 %if amount_currency(data):
                     ## currency balance cumulated
                     %if account.currency_id:
-                        <div class="act_as_cell amount sep_left" style="width: 80px;">${ formatLang(account_balance_cumul_curr) | amount }</div>
+                        <div class="act_as_cell amount sep_left" style="width: 80px;">${ formatLang(account_balance_cumul_curr, monetary=True) | amount }</div>
                     %else:
                         <div class="act_as_cell amount sep_left" style="width: 80px; padding-right: 1px;">${ u'-' }</div>
                     %endif


### PR DESCRIPTION
There was a missing parameter in the function formatLang, monetary=True, to print monetary amounts

If was not definite the thousand separator in the languange
To print a report gave us a error
codec can't decode byte 0xe2 in position 2: ordinal not in range(128)
