### PR TITLE
[mis_builder] add prefixes

### DIFF
--- a/account_financial_report_webkit/report/aged_partner_balance.py
+++ b/account_financial_report_webkit/report/aged_partner_balance.py
@@ -285,10 +285,14 @@ class AccountAgedTrialBalanceWebkit(PartnersOpenInvoicesWebkit):
 
         :returns: delta in days
         """
-        sale_lines = [x for x in ledger_lines if x['jtype'] in REC_PAY_TYPE
-                      and line['rec_id'] == x['rec_id']]
-        refund_lines = [x for x in ledger_lines if x['jtype'] in REFUND_TYPE
-                        and line['rec_id'] == x['rec_id']]
+        sale_lines = [
+            x for x in ledger_lines if x['jtype'] in REC_PAY_TYPE and
+            line['rec_id'] == x['rec_id']
+        ]
+        refund_lines = [
+            x for x in ledger_lines if x['jtype'] in REFUND_TYPE and
+            line['rec_id'] == x['rec_id']
+        ]
         if len(sale_lines) == 1:
             reference_line = sale_lines[0]
         elif len(refund_lines) == 1:

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -312,7 +312,10 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
 
                 for partner_id, partner_values in \
                         values['partners_amounts'].copy().iteritems():
-                    base_partner_balance = partners_amounts_accounts[account.id][partner_id]['balance']\
+                    partners_amounts_account =\
+                        partners_amounts_accounts[account.id]
+                    base_partner_balance =\
+                        partners_amounts_account[partner_id]['balance']\
                         if partners_amounts_accounts.get(account.id)\
                         and partners_amounts_accounts.get(account.id)\
                         .get(partner_id) else 0.0

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -130,9 +130,10 @@ class CommonReportHeaderWebkit(common_report_header):
         def recursive_sort_by_code(accounts, parent):
             sorted_accounts = []
             # add all accounts with same parent
-            level_accounts = [account for account in accounts
-                              if account['parent_id']
-                              and account['parent_id'][0] == parent['id']]
+            level_accounts = [
+                account for account in accounts
+                if account['parent_id'] and
+                account['parent_id'][0] == parent['id']]
             # add consolidation children of parent, as they are logically on
             # the same level
             if parent.get('child_consol_ids'):

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -164,8 +164,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             non_null_init_balances = dict([
                 (ib, amounts) for ib, amounts
                 in init_balance[account.id].iteritems()
-                if amounts['init_balance']
-                or amounts['init_balance_currency']])
+                if amounts['init_balance'] or
+                amounts['init_balance_currency']])
             init_bal_lines_pids = non_null_init_balances.keys()
 
             partners_order[account.id] = self._order_partners(

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -165,8 +165,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
                 non_null_init_balances = dict(
                     [(ib, amounts) for ib, amounts
                      in init_balance[account.id].iteritems()
-                     if amounts['init_balance']
-                     or amounts['init_balance_currency']])
+                     if amounts['init_balance'] or
+                     amounts['init_balance_currency']])
                 init_bal_lines_pids = non_null_init_balances.keys()
             else:
                 init_balance[account.id] = {}

--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -27,6 +27,9 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 ##############################################################################
+from mako.template import Template
+from mako.lookup import TemplateLookup
+
 import os
 import subprocess
 import tempfile
@@ -75,8 +78,6 @@ _logger = logging.getLogger('financial.reports.webkit')
 
 # redefine mako_template as this is overriden by jinja since saas-1
 # from openerp.addons.report_webkit.webkit_report import mako_template
-from mako.template import Template
-from mako.lookup import TemplateLookup
 
 
 def mako_template(text):

--- a/account_financial_report_webkit_xls/report/general_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/general_ledger_xls.py
@@ -200,8 +200,7 @@ class general_ledger_xls(report_xls):
             display_initial_balance = _p['init_balance'][account.id] and \
                 (_p['init_balance'][account.id].get(
                     'debit', 0.0) != 0.0 or
-                    _p['init_balance'][account.id].get('credit', 0.0)
-                    != 0.0)
+                    _p['init_balance'][account.id].get('credit', 0.0) != 0.0)
             display_ledger_lines = _p['ledger_lines'][account.id]
 
             if _p.display_account_raw(data) == 'all' or \

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -260,8 +260,9 @@ class open_invoices_xls(report_xls):
                                partner_name):
         if regroupmode == "regroup":
             c_specs = [('acc_title', self.nbr_columns, 0, 'text',
-                        ' - '.join([account.code, account.name, partner_name
-                                    or _('No partner')])), ]
+                        ' - '.join([account.code,
+                                    account.name,
+                                    partner_name or _('No partner')])), ]
         else:
             c_specs = [
                 ('acc_title', self.nbr_columns, 0, 'text', ' - '.
@@ -332,10 +333,10 @@ class open_invoices_xls(report_xls):
         else:
             c_specs += [('datedue', 1, 0, 'text', None)]
         c_specs += [
-            ('debit', 1, 0, 'number', line.get('debit')
-             or 0.0, None, style_line_decimal),
-            ('credit', 1, 0, 'number', line.get('credit')
-             or 0.0, None, style_line_decimal),
+            ('debit', 1, 0, 'number', line.get('debit') or 0.0, None,
+             style_line_decimal),
+            ('credit', 1, 0, 'number', line.get('credit') or 0.0, None,
+             style_line_decimal),
         ]
 
         # determine the formula of the cumulated balance
@@ -357,8 +358,9 @@ class open_invoices_xls(report_xls):
         if _p.amount_currency(data):
             if account.currency_id:
                 c_specs += [
-                    ('curramount', 1, 0, 'number', line.get('amount_currency')
-                     or 0.0, None, style_line_decimal),
+                    ('curramount', 1, 0, 'number',
+                     line.get('amount_currency') or 0.0, None,
+                     style_line_decimal),
                     ('currcode', 1, 0, 'text', line[
                      'currency_code'], None, style_line_right),
                 ]
@@ -428,18 +430,18 @@ class open_invoices_xls(report_xls):
         else:
             c_specs += [('datedue', 1, 0, 'text', None)]
         c_specs += [
-            ('debit', 1, 0, 'number', line.get('debit')
-             or 0.0, None, style_line_decimal),
-            ('credit', 1, 0, 'number', line.get('credit')
-             or 0.0, None, style_line_decimal),
+            ('debit', 1, 0, 'number', line.get('debit') or 0.0, None,
+             style_line_decimal),
+            ('credit', 1, 0, 'number', line.get('credit') or 0.0, None,
+             style_line_decimal),
             ('cumul', 1, 0, 'number', None, cumul_balance, style_line_decimal),
         ]
         if account.currency_id:
             c_specs += [
-                ('curramount', 1, 0, 'number', line.get('amount_currency')
-                 or 0.0, None, style_line_decimal),
-                ('currcode', 1, 0, 'text', line.get('currency_code')
-                 or '', None, style_line_right),
+                ('curramount', 1, 0, 'number',
+                 line.get('amount_currency') or 0.0, None, style_line_decimal),
+                ('currcode', 1, 0, 'text',
+                 line.get('currency_code') or '', None, style_line_right),
             ]
         else:
             c_specs += [

--- a/account_financial_report_webkit_xls/report/partners_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/partners_balance_xls.py
@@ -137,9 +137,11 @@ class partners_balance_xls(report_xls):
                 ('c', 2, 0, 'text', _('Comparison') + str(index + 1) +
                  ' (C' + str(index + 1) + ')')]
             if params['comparison_filter'] == 'filter_date':
-                c_specs += [('f', 2, 0, 'text', _('Dates Filter') + ': ' +
-                             _p.formatLang(params['start'], date=True) + ' - '
-                             + _p.formatLang(params['stop'], date=True))]
+                c_specs += [
+                    ('f', 2, 0, 'text',
+                     _('Dates Filter') + ': ' +
+                     _p.formatLang(params['start'], date=True) + ' - ' +
+                     _p.formatLang(params['stop'], date=True))]
             elif params['comparison_filter'] == 'filter_period':
                 c_specs += [('f', 2, 0, 'text', _('Periods Filter') +
                              ': ' + params['start'].name + ' - ' +

--- a/account_financial_report_webkit_xls/report/trial_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/trial_balance_xls.py
@@ -308,8 +308,9 @@ class trial_balance_xls(report_xls):
                             ('diff', 1, 0, 'number', comp_account[
                              'diff'], None, cell_style_decimal),
                             ('diff_percent', 1, 0, 'number', comp_account[
-                             'percent_diff'] and comp_account['percent_diff']
-                             or 0, None, cell_style_pct),
+                             'percent_diff'] and
+                             comp_account['percent_diff'] or 0, None,
+                             cell_style_pct),
                         ]
 
             c_specs += [('type', 1, 0, 'text',

--- a/account_journal_report_xls/report/nov_account_journal.py
+++ b/account_journal_report_xls/report/nov_account_journal.py
@@ -166,8 +166,8 @@ class nov_journal_print(report_sxw.rml_parse):
                         "rc.symbol AS currency_symbol, "
                         "coalesce(ai.internal_number,'-') AS inv_number, "
                         "coalesce(abs.name,'-') AS st_number, "
-                        "coalesce(av.number,'-') AS voucher_number "
-                        + select_extra +
+                        "coalesce(av.number,'-') AS voucher_number " +
+                        select_extra +
                         "FROM account_move_line l "
                         "INNER JOIN account_move am ON l.move_id = am.id "
                         "INNER JOIN account_account aa "
@@ -192,11 +192,9 @@ class nov_journal_print(report_sxw.rml_parse):
                         "LEFT OUTER JOIN account_analytic_account ana "
                         "ON l.analytic_account_id = ana.id  "
                         "LEFT OUTER JOIN res_currency rc "
-                        "ON l.currency_id = rc.id  "
-                        + join_extra +
+                        "ON l.currency_id = rc.id  " + join_extra +
                         "WHERE l.period_id IN %s AND l.journal_id = %s "
-                        "AND am.state IN %s "
-                        + where_extra +
+                        "AND am.state IN %s " + where_extra +
                         "ORDER BY " + self.sort_selection +
                         ", move_date, move_id, acc_code",
                         (tuple(period_ids), journal_id,
@@ -206,12 +204,12 @@ class nov_journal_print(report_sxw.rml_parse):
         # add reference of corresponding origin document
         if journal.type in ('sale', 'sale_refund', 'purchase',
                             'purchase_refund'):
-            [x.update({'docname': (_('Invoice') + ': ' + x['inv_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+            [x.update({'docname': (_('Invoice') + ': ' + x['inv_number']) or
+                       (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         elif journal.type in ('bank', 'cash'):
-            [x.update({'docname': (_('Statement') + ': ' + x['st_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+            [x.update({'docname': (_('Statement') + ': ' + x['st_number']) or
+                       (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         else:
             code_string = j_obj._report_xls_document_extra(

--- a/mis_builder/__init__.py
+++ b/mis_builder/__init__.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import models
 from . import wizard

--- a/mis_builder/__openerp__.py
+++ b/mis_builder/__openerp__.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
     'name': 'MIS Builder',

--- a/mis_builder/models/__init__.py
+++ b/mis_builder/models/__init__.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import mis_builder
 from . import aep

--- a/mis_builder/models/aep.py
+++ b/mis_builder/models/aep.py
@@ -1,32 +1,12 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import re
 from collections import defaultdict
 
-from openerp.exceptions import Warning
-from openerp.osv import expression
+from openerp.exceptions import Warning as UserError
+from openerp.models import expression
 from openerp.tools.safe_eval import safe_eval
 from openerp.tools.translate import _
 
@@ -321,7 +301,7 @@ class AccountingExpressionProcessor(object):
             if mode == MODE_VARIATION:
                 domain = [('date', '>=', date_from), ('date', '<=', date_to)]
             else:
-                raise Warning(_("Modes i and e are only applicable for "
+                raise UserError(_("Modes i and e are only applicable for "
                                 "fiscal periods"))
         if target_move == 'posted':
             domain.append(('move_id.state', '=', 'posted'))

--- a/mis_builder/models/aggregate.py
+++ b/mis_builder/models/aggregate.py
@@ -2,6 +2,7 @@
 # © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+
 def _sum(l):
     """ Same as stdlib sum but returns None instead of 0
     in case of empty sequence.

