### PR TITLE
7.0-Add filter to skip account with a null balance

### DIFF
--- a/account_financial_report_webkit/i18n/account_financial_report_webkit.pot
+++ b/account_financial_report_webkit/i18n/account_financial_report_webkit.pot
@@ -1467,3 +1467,13 @@ msgstr ""
 msgid "{'required': [('filter', '=', 'filter_opening')]}"
 msgstr ""
 
+#. module: account_financial_report_webkit
+#: field:partner.balance.webkit,exclude_null_balance:0
+msgid "Exclude null Balance"
+msgstr ""
+
+#. module: account_financial_report_webkit
+#: view:partner.balance.webkit:0
+msgid "Other Filters"
+msgstr ""
+

--- a/account_financial_report_webkit/i18n/fr.po
+++ b/account_financial_report_webkit/i18n/fr.po
@@ -1347,3 +1347,13 @@ msgstr ""
 #: field:trial.balance.webkit,comp2_filter:0
 msgid "Compare By"
 msgstr "Compare By"
+
+#. module: account_financial_report_webkit
+#: field:partner.balance.webkit,exclude_null_balance:0
+msgid "Exclude null Balance"
+msgstr "Exclure les balances nulles"
+
+#. module: account_financial_report_webkit
+#: view:partner.balance.webkit:0
+msgid "Other Filters"
+msgstr "Autres Filtres"

--- a/account_financial_report_webkit/wizard/partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard.py
@@ -40,6 +40,10 @@ class AccountPartnerBalanceWizard(orm.TransientModel):
             'res.partner', string='Filter on partner',
             help="Only selected partners will be printed. \
                   Leave empty to print all partners."),
+        'exclude_null_balance': fields.boolean(
+            string='Exclude null Balance',
+            help="if matched, the report will exclude account if the balance "
+                 "is null"),
     }
 
     _defaults = {
@@ -50,7 +54,9 @@ class AccountPartnerBalanceWizard(orm.TransientModel):
         data = super(AccountPartnerBalanceWizard, self).\
             pre_print_report(cr, uid, ids, data, context)
         vals = self.read(cr, uid, ids,
-                         ['result_selection', 'partner_ids'],
+                         ['result_selection',
+                          'partner_ids',
+                          'exclude_null_balance'],
                          context=context)[0]
         data['form'].update(vals)
         return data

--- a/account_financial_report_webkit/wizard/partner_balance_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard_view.xml
@@ -39,6 +39,11 @@
                             <separator string="Print only" colspan="4"/>
                             <field name="partner_ids" colspan="4" nolabel="1"/>
                         </page>
+                        <page string="Other Filters">
+                            <group>
+                                <field name="exclude_null_balance" colspan="4"/>
+                            </group>
+                        </page>
                         <page name="placeholder"/>
                     </page>
                     <page name="journal_ids" position="attributes">


### PR DESCRIPTION
In the partner ledger report.
Some companies have so much journal items in one fical year that the excel file become too big.
Skipping account with a null balance resolve the problem and make a cleaner report.
