### PR TITLE
[FIX] account_financial_report_webkit: search of first opening period…

### DIFF
--- a/account_financial_report_webkit/report/common_partner_reports.py
+++ b/account_financial_report_webkit/report/common_partner_reports.py
@@ -66,16 +66,15 @@ class CommonPartnersReportHeaderWebkit(CommonReportHeaderWebkit):
 
         :return: browse record of the first special period.
         """
-        move_line_obj = self.pool.get('account.move.line')
-        first_entry_id = move_line_obj.search(
-            self.cr, self.uid, [], order='date ASC', limit=1)
-        # it means there is no entry at all, that's unlikely to happen, but
-        # it may so
-        if not first_entry_id:
+        self.cursor.execute("""select account_fiscalyear.id from account_fiscalyear
+            right join account_period on account_fiscalyear.id=account_period.fiscalyear_id
+            right join account_move on account_period.id=account_move.period_id
+            order by account_fiscalyear.date_start ASC limit 1""")
+        fiscalyear_id = self.cursor.fetchone()
+        if not fiscalyear_id:
             return
-        first_entry = move_line_obj.browse(
-            self.cr, self.uid, first_entry_id[0])
-        fiscalyear = first_entry.period_id.fiscalyear_id
+        fiscalyear = self.pool['account.fiscalyear'].browse(
+            self.cursor, self.uid, fiscalyear_id[0])
         special_periods = [
             period for period in fiscalyear.period_ids if period.special]
         # so, we have no opening period on the first year, nothing to return


### PR DESCRIPTION
search of first opening period cannot be based on simply ordering moves by dates (could be that an old document is entered later in the accounting). Find first fiscal year having moves and take its opening period (as it was documented in the method).

Method Documentation:
||  57         Returns the browse record of the period with the `special` flag, which
||  58         is the special period of the first fiscal year used in the accounting.
||  59 
||  60         i.e. it searches the first fiscal year with at least one journal entry,
||  61         and it returns the id of the first period for which `special` is True
||  62         in this fiscal year.
||  63 
||  64         It is used for example in the partners reports, where we have to
||  65         include the first, and only the first opening period.
||  66 
||  67         :return: browse record of the first special period.
