### PR TITLE
[7.0] mis_builder : in compute do not set val in localdict if val is none

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -651,6 +651,7 @@ class MisReportInstancePeriod(orm.Model):
                     kpi_val_comment = kpi.name + " = " + kpi.expression
                     kpi_eval_expression = aep.replace_expr(kpi.expression)
                     kpi_val = safe_eval(kpi_eval_expression, localdict)
+                    localdict[kpi.name] = kpi_val
                 except ZeroDivisionError:
                     kpi_val = None
                     kpi_val_rendered = '#DIV/0'
@@ -668,7 +669,6 @@ class MisReportInstancePeriod(orm.Model):
                     kpi_val_rendered = kpi_obj.render(
                         cr, uid, lang_id, kpi, kpi_val, context=context)
 
-                localdict[kpi.name] = kpi_val
                 try:
                     kpi_style = None
                     if kpi.css_style:


### PR DESCRIPTION
Use case is the following :

line total is a + b + c
line a is 5
line b is d + e
line c is 3
line d is 7
line e is 4

When the computation is done, total and b are set in localdict with value None.
(the first error is a NameError, it is normal)
When we try to recompute total (cause of NameError), the error is the following : bad operand type for unary +: 'NoneType' so in this case, we don't add it to recompute_queue.
And total is recomputed before b.

To resolve this case, I propose to not append value None in the localdict.
