### PR TITLE
import guard for report_xls

### DIFF
--- a/mis_builder/report/__init__.py
+++ b/mis_builder/report/__init__.py
@@ -22,5 +22,9 @@
 #
 ##############################################################################
 
-from . import mis_builder_xls
+try:
+    from . import mis_builder_xls
+except ImportError:
+    pass  # this module is not installed
+
 from . import report_mis_report_instance


### PR DESCRIPTION
The dependency is indeed declared in **openerp**.py and will be
enforced. Odoo evaluates all python files, even for modules which are
not installed, and crashes if an unneeded dependency is needed.
