### PR TITLE
Remove un-optimized "LIMIT 1" from SQL request

### DIFF
--- a/account_financial_report_webkit/account_move_line.py
+++ b/account_financial_report_webkit/account_move_line.py
@@ -47,11 +47,14 @@ class AccountMoveLine(orm.Model):
             res[line.id] = {'last_rec_date': False}
             rec = line.reconcile_id or line.reconcile_partial_id or False
             if rec:
-                # we use cursor in order to gain some perfs
+                # we use cursor in order to gain some perfs.
+                # also, important point: LIMIT 1 is not used due to
+                # performance issues when in conjonction with "OR"
+                # (one backwards index scan instead of 2 scans and a sort)
                 cursor.execute('SELECT date from account_move_line'
                                ' WHERE reconcile_id = %s'
                                ' OR reconcile_partial_id = %s'
-                               ' ORDER BY date DESC LIMIT 1 ',
+                               ' ORDER BY date DESC',
                                (rec.id, rec.id))
                 res_set = cursor.fetchone()
                 if res_set:


### PR DESCRIPTION
This PR is an SQL optimization for the field `last_rec_date` in `account_move_line`.

As described here: http://stackoverflow.com/a/21386282 , using `LIMIT 1` in the request with a `OR` condition will mean that the request will first sort the records by `date DESC` then filtering on the reconcilation IDs (because it think that it will find the record quickly in the sorted record, but it doesn't), instead of using the Bitmap indexes for both reconciliation columns then sorting the result.

Here are 2 ANALYZE done before and after the change.
Before:

```
explain analyze SELECT date FROM account_move_line WHERE reconcile_id = 2044475 OR reconcile_partial_id = 2044475 ORDER BY date DESC LIMIT 1;
                                                                                 QUERY PLAN                                                                                 
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..1048.85 rows=1 width=4) (actual time=1864.691..1864.691 rows=0 loops=1)
   ->  Index Scan Backward using account_move_line_date_index on account_move_line  (cost=0.43..337593.23 rows=322 width=4) (actual time=1864.691..1864.691 rows=0 loops=1)
         Filter: ((reconcile_id = 2044475) OR (reconcile_partial_id = 2044475))
         Rows Removed by Filter: 3909097
 Planning time: 0.124 ms
 Execution time: 1864.706 ms
(6 rows)

Time: 1865.111 ms
```

After:

```
explain analyze SELECT date FROM account_move_line WHERE reconcile_id = 2044475 OR reconcile_partial_id = 2044475 ORDER BY date DESC;`
                                                                            QUERY PLAN                                                                             
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=1260.58..1261.39 rows=322 width=4) (actual time=0.022..0.022 rows=0 loops=1)
   Sort Key: date
   Sort Method: quicksort  Memory: 25kB
   ->  Bitmap Heap Scan on account_move_line  (cost=11.44..1247.17 rows=322 width=4) (actual time=0.017..0.017 rows=0 loops=1)
         Recheck Cond: ((reconcile_id = 2044475) OR (reconcile_partial_id = 2044475))
         ->  BitmapOr  (cost=11.44..11.44 rows=322 width=0) (actual time=0.015..0.015 rows=0 loops=1)
               ->  Bitmap Index Scan on account_move_line_reconcile_id_index  (cost=0.00..4.98 rows=74 width=0) (actual time=0.010..0.010 rows=0 loops=1)
                     Index Cond: (reconcile_id = 2044475)
               ->  Bitmap Index Scan on account_move_line_reconcile_partial_id_index  (cost=0.00..6.29 rows=248 width=0) (actual time=0.005..0.005 rows=0 loops=1)
                     Index Cond: (reconcile_partial_id = 2044475)
 Planning time: 0.126 ms
 Execution time: 0.041 ms
```
