### PR TITLE
[FIX] account_financial_report_webkit: Don't overpass top level account

### DIFF
--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -288,8 +288,6 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         balance_accounts = dict.fromkeys(account_ids, False)
 
         for account in objects:
-            if not account.parent_id:  # hide top level account
-                continue
             if account.type == 'consolidation':
                 to_display_accounts.update(
                     dict([(a.id, False) for a in account.child_consol_ids]))


### PR DESCRIPTION
With current code, the top level accounts (the 0 one) is ignored in
the population of debit, credit and balance data, provoking that the
report shows a line with all 0's, which leads to confusion to users.

I see no reason for zeroing this data, as it can be significant for
certain account charts, and can be easily ignored for those who not.
