### PR TITLE
8.0 fix overlapping text

### DIFF
--- a/account_financial_report_webkit/data/financial_webkit_header.xml
+++ b/account_financial_report_webkit/data/financial_webkit_header.xml
@@ -73,6 +73,7 @@ body, table, td, span, div {
 }
 .act_as_row  {
     display: table-row;
+    page-break-inside: avoid;
 }
 .act_as_cell {
     display: table-cell;

--- a/account_financial_report_webkit/report/aged_partner_balance.py
+++ b/account_financial_report_webkit/report/aged_partner_balance.py
@@ -285,10 +285,14 @@ class AccountAgedTrialBalanceWebkit(PartnersOpenInvoicesWebkit):
 
         :returns: delta in days
         """
-        sale_lines = [x for x in ledger_lines if x['jtype'] in REC_PAY_TYPE
-                      and line['rec_id'] == x['rec_id']]
-        refund_lines = [x for x in ledger_lines if x['jtype'] in REFUND_TYPE
-                        and line['rec_id'] == x['rec_id']]
+        sale_lines = [
+            x for x in ledger_lines if x['jtype'] in REC_PAY_TYPE and
+            line['rec_id'] == x['rec_id']
+        ]
+        refund_lines = [
+            x for x in ledger_lines if x['jtype'] in REFUND_TYPE and
+            line['rec_id'] == x['rec_id']
+        ]
         if len(sale_lines) == 1:
             reference_line = sale_lines[0]
         elif len(refund_lines) == 1:

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -312,7 +312,10 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
 
                 for partner_id, partner_values in \
                         values['partners_amounts'].copy().iteritems():
-                    base_partner_balance = partners_amounts_accounts[account.id][partner_id]['balance']\
+                    partners_amounts_account =\
+                        partners_amounts_accounts[account.id]
+                    base_partner_balance =\
+                        partners_amounts_account[partner_id]['balance']\
                         if partners_amounts_accounts.get(account.id)\
                         and partners_amounts_accounts.get(account.id)\
                         .get(partner_id) else 0.0

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -130,9 +130,10 @@ class CommonReportHeaderWebkit(common_report_header):
         def recursive_sort_by_code(accounts, parent):
             sorted_accounts = []
             # add all accounts with same parent
-            level_accounts = [account for account in accounts
-                              if account['parent_id']
-                              and account['parent_id'][0] == parent['id']]
+            level_accounts = [
+                account for account in accounts
+                if account['parent_id'] and
+                account['parent_id'][0] == parent['id']]
             # add consolidation children of parent, as they are logically on
             # the same level
             if parent.get('child_consol_ids'):

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -164,8 +164,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             non_null_init_balances = dict([
                 (ib, amounts) for ib, amounts
                 in init_balance[account.id].iteritems()
-                if amounts['init_balance']
-                or amounts['init_balance_currency']])
+                if amounts['init_balance'] or
+                amounts['init_balance_currency']])
             init_bal_lines_pids = non_null_init_balances.keys()
 
             partners_order[account.id] = self._order_partners(

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -165,8 +165,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
                 non_null_init_balances = dict(
                     [(ib, amounts) for ib, amounts
                      in init_balance[account.id].iteritems()
-                     if amounts['init_balance']
-                     or amounts['init_balance_currency']])
+                     if amounts['init_balance'] or
+                     amounts['init_balance_currency']])
                 init_bal_lines_pids = non_null_init_balances.keys()
             else:
                 init_balance[account.id] = {}

--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -27,6 +27,9 @@
 # Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #
 ##############################################################################
+from mako.template import Template
+from mako.lookup import TemplateLookup
+
 import os
 import subprocess
 import tempfile
@@ -75,8 +78,6 @@ _logger = logging.getLogger('financial.reports.webkit')
 
 # redefine mako_template as this is overriden by jinja since saas-1
 # from openerp.addons.report_webkit.webkit_report import mako_template
-from mako.template import Template
-from mako.lookup import TemplateLookup
 
 
 def mako_template(text):

--- a/account_financial_report_webkit_xls/report/general_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/general_ledger_xls.py
@@ -200,8 +200,7 @@ class general_ledger_xls(report_xls):
             display_initial_balance = _p['init_balance'][account.id] and \
                 (_p['init_balance'][account.id].get(
                     'debit', 0.0) != 0.0 or
-                    _p['init_balance'][account.id].get('credit', 0.0)
-                    != 0.0)
+                    _p['init_balance'][account.id].get('credit', 0.0) != 0.0)
             display_ledger_lines = _p['ledger_lines'][account.id]
 
             if _p.display_account_raw(data) == 'all' or \

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -260,8 +260,9 @@ class open_invoices_xls(report_xls):
                                partner_name):
         if regroupmode == "regroup":
             c_specs = [('acc_title', self.nbr_columns, 0, 'text',
-                        ' - '.join([account.code, account.name, partner_name
-                                    or _('No partner')])), ]
+                        ' - '.join([account.code,
+                                    account.name,
+                                    partner_name or _('No partner')])), ]
         else:
             c_specs = [
                 ('acc_title', self.nbr_columns, 0, 'text', ' - '.
@@ -332,10 +333,10 @@ class open_invoices_xls(report_xls):
         else:
             c_specs += [('datedue', 1, 0, 'text', None)]
         c_specs += [
-            ('debit', 1, 0, 'number', line.get('debit')
-             or 0.0, None, style_line_decimal),
-            ('credit', 1, 0, 'number', line.get('credit')
-             or 0.0, None, style_line_decimal),
+            ('debit', 1, 0, 'number', line.get('debit') or 0.0, None,
+             style_line_decimal),
+            ('credit', 1, 0, 'number', line.get('credit') or 0.0, None,
+             style_line_decimal),
         ]
 
         # determine the formula of the cumulated balance
@@ -357,8 +358,9 @@ class open_invoices_xls(report_xls):
         if _p.amount_currency(data):
             if account.currency_id:
                 c_specs += [
-                    ('curramount', 1, 0, 'number', line.get('amount_currency')
-                     or 0.0, None, style_line_decimal),
+                    ('curramount', 1, 0, 'number',
+                     line.get('amount_currency') or 0.0, None,
+                     style_line_decimal),
                     ('currcode', 1, 0, 'text', line[
                      'currency_code'], None, style_line_right),
                 ]
@@ -428,18 +430,18 @@ class open_invoices_xls(report_xls):
         else:
             c_specs += [('datedue', 1, 0, 'text', None)]
         c_specs += [
-            ('debit', 1, 0, 'number', line.get('debit')
-             or 0.0, None, style_line_decimal),
-            ('credit', 1, 0, 'number', line.get('credit')
-             or 0.0, None, style_line_decimal),
+            ('debit', 1, 0, 'number', line.get('debit') or 0.0, None,
+             style_line_decimal),
+            ('credit', 1, 0, 'number', line.get('credit') or 0.0, None,
+             style_line_decimal),
             ('cumul', 1, 0, 'number', None, cumul_balance, style_line_decimal),
         ]
         if account.currency_id:
             c_specs += [
-                ('curramount', 1, 0, 'number', line.get('amount_currency')
-                 or 0.0, None, style_line_decimal),
-                ('currcode', 1, 0, 'text', line.get('currency_code')
-                 or '', None, style_line_right),
+                ('curramount', 1, 0, 'number',
+                 line.get('amount_currency') or 0.0, None, style_line_decimal),
+                ('currcode', 1, 0, 'text',
+                 line.get('currency_code') or '', None, style_line_right),
             ]
         else:
             c_specs += [

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -355,7 +355,7 @@ class open_invoices_xls(report_xls):
                      cumul_balance, style_line_decimal)]
 
         if _p.amount_currency(data):
-            if line.get('amount_currency'):
+            if line.get('currency_code'):
                 c_specs += [
                     ('curramount', 1, 0, 'number', line.get('amount_currency')
                      or 0.0, None, style_line_decimal),

--- a/account_financial_report_webkit_xls/report/open_invoices_xls.py
+++ b/account_financial_report_webkit_xls/report/open_invoices_xls.py
@@ -355,7 +355,7 @@ class open_invoices_xls(report_xls):
                      cumul_balance, style_line_decimal)]
 
         if _p.amount_currency(data):
-            if account.currency_id:
+            if line.get('amount_currency'):
                 c_specs += [
                     ('curramount', 1, 0, 'number', line.get('amount_currency')
                      or 0.0, None, style_line_decimal),

--- a/account_financial_report_webkit_xls/report/partners_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/partners_balance_xls.py
@@ -137,9 +137,11 @@ class partners_balance_xls(report_xls):
                 ('c', 2, 0, 'text', _('Comparison') + str(index + 1) +
                  ' (C' + str(index + 1) + ')')]
             if params['comparison_filter'] == 'filter_date':
-                c_specs += [('f', 2, 0, 'text', _('Dates Filter') + ': ' +
-                             _p.formatLang(params['start'], date=True) + ' - '
-                             + _p.formatLang(params['stop'], date=True))]
+                c_specs += [
+                    ('f', 2, 0, 'text',
+                     _('Dates Filter') + ': ' +
+                     _p.formatLang(params['start'], date=True) + ' - ' +
+                     _p.formatLang(params['stop'], date=True))]
             elif params['comparison_filter'] == 'filter_period':
                 c_specs += [('f', 2, 0, 'text', _('Periods Filter') +
                              ': ' + params['start'].name + ' - ' +

--- a/account_financial_report_webkit_xls/report/trial_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/trial_balance_xls.py
@@ -308,8 +308,9 @@ class trial_balance_xls(report_xls):
                             ('diff', 1, 0, 'number', comp_account[
                              'diff'], None, cell_style_decimal),
                             ('diff_percent', 1, 0, 'number', comp_account[
-                             'percent_diff'] and comp_account['percent_diff']
-                             or 0, None, cell_style_pct),
+                             'percent_diff'] and
+                             comp_account['percent_diff'] or 0, None,
+                             cell_style_pct),
                         ]
 
             c_specs += [('type', 1, 0, 'text',

--- a/account_journal_report_xls/report/nov_account_journal.py
+++ b/account_journal_report_xls/report/nov_account_journal.py
@@ -166,8 +166,8 @@ class nov_journal_print(report_sxw.rml_parse):
                         "rc.symbol AS currency_symbol, "
                         "coalesce(ai.internal_number,'-') AS inv_number, "
                         "coalesce(abs.name,'-') AS st_number, "
-                        "coalesce(av.number,'-') AS voucher_number "
-                        + select_extra +
+                        "coalesce(av.number,'-') AS voucher_number " +
+                        select_extra +
                         "FROM account_move_line l "
                         "INNER JOIN account_move am ON l.move_id = am.id "
                         "INNER JOIN account_account aa "
@@ -192,11 +192,9 @@ class nov_journal_print(report_sxw.rml_parse):
                         "LEFT OUTER JOIN account_analytic_account ana "
                         "ON l.analytic_account_id = ana.id  "
                         "LEFT OUTER JOIN res_currency rc "
-                        "ON l.currency_id = rc.id  "
-                        + join_extra +
+                        "ON l.currency_id = rc.id  " + join_extra +
                         "WHERE l.period_id IN %s AND l.journal_id = %s "
-                        "AND am.state IN %s "
-                        + where_extra +
+                        "AND am.state IN %s " + where_extra +
                         "ORDER BY " + self.sort_selection +
                         ", move_date, move_id, acc_code",
                         (tuple(period_ids), journal_id,
@@ -206,12 +204,12 @@ class nov_journal_print(report_sxw.rml_parse):
         # add reference of corresponding origin document
         if journal.type in ('sale', 'sale_refund', 'purchase',
                             'purchase_refund'):
-            [x.update({'docname': (_('Invoice') + ': ' + x['inv_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+            [x.update({'docname': (_('Invoice') + ': ' + x['inv_number']) or
+                       (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         elif journal.type in ('bank', 'cash'):
-            [x.update({'docname': (_('Statement') + ': ' + x['st_number'])
-                      or (_('Voucher') + ': ' + x['voucher_number']) or '-'})
+            [x.update({'docname': (_('Statement') + ': ' + x['st_number']) or
+                       (_('Voucher') + ': ' + x['voucher_number']) or '-'})
              for x in lines]
         else:
             code_string = j_obj._report_xls_document_extra(

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -42,7 +42,7 @@
                                     </a>
                                 </t>
                                 <t t-if="!value_value.drilldown">
-                                    <t t-esc="value_value.val_r" t-field-options='{"widget": "monetary"}'/>
+                                    <t t-esc="value_value.val_r"/>
                                 </t>
                             </div>
                         </td>

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -42,7 +42,7 @@
                                     </a>
                                 </t>
                                 <t t-if="!value_value.drilldown">
-                                    <t t-esc="value_value.val_r"/>
+                                    <t t-esc="value_value.val_r" t-field-options='{"widget": "monetary"}'/>
                                 </t>
                             </div>
                         </td>


### PR DESCRIPTION
[FIX] account_financial_report_webkit: in landscape layout, row are split accross pages with half the line displayed on page1 and second half displayed on page2 and overlapping on the row header.
This make data unreadable.
Adding page-break-inside: avoid; on tr solves the issue.
It happens with wkhtmltopdf 0.12.3 (with patched qt)
See https://github.com/wkhtmltopdf/wkhtmltopdf/issues/1524
