### PR TITLE
[FIX] 8.0 fix overlapping text

### DIFF
--- a/account_financial_report_webkit/data/financial_webkit_header.xml
+++ b/account_financial_report_webkit/data/financial_webkit_header.xml
@@ -73,6 +73,7 @@ body, table, td, span, div {
 }
 .act_as_row  {
     display: table-row;
+    page-break-inside: avoid;
 }
 .act_as_cell {
     display: table-cell;


### PR DESCRIPTION
[FIX] account_financial_report_webkit: in landscape layout, row are split accross pages with half the line displayed on page1 and second half displayed on page2 and overlapping on the row header.
This make data unreadable.
Adding page-break-inside: avoid; on tr solves the issue.
It happens with wkhtmltopdf 0.12.3 (with patched qt)
See wkhtmltopdf/wkhtmltopdf#1524