--- a/mis_builder/models/aggregate.py
+++ b/mis_builder/models/aggregate.py
@@ -1,27 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
-
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 def _sum(l):
     """ Same as stdlib sum but returns None instead of 0

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -171,7 +171,7 @@ class MisReportKpi(models.Model):
                 return self._render_num(
                     lang_id,
                     value - base_value,
-                    self.divider, self.dp, '', self.suffix, sign='+')
+                    self.divider, self.dp, self.prefix, self.suffix, sign='+')
             elif self.compare_method == 'pct':
                 if round(base_value, self.dp) != 0:
                     return self._render_num(

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -212,15 +212,8 @@ class MisReportKpi(models.Model):
             '%%%s.%df' % (sign, dp),
             value,
             grouping=True)
-        if prefix:
-            if '-' in value:
-                value = value.replace('-', '-%s' % (prefix,))
-            else:
-                value = prefix + value
-
-        value = u'%s%s%s' % \
-            (value, divider_label, suffix or '')
-        value = value.replace('-', u'\N{NON-BREAKING HYPHEN}')
+        value = u'%s%s\N{NO-BREAK SPACE}%s%s' % \
+            (prefix, value, divider_label, suffix or '')
         return value
 
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -193,7 +193,7 @@ class MisReportKpi(models.Model):
             value,
             grouping=True)
         value = u'%s\N{NARROW NO-BREAK SPACE}%s\N{NO-BREAK SPACE}%s%s' % \
-            (suffix or '', value, divider_label, suffix or '')
+            (prefix or '', value, divider_label, suffix or '')
         return value
 
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -194,6 +194,7 @@ class MisReportKpi(models.Model):
             grouping=True)
         value = u'%s\N{NARROW NO-BREAK SPACE}%s\N{NO-BREAK SPACE}%s%s' % \
             (prefix or '', value, divider_label, suffix or '')
+        value = value.replace('-', u'\N{NON-BREAKING HYPHEN}')
         return value
 
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -212,7 +212,7 @@ class MisReportKpi(models.Model):
             '%%%s.%df' % (sign, dp),
             value,
             grouping=True)
-        value = u'%s%s\N{NO-BREAK SPACE}%s%s' % \
+        value = u'%s\N{NARROW NO-BREAK SPACE}%s\N{NO-BREAK SPACE}%s%s' % \
             (prefix, value, divider_label, suffix or '')
         return value
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import datetime
 import dateutil
@@ -213,7 +193,7 @@ class MisReportKpi(models.Model):
             value,
             grouping=True)
         value = u'%s\N{NARROW NO-BREAK SPACE}%s\N{NO-BREAK SPACE}%s%s' % \
-            (prefix, value, divider_label, suffix or '')
+            (suffix or '', value, divider_label, suffix or '')
         return value
 
 

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -171,13 +171,13 @@ class MisReportKpi(models.Model):
                 return self._render_num(
                     lang_id,
                     value - base_value,
-                    self.divider, self.dp, self.suffix, sign='+')
+                    self.divider, self.dp, '', self.suffix, sign='+')
             elif self.compare_method == 'pct':
                 if round(base_value, self.dp) != 0:
                     return self._render_num(
                         lang_id,
                         (value - base_value) / abs(base_value),
-                        0.01, self.dp, self.prefix, '%', sign='+')
+                        0.01, self.dp, '', '%', sign='+')
         return ''
 
     def _render_num(self, lang_id, value, divider,

--- a/mis_builder/report/__init__.py
+++ b/mis_builder/report/__init__.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 try:
     from . import mis_builder_xls

--- a/mis_builder/report/mis_builder_xls.py
+++ b/mis_builder/report/mis_builder_xls.py
@@ -116,5 +116,5 @@ class MisBuilderXls(report_xls):
 
 
 MisBuilderXls('report.mis.report.instance.xls',
-                'mis.report.instance',
-                parser=MisBuilderXlsParser)
+              'mis.report.instance',
+              parser=MisBuilderXlsParser)

--- a/mis_builder/report/mis_builder_xls.py
+++ b/mis_builder/report/mis_builder_xls.py
@@ -118,8 +118,10 @@ class mis_builder_xls(report_xls):
                 if value.get('dp'):
                     num_format_str += '.'
                     num_format_str += '0' * int(value['dp'])
+                if value.get('prefix'):
+                    num_format_str = '"%s"' % value['prefix'] + num_format_str
                 if value.get('suffix'):
-                    num_format_str = num_format_str + ' "%s"' % value['suffix']
+                    num_format_str += ' "%s"' % value['suffix']
                 kpi_cell_style = xlwt.easyxf(
                     _xs['borders_all'] + _xs['right'],
                     num_format_str=num_format_str)

--- a/mis_builder/report/mis_builder_xls.py
+++ b/mis_builder/report/mis_builder_xls.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import xlwt
 from openerp.report import report_sxw
@@ -29,19 +9,19 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-class mis_builder_xls_parser(report_sxw.rml_parse):
+class MisBuilderXlsParser(report_sxw.rml_parse):
 
     def __init__(self, cr, uid, name, context):
-        super(mis_builder_xls_parser, self).__init__(
+        super(MisBuilderXlsParser, self).__init__(
             cr, uid, name, context=context)
         self.context = context
 
 
-class mis_builder_xls(report_xls):
+class MisBuilderXls(report_xls):
 
     def __init__(self, name, table, rml=False, parser=False, header=True,
                  store=False):
-        super(mis_builder_xls, self).__init__(
+        super(MisBuilderXls, self).__init__(
             name, table, rml, parser, header, store)
 
         # Cell Styles
@@ -135,6 +115,6 @@ class mis_builder_xls(report_xls):
             row_pos += 1
 
 
-mis_builder_xls('report.mis.report.instance.xls',
+MisBuilderXls('report.mis.report.instance.xls',
                 'mis.report.instance',
-                parser=mis_builder_xls_parser)
+                parser=MisBuilderXlsParser)

--- a/mis_builder/report/report_mis_report_instance.py
+++ b/mis_builder/report/report_mis_report_instance.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import logging
 

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -42,7 +42,7 @@
                                     </a>
                                 </t>
                                 <t t-if="!value_value.drilldown">
-                                    <t t-esc="value_value.val_r" t-field-options='{"widget": "monetary"}'/>
+                                    <t t-esc="value_value.val_r"/>
                                 </t>
                             </div>
                         </td>

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -42,7 +42,7 @@
                                     </a>
                                 </t>
                                 <t t-if="!value_value.drilldown">
-                                    <t t-esc="value_value.val_r"/>
+                                    <t t-esc="value_value.val_r" t-field-options='{"widget": "monetary"}'/>
                                 </t>
                             </div>
                         </td>

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -70,7 +70,7 @@ class test_mis_builder(common.TransactionCase):
                             'expr': 'len(test)',
                             'val_c': 'total_test = len(test)',
                             'val': 0,
-                            'val_r': u'0',
+                            'val_r': u'0\xa0',
                             'is_percentage': False,
                             'dp': 0,
                             'drilldown': False}]

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -7,10 +7,10 @@ import openerp.tests.common as common
 from ..models import mis_builder
 
 
-class test_mis_builder(common.TransactionCase):
+class TestMisBuilder(common.TransactionCase):
 
     def setUp(self):
-        super(test_mis_builder, self).setUp()
+        super(TestMisBuilder, self).setUp()
 
     def test_datetime_conversion(self):
         date_to_convert = '2014-07-05'

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -65,6 +65,7 @@ class test_mis_builder(common.TransactionCase):
                                                   'mis_report_instance_'
                                                   'period_test'),
                             'style': None,
+                            'prefix': False,
                             'suffix': False,
                             'expr': 'len(test)',
                             'val_c': 'total_test = len(test)',

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -50,7 +50,7 @@ class TestMisBuilder(common.TransactionCase):
                             'expr': 'len(test)',
                             'val_c': 'total_test = len(test)',
                             'val': 0,
-                            'val_r': u'0\xa0',
+                            'val_r': u'\u202f0\xa0',
                             'is_percentage': False,
                             'dp': 0,
                             'drilldown': False}]

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -1,26 +1,6 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 import openerp.tests.common as common
 

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -70,7 +70,7 @@ class test_mis_builder(common.TransactionCase):
                             'expr': 'len(test)',
                             'val_c': 'total_test = len(test)',
                             'val': 0,
-                            'val_r': u'0\xa0',
+                            'val_r': u'0',
                             'is_percentage': False,
                             'dp': 0,
                             'drilldown': False}]

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -49,6 +49,7 @@
                                 <field name="type"/>
                                 <field name="dp" attrs="{'invisible': [('type', '=', 'str')]}"/>
                                 <field name="divider" attrs="{'invisible': [('type', '=', 'str')]}"/>
+                                <field name="prefix"/>
                                 <field name="suffix"/>
                                 <field name="compare_method" attrs="{'invisible': [('type', '=', 'str')]}"/>
                                 <field name="default_css_style"/>

--- a/mis_builder/wizard/__init__.py
+++ b/mis_builder/wizard/__init__.py
@@ -1,25 +1,5 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from . import mis_builder_dashboard

--- a/mis_builder/wizard/mis_builder_dashboard.py
+++ b/mis_builder/wizard/mis_builder_dashboard.py
@@ -2,67 +2,65 @@
 # © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp.osv import orm, fields
+from openerp import api, fields, models, _
 from lxml import etree
 
 
-class AddMisReportInstanceDashboard(orm.TransientModel):
+class AddMisReportInstanceDashboard(models.TransientModel):
     _name = "add.mis.report.instance.dashboard.wizard"
 
-    _columns = {'name': fields.char('Name', size=32, required=True),
-                'dashboard_id': fields.many2one(
-                    'ir.actions.act_window',
-                    string="Dashboard", required=True,
-                    domain="[('res_model', '=', 'board.board')]"),
-                }
+    name = fields.Char('Name', size=32, required=True)
 
-    def default_get(self, cr, uid, fields, context=None):
-        if context is None:
-            context = {}
+    dashboard_id = fields.Many2one('ir.actions.act_window',
+                                   string="Dashboard", required=True,
+                                   domain="[('res_model', '=', "
+                                          "'board.board')]")
+
+    @api.model
+    def default_get(self, fields):
         res = {}
-        if context.get('active_id'):
+        if self.env.context.get('active_id', False):
             res = super(AddMisReportInstanceDashboard, self).default_get(
-                cr, uid, fields, context=context)
+                fields)
             # get report instance name
-            res['name'] = self.pool['mis.report.instance'].read(
-                cr, uid, context['active_id'], ['name'])['name']
+            res['name'] = self.env['mis.report.instance'].browse(
+                self.env.context['active_id']).name
         return res
 
-    def action_add_to_dashboard(self, cr, uid, ids, context=None):
-        if context is None:
-            context = {}
-        assert 'active_id' in context, "active_id missing in context"
-        wizard_data = self.browse(cr, uid, ids, context=context)[0]
+    @api.multi
+    def action_add_to_dashboard(self):
+        assert self.env.context.get('active_id', False), \
+            "active_id missing in context"
         # create the act_window corresponding to this report
-        view_id = self.pool['ir.model.data'].get_object_reference(
-            cr, uid, 'mis_builder', 'mis_report_instance_result_view_form')[1]
-        report_result = self.pool['ir.actions.act_window'].create(
-            cr, uid,
+        self.env.ref('mis_builder.mis_report_instance_result_view_form')
+        view = self.env.ref(
+            'mis_builder.mis_report_instance_result_view_form')
+        report_result = self.env['ir.actions.act_window'].create(
             {'name': 'mis.report.instance.result.view.action.%d'
-             % context['active_id'],
+             % self.env.context['active_id'],
              'res_model': 'mis.report.instance',
-             'res_id': context['active_id'],
+             'res_id': self.env.context['active_id'],
              'target': 'current',
              'view_mode': 'form',
-             'view_id': view_id})
+             'view_id': view.id})
         # add this result in the selected dashboard
-        last_customization = self.pool['ir.ui.view.custom'].search(
-            cr, uid,
-            [('user_id', '=', uid),
-             ('ref_id', '=', wizard_data.dashboard_id.view_id.id)], limit=1)
-        arch = wizard_data.dashboard_id.view_id.arch
+        last_customization = self.env['ir.ui.view.custom'].search(
+            [('user_id', '=', self.env.uid),
+             ('ref_id', '=', self.dashboard_id.view_id.id)], limit=1)
+        arch = self.dashboard_id.view_id.arch
         if last_customization:
-            arch = self.pool['ir.ui.view.custom'].read(
-                cr, uid, last_customization[0], ['arch'])['arch']
+            arch = self.env['ir.ui.view.custom'].browse(
+                last_customization[0].id).arch
         new_arch = etree.fromstring(arch)
         column = new_arch.xpath("//column")[0]
-        column.append(etree.Element('action', {'context': str(context),
-                                               'name': str(report_result),
-                                               'string': wizard_data.name,
-                                               'view_mode': 'form'}))
-        self.pool['ir.ui.view.custom'].create(
-            cr, uid, {'user_id': uid,
-                      'ref_id': wizard_data.dashboard_id.view_id.id,
-                      'arch': etree.tostring(new_arch, pretty_print=True)})
+        column.append(etree.Element('action', {'context': str(
+            self.env.context),
+            'name': str(report_result.id),
+            'string': self.name,
+            'view_mode': 'form'}))
+        self.env['ir.ui.view.custom'].create(
+            {'user_id': self.env.uid,
+             'ref_id': self.dashboard_id.view_id.id,
+             'arch': etree.tostring(new_arch, pretty_print=True)})
 
         return {'type': 'ir.actions.act_window_close', }

--- a/mis_builder/wizard/mis_builder_dashboard.py
+++ b/mis_builder/wizard/mis_builder_dashboard.py
@@ -2,7 +2,7 @@
 # © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from openerp import api, fields, models, _
+from openerp import api, fields, models
 from lxml import etree
 
 

--- a/mis_builder/wizard/mis_builder_dashboard.py
+++ b/mis_builder/wizard/mis_builder_dashboard.py
@@ -1,32 +1,12 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    mis_builder module for Odoo, Management Information System Builder
-#    Copyright (C) 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
-#
-#    This file is a part of mis_builder
-#
-#    mis_builder is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License v3 or later
-#    as published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    mis_builder is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License v3 or later for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    v3 or later along with this program.
-#    If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# © 2014-2015 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openerp.osv import orm, fields
 from lxml import etree
 
 
-class add_mis_report_instance_dashboard(orm.TransientModel):
+class AddMisReportInstanceDashboard(orm.TransientModel):
     _name = "add.mis.report.instance.dashboard.wizard"
 
     _columns = {'name': fields.char('Name', size=32, required=True),
@@ -39,8 +19,9 @@ class add_mis_report_instance_dashboard(orm.TransientModel):
     def default_get(self, cr, uid, fields, context=None):
         if context is None:
             context = {}
+        res = {}
         if context.get('active_id'):
-            res = super(add_mis_report_instance_dashboard, self).default_get(
+            res = super(AddMisReportInstanceDashboard, self).default_get(
                 cr, uid, fields, context=context)
             # get report instance name
             res['name'] = self.pool['mis.report.instance'].read(


### PR DESCRIPTION
This PR adds a new field to the MIS Report template, to the KPI section, called 'prefix'.

The typical use case will be for companies that operate in currencies such as $, where the sign is indicated as a prefix of the value. Note that with negative numbers the prefix goes as -$100, not as $-100.

image
![image](https://cloud.githubusercontent.com/assets/7683926/11716023/1f881ad4-9f47-11e5-885d-d04ec7e30102.png)

![image](https://cloud.githubusercontent.com/assets/7683926/11716028/26e3fece-9f47-11e5-8bfc-c763d38ae132.png)

![image](https://cloud.githubusercontent.com/assets/7683926/11716031/2c42ee84-9f47-11e5-872c-8871b65e2db8.png)
