### PR TITLE
[IMP] account_financial_report_webkit: Allow to select account level on trial balance

### DIFF
--- a/account_financial_report_webkit/i18n/es.po
+++ b/account_financial_report_webkit/i18n/es.po
@@ -1,49 +1,64 @@
-# Spanish translation for account-financial-report
-# Copyright (c) 2014 Rosetta Contributors and Canonical Ltd 2014
-# This file is distributed under the same license as the account-financial-report package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2014.
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* account_financial_report_webkit
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: account-financial-report\n"
-"Report-Msgid-Bugs-To: FULL NAME <EMAIL@ADDRESS>\n"
-"POT-Creation-Date: 2012-05-07 07:02+0000\n"
-"PO-Revision-Date: 2014-02-21 01:18+0000\n"
-"Last-Translator: Pedro Manuel Baeza <pedro.baeza@gmail.com>\n"
-"Language-Team: Spanish <es@li.org>\n"
+"Project-Id-Version: Odoo Server 8.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-03-04 17:13+0000\n"
+"PO-Revision-Date: 2016-03-04 17:13+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Launchpad-Export-Date: 2014-06-19 06:33+0000\n"
-"X-Generator: Launchpad (build 17048)\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
 
 #. module: account_financial_report_webkit
-#: field:account.common.balance.report,account_ids:0
-#: field:general.ledger.webkit,account_ids:0
-#: field:partner.balance.webkit,account_ids:0
-#: field:trial.balance.webkit,account_ids:0
-msgid "Filter on accounts"
-msgstr "Filtro en cuentas"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:175
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:135
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:150
+msgid "% Difference"
+msgstr "% diferencia"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:424
-#, python-format
-msgid "Please set a valid time filter"
-msgstr "Establezca por favor un filtro de tiempo válido"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:104
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:83
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:105
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:120
+#: model:ir.model,name:account_financial_report_webkit.model_account_account
+msgid "Account"
+msgstr "Cuenta"
 
 #. module: account_financial_report_webkit
-#: view:general.ledger.webkit:0
-#: view:open.invoices.webkit:0
-#: view:partners.ledger.webkit:0
-msgid "Layout Options"
-msgstr "Opciones de disposición"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:143
+msgid "Account / Partner Name"
+msgstr "Cuenta / Nombre de la empresa"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:203
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:228
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:258
-msgid "Cumulated Balance on Account"
-msgstr "Saldo acumulado en la cuenta"
+#: field:account.common.balance.report,account_level:0
+#: field:partner.balance.webkit,account_level:0
+#: field:trial.balance.webkit,account_level:0
+msgid "Account level"
+msgstr "Nivel de cuenta"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:41
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:43
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:53
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:38
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:62
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:59
+msgid "Accounts Filter"
+msgstr "Filtro de cuentas"
+
+#. module: account_financial_report_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "Accounts Filters"
+msgstr "Filtros de cuentas"
 
 #. module: account_financial_report_webkit
 #: field:general.ledger.webkit,centralize:0
@@ -51,442 +66,411 @@ msgid "Activate Centralization"
 msgstr "Activar centralización"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:154
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:80
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:92
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_aged_trial_blanance_webkit
+#, python-format
+msgid "Aged Partner Balance"
+msgstr "Saldos vencidos de empresa"
+
+#. module: account_financial_report_webkit
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_aged_trial_balance_menu_webkit
+msgid "Aged partner balance"
+msgstr "Saldos de empresa por antiguedad"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_account_aged_trial_balance_webkit
+msgid "Aged partner balanced"
+msgstr "Saldos de empresa por antiguedad"
+
+#. module: account_financial_report_webkit
+#: selection:account.common.balance.report,display_account:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:66
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:79
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:57
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:74
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:87
+#: selection:general.ledger.webkit,display_account:0
+#: selection:partner.balance.webkit,display_account:0
+#: selection:print.journal.webkit,display_account:0
+#: selection:trial.balance.webkit,display_account:0
+msgid "All"
+msgstr "Todas"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,target_move:0
+#: selection:account.common.balance.report,target_move:0
+#: code:addons/account_financial_report_webkit/report/common_reports.py:94
+#: selection:general.ledger.webkit,target_move:0
+#: selection:open.invoices.webkit,target_move:0
+#: selection:partner.balance.webkit,target_move:0
+#: selection:partners.ledger.webkit,target_move:0
+#: selection:print.journal.webkit,target_move:0
+#: selection:trial.balance.webkit,target_move:0
+#, python-format
+msgid "All Entries"
+msgstr "Todos los asientos"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,target_move:0
+#: selection:account.common.balance.report,target_move:0
+#: code:addons/account_financial_report_webkit/report/common_reports.py:92
+#: selection:general.ledger.webkit,target_move:0
+#: selection:open.invoices.webkit,target_move:0
+#: selection:partner.balance.webkit,target_move:0
+#: selection:partners.ledger.webkit,target_move:0
+#: selection:print.journal.webkit,target_move:0
+#: selection:trial.balance.webkit,target_move:0
+#, python-format
+msgid "All Posted Entries"
+msgstr "Todos los asientos asentados"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:72
+#, python-format
+msgid "All accounts"
+msgstr "Todas las cuentas"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "At the end of"
+msgstr "Al final de"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:159
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:119
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:134
+msgid "Balance"
+msgstr "Saldo"
+
+#. module: account_financial_report_webkit
 #: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:161
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:120
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:127
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:135
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:142
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:168
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:121
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:128
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:136
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:143
 msgid "Balance %s"
 msgstr "Saldo %s"
 
 #. module: account_financial_report_webkit
-#: view:account.move.line:0
-msgid "Misc."
-msgstr "Varios"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:170
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:130
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:145
+msgid "Balance C%s"
+msgstr "Saldo C%s"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:92
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:102
-msgid "Periods Filter:"
-msgstr "Filtro de periodos:"
+#: field:account.account,centralized:0
+msgid "Centralized"
+msgstr "Centralizado"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:170
+#: code:addons/account_financial_report_webkit/report/general_ledger.py:170
 #, python-format
-msgid "No header defined for this Webkit report!"
-msgstr "¡ Ninguna cabecera definida para este informe de Webkit !"
+msgid "Centralized Entries"
+msgstr "Entradas centralizadas"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:162
-#, python-format
-msgid "Filter has to be in filter date, period, or none"
-msgstr "El filtro debe ser fecha, periodo o ninguno"
+#: field:account.aged.trial.balance.webkit,chart_account_id:0
+#: field:account.common.balance.report,chart_account_id:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:32
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:33
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:44
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:29
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:24
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:40
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:53
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:49
+#: field:general.ledger.webkit,chart_account_id:0
+#: field:open.invoices.webkit,chart_account_id:0
+#: field:partner.balance.webkit,chart_account_id:0
+#: field:partners.ledger.webkit,chart_account_id:0
+#: field:print.journal.webkit,chart_account_id:0
+#: field:trial.balance.webkit,chart_account_id:0
+msgid "Chart of Account"
+msgstr "Árbol de cuentas"
 
 #. module: account_financial_report_webkit
-#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_trial_balance_webkit
-msgid "Trial Balance Webkit"
-msgstr "Balance de sumas y saldos webkit"
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "Clearance Analysis Options"
+msgstr "Opciones de análisis de liquidación"
 
 #. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:42
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:58
+msgid "Clearance Date"
+msgstr "Fecha de liquidación"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,until_date:0
+#: field:open.invoices.webkit,until_date:0
+msgid "Clearance date"
+msgstr "Fecha de liquidación"
+
+#. module: account_financial_report_webkit
+#: constraint:account.aged.trial.balance.webkit:0
+#: constraint:open.invoices.webkit:0
+msgid "Clearance date must be the very last date of the         last period or later."
+msgstr "La fecha de liquidación debe ser al menos igual que la última del último periodo."
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:118
+msgid "Code"
+msgstr "Código"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:145
+msgid "Code / Ref"
+msgstr "Código / Ref."
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_account_common_balance_report
+msgid "Common Balance Report"
+msgstr "Informe de saldo general"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,company_id:0
 #: field:account.common.balance.report,company_id:0
 #: field:general.ledger.webkit,company_id:0
 #: field:open.invoices.webkit,company_id:0
 #: field:partner.balance.webkit,company_id:0
 #: field:partners.ledger.webkit,company_id:0
+#: field:print.journal.webkit,company_id:0
 #: field:trial.balance.webkit,company_id:0
 msgid "Company"
 msgstr "Compañía"
 
 #. module: account_financial_report_webkit
-#: view:partner.balance.webkit:0
-msgid ""
-"This report is an analysis done by a partner, It is a PDF report containing "
-"one line per partner representing the cumulative credit balance"
-msgstr ""
-"Este informe es un análisis realizado por empresa. Es un informe PDF "
-"conteniendo una línea por empresa representando su saldo acumulado."
+#: field:account.common.balance.report,comp0_filter:0
+#: field:account.common.balance.report,comp1_filter:0
+#: field:account.common.balance.report,comp2_filter:0
+#: field:partner.balance.webkit,comp0_filter:0
+#: field:partner.balance.webkit,comp1_filter:0
+#: field:partner.balance.webkit,comp2_filter:0
+#: field:trial.balance.webkit,comp0_filter:0
+#: field:trial.balance.webkit,comp1_filter:0
+#: field:trial.balance.webkit,comp2_filter:0
+msgid "Compare By"
+msgstr "Comparar por"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:138
-msgid "Account / Partner Name"
-msgstr "Cuenta / Nombre de la empresa"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,journal_ids:0
-#: field:general.ledger.webkit,journal_ids:0
-#: field:open.invoices.webkit,journal_ids:0
-#: field:partner.balance.webkit,journal_ids:0
-#: field:partners.ledger.webkit,journal_ids:0
-#: field:trial.balance.webkit,journal_ids:0
-msgid "Journals"
-msgstr "Diarios"
-
-#. module: account_financial_report_webkit
-#: help:general.ledger.webkit,amount_currency:0
-#: help:open.invoices.webkit,amount_currency:0
-#: help:partners.ledger.webkit,amount_currency:0
-msgid "It adds the currency column"
-msgstr "Añade la columna de moneda"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:75
-#: selection:open.invoices.webkit,result_selection:0
-#: selection:partner.balance.webkit,result_selection:0
-#: selection:partners.ledger.webkit,result_selection:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:91
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:85
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:98
+#: code:addons/account_financial_report_webkit/wizard/balance_common.py:178
 #, python-format
-msgid "Receivable and Payable Accounts"
-msgstr "Cuentas a cobrar y a pagar"
+msgid "Comparison %s"
+msgstr "Comparación %s"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:104
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:119
-#: model:ir.model,name:account_financial_report_webkit.model_account_account
-msgid "Account"
-msgstr "Cuenta"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:23
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:39
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:24
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:48
+msgid "Computed"
+msgstr "Calculado"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/trial_balance.py:42
-#, python-format
-msgid "TRIAL BALANCE"
-msgstr "BALANCE DE SUMAS Y SALDOS"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:112
+msgid "Counter part"
+msgstr "Contrapartida"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:118
-msgid "Due Date"
-msgstr "Fecha de vencimiento"
+#: field:account.aged.trial.balance.webkit,create_uid:0
+#: field:account.common.balance.report,create_uid:0
+#: field:general.ledger.webkit,create_uid:0
+#: field:open.invoices.webkit,create_uid:0
+#: field:partner.balance.webkit,create_uid:0
+#: field:partners.ledger.webkit,create_uid:0
+#: field:print.journal.webkit,create_uid:0
+#: field:trial.balance.webkit,create_uid:0
+msgid "Created by"
+msgstr "Creado por"
 
 #. module: account_financial_report_webkit
-#: view:general.ledger.webkit:0
-#: view:open.invoices.webkit:0
-#: view:partner.balance.webkit:0
-#: view:partners.ledger.webkit:0
-#: view:trial.balance.webkit:0
-msgid "Print only"
-msgstr "Sólo imprimir"
+#: field:account.aged.trial.balance.webkit,create_date:0
+#: field:account.common.balance.report,create_date:0
+#: field:general.ledger.webkit,create_date:0
+#: field:open.invoices.webkit,create_date:0
+#: field:partner.balance.webkit,create_date:0
+#: field:partners.ledger.webkit,create_date:0
+#: field:print.journal.webkit,create_date:0
+#: field:trial.balance.webkit,create_date:0
+msgid "Created on"
+msgstr "Creado en"
 
 #. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_partner_balance_webkit
-msgid "Partner Balance Report"
-msgstr "Balance de empresa"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:116
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:154
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:119
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:93
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:114
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:129
+msgid "Credit"
+msgstr "Haber"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:194
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:205
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:220
-#, python-format
-msgid "Webkit render"
-msgstr "Renderizador de Webkit"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:118
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:121
+msgid "Cumul. Bal."
+msgstr "Saldo acumulado"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:165
-#, python-format
-msgid "Error!"
-msgstr "¡Error!"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:220
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:267
+msgid "Cumulated Balance on Account"
+msgstr "Saldo acumulado en la cuenta"
 
 #. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_trial_balance_webkit
-msgid "Trial Balance Report"
-msgstr "Balance de sumas y saldos"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:117
-msgid "Code"
-msgstr "Código"
-
-#. module: account_financial_report_webkit
-#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_partners_ledger_webkit
-msgid "Partner Ledger Webkit"
-msgstr "Libro mayor de empresas Webkit"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,display_account:0
-#: field:partner.balance.webkit,display_account:0
-#: field:trial.balance.webkit,display_account:0
-msgid "Display Accounts"
-msgstr "Mostrar cuentas"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:192
-msgid "Unallocated"
-msgstr "Sin asignar"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:123
-#, python-format
-msgid "Webkit raise an error"
-msgstr "Webkit lanzó un error"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:71
-#: selection:open.invoices.webkit,result_selection:0
-#: selection:partner.balance.webkit,result_selection:0
-#: selection:partners.ledger.webkit,result_selection:0
-#, python-format
-msgid "Receivable Accounts"
-msgstr "Cuentas a cobrar"
-
-#. module: account_financial_report_webkit
-#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_general_ledger_webkit
-msgid "General Ledger Webkit"
-msgstr "Libro mayor Webkit"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:116
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:112
-msgid "Rec."
-msgstr "A cobrar"
-
-#. module: account_financial_report_webkit
-#: constraint:account.account:0
-msgid "Error ! You can not create recursive accounts."
-msgstr "¡Error! No se pueden crear cuentas recursivas."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:33
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:37
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:46
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:34
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:58
-msgid "Periods Filter"
-msgstr "Filtro de periodos"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:313
-#, python-format
-msgid "No period found"
-msgstr "No se ha encontrado ningún periodo"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:38
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:139
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:52
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:142
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:39
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:153
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:50
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:108
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:63
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:123
-msgid "Initial Balance"
-msgstr "Saldo inicial"
-
-#. module: account_financial_report_webkit
-#: constraint:account.move.line:0
-msgid ""
-"The date of your Journal Entry is not in the defined period! You should "
-"change the date or remove this constraint from the journal."
-msgstr ""
-"¡La fecha de su asiento no está en el periodo definido! Usted debería "
-"cambiar la fecha o borrar este esta restricción del diario."
-
-#. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_general_ledger_webkit
-msgid "General Ledger Report"
-msgstr "Informe del libro mayor"
-
-#. module: account_financial_report_webkit
-#: constraint:open.invoices.webkit:0
-msgid ""
-"Clearance date must be the very last date of the last period or later."
-msgstr ""
-"La fecha de liquidación debe ser igual o mayor a la última fecha del último "
-"periodo."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:48
-msgid "Displayed Accounts"
-msgstr "Cuentas mostradas"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:99
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:112
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:108
-msgid "Partner"
-msgstr "Empresa"
-
-#. module: account_financial_report_webkit
-#: help:account.common.balance.report,chart_account_id:0
-#: help:general.ledger.webkit,chart_account_id:0
-#: help:open.invoices.webkit,chart_account_id:0
-#: help:partner.balance.webkit,chart_account_id:0
-#: help:partners.ledger.webkit,chart_account_id:0
-#: help:trial.balance.webkit,chart_account_id:0
-msgid "Select Charts of Accounts"
-msgstr "Seleccionar plan contable"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,filter:0
-#: field:general.ledger.webkit,filter:0
-#: field:open.invoices.webkit,filter:0
-#: field:partner.balance.webkit,filter:0
-#: field:partners.ledger.webkit,filter:0
-#: field:trial.balance.webkit,filter:0
-msgid "Filter by"
-msgstr "Filtrar por"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:48
-#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_partners_ledger_menu_webkit
-#: view:partners.ledger.webkit:0
-#, python-format
-msgid "Partner Ledger"
-msgstr "Libro mayor de empresass"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:114
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:129
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:123
-msgid "Curr."
-msgstr "Moneda"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:101
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:114
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:110
-msgid "Label"
-msgstr "Etiqueta"
-
-#. module: account_financial_report_webkit
-#: help:account.common.balance.report,account_ids:0
-#: help:general.ledger.webkit,account_ids:0
-#: help:partner.balance.webkit,account_ids:0
-#: help:trial.balance.webkit,account_ids:0
-msgid ""
-"Only selected accounts will be printed. Leave empty to print all accounts."
-msgstr ""
-"Sólo se imprimirán las cuentas seleccionadas. Déjelo vacío para imprimir "
-"todas las cuentas."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:105
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:120
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:145
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:114
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:111
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:126
-msgid "Debit"
-msgstr "Debe"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:171
-#, python-format
-msgid "Please set a header in company settings"
-msgstr "Por favor, indique la cabecera en la configuración de la compañía"
-
-#. module: account_financial_report_webkit
-#: view:general.ledger.webkit:0
-#: view:open.invoices.webkit:0
-#: view:partner.balance.webkit:0
-#: view:partners.ledger.webkit:0
-#: view:trial.balance.webkit:0
-msgid "Time Filters"
-msgstr "Filtros de tiempo"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:193
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:224
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:233
 msgid "Cumulated Balance on Partner"
 msgstr "Saldo acumulado en la empresa"
 
 #. module: account_financial_report_webkit
-#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_partner_balance_webkit
-msgid "Partner Balance Webkit"
-msgstr "Balance de empresa Webkit"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:123
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:126
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:98
+msgid "Curr."
+msgstr "Moneda"
 
 #. module: account_financial_report_webkit
-#: help:open.invoices.webkit,until_date:0
-msgid ""
-"The clearance date is essentially a tool used for debtors provisionning "
-"calculation.\n"
-"\n"
-"By default, this date is equal to the the end date (ie: 31/12/2011 if you "
-"select fy 2011).\n"
-"\n"
-"By amending the clearance date, you will be, for instance, able to answer "
-"the question : 'based on my last year end debtors open invoices, which "
-"invoices are still unpaid today (today is my clearance date)?'\n"
-msgstr ""
-"La fecha de liquidación es esencialmente una herramienta usado para el "
-"cálculo de provisiones de deudores.\n"
-"\n"
-"Por defecto, esta fecha será igual a la fecha final (por ejemplo, 31/12/2011 "
-"si selecciona el ejercicio fiscal 2011).\n"
-"\n"
-"Corrigiendo la fecha de liquidación, se podrá, por ejemplo, responder a la "
-"pregunta: '¿en base a las facturas abiertas de mis deudores de fin de año, "
-"que facturas están hoy todavía sin pagar (hoy es mi fecha de liquidación)?'\n"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:121
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:124
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:96
+msgid "Curr. Balance"
+msgstr "Saldo actual"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:40
-msgid "Clearance Date"
-msgstr "Fecha de liquidación"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:67
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:61
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:83
+msgid "Custom Filter"
+msgstr "Filtro personalizado"
 
 #. module: account_financial_report_webkit
-#: view:partners.ledger.webkit:0
-msgid ""
-"This report allows you to print or generate a pdf of your partner ledger "
-"with details of all your payable/receivable account"
-msgstr ""
-"Este informe permite imprimir o generar un PDF de su libro mayor de empresas "
-"con detalles de todas sus cuentas a cobrar/a pagar."
+#: selection:account.common.balance.report,comp0_filter:0
+#: selection:account.common.balance.report,comp1_filter:0
+#: selection:account.common.balance.report,comp2_filter:0
+#: selection:account.common.balance.report,filter:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:96
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:101
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:79
+#: selection:general.ledger.webkit,filter:0
+#: selection:open.invoices.webkit,filter:0
+#: selection:partner.balance.webkit,comp0_filter:0
+#: selection:partner.balance.webkit,comp1_filter:0
+#: selection:partner.balance.webkit,comp2_filter:0
+#: selection:partner.balance.webkit,filter:0
+#: selection:partners.ledger.webkit,filter:0
+#: selection:print.journal.webkit,filter:0
+#: selection:trial.balance.webkit,comp0_filter:0
+#: selection:trial.balance.webkit,comp1_filter:0
+#: selection:trial.balance.webkit,comp2_filter:0
+#: selection:trial.balance.webkit,filter:0
+msgid "Date"
+msgstr "Fecha"
 
 #. module: account_financial_report_webkit
-#: selection:account.common.balance.report,display_account:0
-#: selection:partner.balance.webkit,display_account:0
-#: selection:trial.balance.webkit,display_account:0
-msgid "With balance is not equal to 0"
-msgstr "Con saldo distinto a 0"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:94
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:104
-msgid "Fiscal Year :"
-msgstr "Ejercicio fiscal:"
-
-#. module: account_financial_report_webkit
-#: view:open.invoices.webkit:0
-msgid ""
-"This report allows you to print or generate a pdf of your open invoices per "
-"partner with details of all your payable/receivable account. Exclude full "
-"reconciled journal items."
-msgstr ""
-"Este informe permite imprimir o generar un PDF de las facturas abiertas (con "
-"deuda pendiente) por empresa con detalles de todas las cuentas a pagar/a "
-"cobrar. Excluye los apuntes totalmente conciliados."
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:416
-#, python-format
-msgid "Must be in include_opening, exclude_opening"
-msgstr "Debe ser include_opening o exclude_opening"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:43
-#: code:addons/account_financial_report_webkit/wizard/balance_common.py:151
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:44
+#: code:addons/account_financial_report_webkit/wizard/balance_common.py:208
 #, python-format
 msgid "Dates"
 msgstr "Fechas"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:136
-msgid "Code / Ref"
-msgstr "Código / Ref."
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/trial_balance.py:49
-#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_trial_balance_menu_webkit
-#: view:trial.balance.webkit:0
-#, python-format
-msgid "Trial Balance"
-msgstr "Balance de sumas y saldos"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:87
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:88
 msgid "Dates : "
 msgstr "Fechas: "
 
 #. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:36
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:37
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:48
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:33
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:28
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:57
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:53
+msgid "Dates Filter"
+msgstr "Filtros de fechas"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:94
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:101
+msgid "Dates Filter:"
+msgstr "Filtro de fechas:"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:114
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:152
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:117
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:91
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:112
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:127
+msgid "Debit"
+msgstr "Debe"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:174
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:134
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:149
+msgid "Difference"
+msgstr "Diferencia"
+
+#. module: account_financial_report_webkit
+#: field:account.common.balance.report,display_account:0
+#: field:partner.balance.webkit,display_account:0
+#: field:print.journal.webkit,display_account:0
+#: field:trial.balance.webkit,display_account:0
+msgid "Display Accounts"
+msgstr "Mostrar cuentas"
+
+#. module: account_financial_report_webkit
+#: field:general.ledger.webkit,display_account:0
+msgid "Display accounts"
+msgstr "Mostrar cuentas"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:49
+msgid "Displayed Accounts"
+msgstr "Cuentas mostradas"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:52
+#, python-format
+msgid "Due"
+msgstr "Vencido"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:85
+msgid "Due Date"
+msgstr "Fecha de vencimiento"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,date_to:0
+#: field:account.common.balance.report,comp0_date_to:0
+#: field:account.common.balance.report,comp1_date_to:0
+#: field:account.common.balance.report,comp2_date_to:0
+#: field:account.common.balance.report,date_to:0
+#: field:general.ledger.webkit,date_to:0
+#: field:open.invoices.webkit,date_to:0
+#: field:partner.balance.webkit,comp0_date_to:0
+#: field:partner.balance.webkit,comp1_date_to:0
+#: field:partner.balance.webkit,comp2_date_to:0
+#: field:partner.balance.webkit,date_to:0
+#: field:partners.ledger.webkit,date_to:0
+#: field:print.journal.webkit,date_to:0
+#: field:trial.balance.webkit,comp0_date_to:0
+#: field:trial.balance.webkit,comp1_date_to:0
+#: field:trial.balance.webkit,comp2_date_to:0
+#: field:trial.balance.webkit,date_to:0
+msgid "End Date"
+msgstr "Fecha final"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,period_to:0
 #: field:account.common.balance.report,comp0_period_to:0
 #: field:account.common.balance.report,comp1_period_to:0
 #: field:account.common.balance.report,comp2_period_to:0
@@ -498,6 +482,7 @@ msgstr "Fechas: "
 #: field:partner.balance.webkit,comp2_period_to:0
 #: field:partner.balance.webkit,period_to:0
 #: field:partners.ledger.webkit,period_to:0
+#: field:print.journal.webkit,period_to:0
 #: field:trial.balance.webkit,comp0_period_to:0
 #: field:trial.balance.webkit,comp1_period_to:0
 #: field:trial.balance.webkit,comp2_period_to:0
@@ -506,18 +491,454 @@ msgid "End Period"
 msgstr "Periodo final"
 
 #. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_account_common_balance_report
-msgid "Common Balance Report"
-msgstr "Informe de balance general"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:100
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:105
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:81
+msgid "Entry"
+msgstr "Asiento"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:36
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:41
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:49
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:37
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:61
-msgid "Accounts Filter"
+#: code:addons/account_financial_report_webkit/report/common_reports.py:403
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:136
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:119
+#, python-format
+msgid "Error"
+msgstr "Error"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:217
+#, python-format
+msgid "Error!"
+msgstr "¡Error!"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,filter:0
+#: field:account.common.balance.report,filter:0
+#: field:general.ledger.webkit,filter:0
+#: field:open.invoices.webkit,filter:0
+#: field:partner.balance.webkit,filter:0
+#: field:partners.ledger.webkit,filter:0
+#: field:print.journal.webkit,filter:0
+#: field:trial.balance.webkit,filter:0
+msgid "Filter by"
+msgstr "Filtrar por"
+
+#. module: account_financial_report_webkit
+#: help:account.common.balance.report,filter:0
+#: help:open.invoices.webkit,filter:0
+#: help:partner.balance.webkit,filter:0
+#: help:partners.ledger.webkit,filter:0
+#: help:trial.balance.webkit,filter:0
+msgid "Filter by date: no opening balance will be displayed. (opening balance can only be computed based on period to be             correct)."
+msgstr "Filtro por fecha: no se mostrara el saldo de apertura. (el saldo de apertura solo puede ser calculado basado en periodos para que sea correcto)."
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:212
+#, python-format
+msgid "Filter has to be in filter date, period,                                  or none"
+msgstr "El filtro debe ser de fecha, periodo o ninguno"
+
+#. module: account_financial_report_webkit
+#: field:account.common.balance.report,account_ids:0
+#: field:general.ledger.webkit,account_ids:0
+#: field:partner.balance.webkit,account_ids:0
+#: field:trial.balance.webkit,account_ids:0
+msgid "Filter on accounts"
 msgstr "Filtro de cuentas"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,partner_ids:0
+#: field:open.invoices.webkit,partner_ids:0
+#: field:partner.balance.webkit,partner_ids:0
+#: field:partners.ledger.webkit,partner_ids:0
+msgid "Filter on partner"
+msgstr "Filtro de empresas"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,fiscalyear_id:0
+#: selection:account.common.balance.report,comp0_filter:0
+#: field:account.common.balance.report,comp0_fiscalyear_id:0
+#: selection:account.common.balance.report,comp1_filter:0
+#: field:account.common.balance.report,comp1_fiscalyear_id:0
+#: selection:account.common.balance.report,comp2_filter:0
+#: field:account.common.balance.report,comp2_fiscalyear_id:0
+#: field:account.common.balance.report,fiscalyear_id:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:33
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:34
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:45
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:30
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:25
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:41
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:54
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:50
+#: field:general.ledger.webkit,fiscalyear_id:0
+#: field:open.invoices.webkit,fiscalyear_id:0
+#: selection:partner.balance.webkit,comp0_filter:0
+#: field:partner.balance.webkit,comp0_fiscalyear_id:0
+#: selection:partner.balance.webkit,comp1_filter:0
+#: field:partner.balance.webkit,comp1_fiscalyear_id:0
+#: selection:partner.balance.webkit,comp2_filter:0
+#: field:partner.balance.webkit,comp2_fiscalyear_id:0
+#: field:partner.balance.webkit,fiscalyear_id:0
+#: field:partners.ledger.webkit,fiscalyear_id:0
+#: field:print.journal.webkit,fiscalyear_id:0
+#: selection:trial.balance.webkit,comp0_filter:0
+#: field:trial.balance.webkit,comp0_fiscalyear_id:0
+#: selection:trial.balance.webkit,comp1_filter:0
+#: field:trial.balance.webkit,comp1_fiscalyear_id:0
+#: selection:trial.balance.webkit,comp2_filter:0
+#: field:trial.balance.webkit,comp2_fiscalyear_id:0
+#: field:trial.balance.webkit,fiscalyear_id:0
+msgid "Fiscal Year"
+msgstr "Ejercicio fiscal"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:98
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:105
+msgid "Fiscal Year :"
+msgstr "Ejercicio fiscal:"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:92
+msgid "Fiscal Year : "
+msgstr "Ejercicio fiscal: "
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:49
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:51
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:62
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:46
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:40
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:57
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:70
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:67
+msgid "From:"
+msgstr "De:"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/general_ledger.py:44
+#, python-format
+msgid "GENERAL LEDGER"
+msgstr "LIBRO MAYOR"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/general_ledger.py:52
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_general_ledger_menu_webkit
+#, python-format
+msgid "General Ledger"
+msgstr "Libro mayor"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_general_ledger_webkit
+msgid "General Ledger Report"
+msgstr "Informe del libro mayor"
+
+#. module: account_financial_report_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_general_ledger_webkit
+msgid "General Ledger Webkit"
+msgstr "Libro mayor Webkit"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,group_by_currency:0
+#: field:open.invoices.webkit,group_by_currency:0
+msgid "Group Partner by currency"
+msgstr "Agrupar empresas por moneda"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,id:0
+#: field:account.common.balance.report,id:0
+#: field:general.ledger.webkit,id:0
+#: field:open.invoices.webkit,id:0
+#: field:partner.balance.webkit,id:0
+#: field:partners.ledger.webkit,id:0
+#: field:print.journal.webkit,id:0
+#: field:trial.balance.webkit,id:0
+msgid "ID"
+msgstr "ID"
+
+#. module: account_financial_report_webkit
+#: help:account.account,centralized:0
+msgid "If flagged, no details will be displayed in the General Ledger report (the webkit one only), only centralized amounts per period."
+msgstr "Si está marcado, no se mostrarán detalles en el libro mayor (sólo en el de Webkit), sino que se mostrará únicamente los importes totales por periodo."
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:43
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:152
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:56
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:149
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:40
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:158
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:51
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:109
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:64
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:124
+msgid "Initial Balance"
+msgstr "Saldo inicial"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:101
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:95
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:108
+msgid "Initial Balance:"
+msgstr "Saldo inicial:"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:489
+#, python-format
+msgid "Invalid query mode"
+msgstr "Modo de consulta no válido"
+
+#. module: account_financial_report_webkit
+#: help:account.aged.trial.balance.webkit,amount_currency:0
+#: help:general.ledger.webkit,amount_currency:0
+#: help:open.invoices.webkit,amount_currency:0
+#: help:partners.ledger.webkit,amount_currency:0
+#: help:print.journal.webkit,amount_currency:0
+msgid "It adds the currency column"
+msgstr "Añade la columna de moneda"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/print_journal.py:49
+#, python-format
+msgid "JOURNALS"
+msgstr "DIARIOS"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:102
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:107
+msgid "Journal"
+msgstr "Diario"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:33
+msgid "Journal Filter"
+msgstr "Filtro de diarios"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_account_move_line
+msgid "Journal Items"
+msgstr "Apuntes contables"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,journal_ids:0
+#: field:account.common.balance.report,journal_ids:0
+#: code:addons/account_financial_report_webkit/report/print_journal.py:58
+#: field:general.ledger.webkit,journal_ids:0
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_print_journal_menu_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_print_journal_webkit
+#: field:open.invoices.webkit,journal_ids:0
+#: field:partner.balance.webkit,journal_ids:0
+#: field:partners.ledger.webkit,journal_ids:0
+#: view:print.journal.webkit:account_financial_report_webkit.account_report_print_journal_view_webkit
+#: field:print.journal.webkit,journal_ids:0
+#: field:trial.balance.webkit,journal_ids:0
+#, python-format
+msgid "Journals"
+msgstr "Diarios"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_print_journal_webkit
+msgid "Journals Report"
+msgstr "Informe de diarios"
+
+#. module: account_financial_report_webkit
+#: help:account.common.balance.report,fiscalyear_id:0
+#: help:general.ledger.webkit,fiscalyear_id:0
+#: help:open.invoices.webkit,fiscalyear_id:0
+#: help:partner.balance.webkit,fiscalyear_id:0
+#: help:partners.ledger.webkit,fiscalyear_id:0
+#: help:print.journal.webkit,fiscalyear_id:0
+#: help:trial.balance.webkit,fiscalyear_id:0
+msgid "Keep empty for all open fiscal year"
+msgstr "Dejarlo vacío para todos los ejercicios fiscales abiertos."
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:110
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:113
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:89
+msgid "Label"
+msgstr "Etiqueta"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,write_uid:0
+#: field:account.common.balance.report,write_uid:0
+#: field:general.ledger.webkit,write_uid:0
+#: field:open.invoices.webkit,write_uid:0
+#: field:partner.balance.webkit,write_uid:0
+#: field:partners.ledger.webkit,write_uid:0
+#: field:print.journal.webkit,write_uid:0
+#: field:trial.balance.webkit,write_uid:0
+msgid "Last Updated by"
+msgstr "Última actualización por"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,write_date:0
+#: field:account.common.balance.report,write_date:0
+#: field:general.ledger.webkit,write_date:0
+#: field:open.invoices.webkit,write_date:0
+#: field:partner.balance.webkit,write_date:0
+#: field:partners.ledger.webkit,write_date:0
+#: field:print.journal.webkit,write_date:0
+#: field:trial.balance.webkit,write_date:0
+msgid "Last Updated on"
+msgstr "Última actualización en"
+
+#. module: account_financial_report_webkit
+#: field:account.move.line,last_rec_date:0
+msgid "Last reconciliation date"
+msgstr "Última fecha de conciliación"
+
+#. module: account_financial_report_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+msgid "Layout Options"
+msgstr "Opciones de disposición"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:490
+#, python-format
+msgid "Must be in include_opening, exclude_opening"
+msgstr "Debe ser include_opening o exclude_opening"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:23
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:39
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:24
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:78
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:95
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:48
+msgid "No"
+msgstr "No"
+
+#. module: account_financial_report_webkit
+#: selection:account.common.balance.report,comp0_filter:0
+#: selection:account.common.balance.report,comp1_filter:0
+#: selection:account.common.balance.report,comp2_filter:0
+#: selection:partner.balance.webkit,comp0_filter:0
+#: selection:partner.balance.webkit,comp1_filter:0
+#: selection:partner.balance.webkit,comp2_filter:0
+#: selection:trial.balance.webkit,comp0_filter:0
+#: selection:trial.balance.webkit,comp1_filter:0
+#: selection:trial.balance.webkit,comp2_filter:0
+msgid "No Comparison"
+msgstr "Sin comparación"
+
+#. module: account_financial_report_webkit
+#: selection:account.common.balance.report,filter:0
+#: selection:general.ledger.webkit,filter:0
+#: selection:open.invoices.webkit,filter:0
+#: selection:partner.balance.webkit,filter:0
+#: selection:partners.ledger.webkit,filter:0
+#: selection:print.journal.webkit,filter:0
+#: selection:trial.balance.webkit,filter:0
+msgid "No Filters"
+msgstr "Sin filtros"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:96
+msgid "No Partner"
+msgstr "Sin empresa"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:136
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:119
+#, python-format
+msgid "No accounts to print."
+msgstr "Sin cuentas que imprimir."
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:161
+#, python-format
+msgid "No diagnosis message was provided"
+msgstr "No se ha dado ningún mensaje de diagnosis"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:222
+#, python-format
+msgid "No header defined for this Webkit report!"
+msgstr "¡ Ninguna cabecera definida para este informe de Webkit !"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:404
+#, python-format
+msgid "No opening period found to compute the opening balances.\n"
+"You have to configure a period on the first of January with the special flag."
+msgstr "No se ha encontrado ningún periodo de apertura para calcular los saldos de apertura.\n"
+"Tiene que configurar un periodo para el primer día del ejercicio con la casilla de "Periodo especial" activada."
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:359
+#, python-format
+msgid "No period found"
+msgstr "No se ha encontrado ningún periodo"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:501
+#, python-format
+msgid "No valid filter"
+msgstr "Sin filtro válido"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:57
+#, python-format
+msgid "OPEN INVOICES REPORT"
+msgstr "INFORME DE FACTURAS ABIERTAS"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:54
+#, python-format
+msgid "Older"
+msgstr "Más antiguo que"
+
+#. module: account_financial_report_webkit
+#: help:general.ledger.webkit,account_ids:0
+msgid "Only selected accounts will be printed. Leave empty to\n"
+"                    print all accounts."
+msgstr "Sólo las cuentas seleccionadas serán mostradas. Déjelo vacío para mostrar todas las cuentas."
+
+#. module: account_financial_report_webkit
+#: help:account.common.balance.report,account_ids:0
+#: help:partner.balance.webkit,account_ids:0
+#: help:trial.balance.webkit,account_ids:0
+msgid "Only selected accounts will be printed. Leave empty to             print all accounts."
+msgstr "Sólo las cuentas seleccionadas serán mostradas. Déjelo vacío para mostrar todas las cuentas."
+
+#. module: account_financial_report_webkit
+#: help:partner.balance.webkit,partner_ids:0
+msgid "Only selected partners will be printed.                   Leave empty to print all partners."
+msgstr "Sólo las empresas seleccionadas serán mostradas. Déjelo vacío para mostrar todas las empresas."
+
+#. module: account_financial_report_webkit
+#: help:account.aged.trial.balance.webkit,partner_ids:0
+#: help:open.invoices.webkit,partner_ids:0
+#: help:partners.ledger.webkit,partner_ids:0
+msgid "Only selected partners will be printed. Leave empty to print all partners."
+msgstr "Sólo se imprimirán las empresas seleccionadas. Déjelo en blanco para imprimir todas las empresas."
+
+#. module: account_financial_report_webkit
+#: model:ir.ui.menu,name:account_financial_report_webkit.menu_account_open_invoices
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "Open Invoices"
+msgstr "Facturas abiertas"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:67
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_open_invoices_menu_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_open_invoices_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_open_invoices_webkit
+#, python-format
+msgid "Open Invoices Report"
+msgstr "Informe de facturas abiertas"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:23
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:39
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:24
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:48
+msgid "Opening Entries"
+msgstr "Asiento de apertura"
 
 #. module: account_financial_report_webkit
 #: selection:account.common.balance.report,comp0_filter:0
@@ -536,72 +957,103 @@ msgid "Opening Only"
 msgstr "Sólo apertura"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:65
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:60
-msgid "Custom Filter"
-msgstr "Filtro personalizado"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:90
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:100
-msgid "Dates Filter:"
-msgstr "Filtro de fechas:"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:91
-msgid "Fiscal Year : "
-msgstr "Ejercicio fiscal: "
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,display_account:0
-#: selection:partner.balance.webkit,display_account:0
-#: selection:trial.balance.webkit,display_account:0
-msgid "With movements"
-msgstr "Con movimientos"
-
-#. module: account_financial_report_webkit
-#: constraint:account.common.balance.report:0
-#: constraint:general.ledger.webkit:0
-#: constraint:open.invoices.webkit:0
-#: constraint:partner.balance.webkit:0
-#: constraint:partners.ledger.webkit:0
-#: constraint:trial.balance.webkit:0
-msgid ""
-"The fiscalyear, periods or chart of account chosen have to belong to the "
-"same company."
-msgstr ""
-"El ejercicio fiscal, periodos y árbol de cuentas escogido deben pertenecer a "
-"la misma compañía."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:109
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:124
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:118
-msgid "Cumul. Bal."
-msgstr "Saldo acumulado"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:22
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:35
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:23
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:47
-msgid "Computed"
-msgstr "Calculado"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/general_ledger.py:64
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:63
-#: code:addons/account_financial_report_webkit/report/partner_balance.py:63
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:64
-#: code:addons/account_financial_report_webkit/report/profit_loss.py:68
-#: code:addons/account_financial_report_webkit/report/trial_balance.py:64
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:68
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:53
 #, python-format
-msgid "of"
-msgstr "de"
+msgid "Overdue ≤ %s d."
+msgstr "Retraso ≤ %s d."
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:73
+#: code:addons/account_financial_report_webkit/report/partner_balance.py:44
+#, python-format
+msgid "PARTNER BALANCE"
+msgstr "BALANCE DE EMPRESA"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:44
+#, python-format
+msgid "PARTNER LEDGER"
+msgstr "LIBRO MAYOR DE EMPRESAS"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:102
+#: code:addons/account_financial_report_webkit/report/general_ledger.py:70
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:83
+#: code:addons/account_financial_report_webkit/report/partner_balance.py:71
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:71
+#: code:addons/account_financial_report_webkit/report/print_journal.py:75
+#: code:addons/account_financial_report_webkit/report/trial_balance.py:71
+#, python-format
+msgid "Page"
+msgstr "Página"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:106
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:109
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:87
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:101
+msgid "Partner"
+msgstr "Empresa"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/partner_balance.py:54
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_partner_balance_menu_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#, python-format
+msgid "Partner Balance"
+msgstr "Saldo de empresa"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_partner_balance_webkit
+msgid "Partner Balance Report"
+msgstr "Saldo de empresa"
+
+#. module: account_financial_report_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_partner_balance_webkit
+msgid "Partner Balance Webkit"
+msgstr "Saldo de empresa Webkit"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:54
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_partners_ledger_menu_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+#, python-format
+msgid "Partner Ledger"
+msgstr "Libro mayor de empresas"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_partners_ledger_webkit
+msgid "Partner Ledger Report"
+msgstr "Libro mayor de empresas"
+
+#. module: account_financial_report_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_partners_ledger_webkit
+msgid "Partner Ledger Webkit"
+msgstr "Libro mayor de empresas Webkit"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,result_selection:0
+#: field:open.invoices.webkit,result_selection:0
+#: field:partner.balance.webkit,result_selection:0
+#: field:partners.ledger.webkit,result_selection:0
+msgid "Partner's"
+msgstr "De empresas"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:54
+msgid "Partners Filter"
+msgstr "Filtros de empresas"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+msgid "Partners Filters"
+msgstr "Filtros de empresas"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,result_selection:0
+#: code:addons/account_financial_report_webkit/report/common_reports.py:83
 #: selection:open.invoices.webkit,result_selection:0
 #: selection:partner.balance.webkit,result_selection:0
 #: selection:partners.ledger.webkit,result_selection:0
@@ -610,35 +1062,130 @@ msgid "Payable Accounts"
 msgstr "Cuentas a pagar"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:48
-#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_open_invoices_menu_webkit
-#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_open_invoices_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_open_invoices_webkit
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:141
+msgid "Percents"
+msgstr "Porcentajes"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:98
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:103
+msgid "Period"
+msgstr "Período"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,filter:0
+#: selection:account.common.balance.report,comp0_filter:0
+#: selection:account.common.balance.report,comp1_filter:0
+#: selection:account.common.balance.report,comp2_filter:0
+#: selection:account.common.balance.report,filter:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:46
+#: code:addons/account_financial_report_webkit/wizard/balance_common.py:228
+#: selection:general.ledger.webkit,filter:0
+#: selection:open.invoices.webkit,filter:0
+#: selection:partner.balance.webkit,comp0_filter:0
+#: selection:partner.balance.webkit,comp1_filter:0
+#: selection:partner.balance.webkit,comp2_filter:0
+#: selection:partner.balance.webkit,filter:0
+#: selection:partners.ledger.webkit,filter:0
+#: view:print.journal.webkit:account_financial_report_webkit.account_report_print_journal_view_webkit
+#: selection:print.journal.webkit,filter:0
+#: selection:trial.balance.webkit,comp0_filter:0
+#: selection:trial.balance.webkit,comp1_filter:0
+#: selection:trial.balance.webkit,comp2_filter:0
+#: selection:trial.balance.webkit,filter:0
 #, python-format
-msgid "Open Invoices Report"
-msgstr "Informe de facturas abiertas"
+msgid "Periods"
+msgstr "Periodos"
 
 #. module: account_financial_report_webkit
-#: field:account.account,centralized:0
-msgid "Centralized"
-msgstr "Centralizado"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:90
+msgid "Periods : "
+msgstr "Periodos: "
 
 #. module: account_financial_report_webkit
-#: field:general.ledger.webkit,display_account:0
-msgid "Display accounts"
-msgstr "Mostrar cuentas"
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:38
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:39
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:50
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:35
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:30
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:59
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:55
+msgid "Periods Filter"
+msgstr "Filtro de periodos"
 
 #. module: account_financial_report_webkit
-#: constraint:account.account:0
-msgid ""
-"Configuration Error! \n"
-"You can not define children to an account with internal type different of "
-"\"View\"! "
-msgstr ""
-"¡Error de configuración! \n"
-"¡No puede definir hijos en una cuenta con tipo interno distinto a \"Vista\"! "
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:96
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:103
+msgid "Periods Filter:"
+msgstr "Filtro de periodos:"
 
 #. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:223
+#, python-format
+msgid "Please set a header in company settings."
+msgstr "Establezca por favor una cabecera en la configuracion de la compañía."
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:501
+#, python-format
+msgid "Please set a valid time filter"
+msgstr "Establezca por favor un filtro de tiempo válido"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "Print only"
+msgstr "Sólo imprimir"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:115
+msgid "Rec."
+msgstr "A cobrar"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,result_selection:0
+#: code:addons/account_financial_report_webkit/report/common_reports.py:81
+#: selection:open.invoices.webkit,result_selection:0
+#: selection:partner.balance.webkit,result_selection:0
+#: selection:partners.ledger.webkit,result_selection:0
+#, python-format
+msgid "Receivable Accounts"
+msgstr "Cuentas a cobrar"
+
+#. module: account_financial_report_webkit
+#: selection:account.aged.trial.balance.webkit,result_selection:0
+#: code:addons/account_financial_report_webkit/report/common_reports.py:85
+#: selection:open.invoices.webkit,result_selection:0
+#: selection:partner.balance.webkit,result_selection:0
+#: selection:partners.ledger.webkit,result_selection:0
+#, python-format
+msgid "Receivable and Payable Accounts"
+msgstr "Cuentas a cobrar y a pagar"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:108
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:111
+msgid "Reference"
+msgstr "Referencia"
+
+#. module: account_financial_report_webkit
+#: help:account.aged.trial.balance.webkit,chart_account_id:0
+#: help:account.common.balance.report,chart_account_id:0
+#: help:general.ledger.webkit,chart_account_id:0
+#: help:open.invoices.webkit,chart_account_id:0
+#: help:partner.balance.webkit,chart_account_id:0
+#: help:partners.ledger.webkit,chart_account_id:0
+#: help:print.journal.webkit,chart_account_id:0
+#: help:trial.balance.webkit,chart_account_id:0
+msgid "Select Charts of Accounts"
+msgstr "Seleccionar plan contable"
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,date_from:0
 #: field:account.common.balance.report,comp0_date_from:0
 #: field:account.common.balance.report,comp1_date_from:0
 #: field:account.common.balance.report,comp2_date_from:0
@@ -650,6 +1197,7 @@ msgstr ""
 #: field:partner.balance.webkit,comp2_date_from:0
 #: field:partner.balance.webkit,date_from:0
 #: field:partners.ledger.webkit,date_from:0
+#: field:print.journal.webkit,date_from:0
 #: field:trial.balance.webkit,comp0_date_from:0
 #: field:trial.balance.webkit,comp1_date_from:0
 #: field:trial.balance.webkit,comp2_date_from:0
@@ -658,544 +1206,7 @@ msgid "Start Date"
 msgstr "Fecha inicial"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:22
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:35
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:23
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:47
-msgid "Opening Entries"
-msgstr "Asiento de apertura"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/general_ledger.py:40
-#, python-format
-msgid "GENERAL LEDGER"
-msgstr "LIBRO MAYOR"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/wizard/profit_loss_wizard.py:129
-#, python-format
-msgid "Level %s"
-msgstr "Nivel %s"
-
-#. module: account_financial_report_webkit
-#: help:account.account,centralized:0
-msgid ""
-"If flagged, no details will be displayed in the General Ledger report (the "
-"webkit one only), only centralized amounts per period."
-msgstr ""
-"Si está marcado, no se mostrarán detalles en el libro mayor (sólo en el de "
-"Webkit), sino que se mostrará únicamente los importes totales por periodo."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:22
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:35
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:23
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:77
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:94
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:47
-msgid "No"
-msgstr "No"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:97
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:94
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:107
-msgid "Initial Balance:"
-msgstr "Saldo inicial:"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:163
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:129
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:144
-msgid "Balance C%s"
-msgstr "Saldo C%s"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:95
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:108
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:104
-msgid "Entry"
-msgstr "Asiento"
-
-#. module: account_financial_report_webkit
-#: field:account.move.line,last_rec_date:0
-msgid "Last reconciliation date"
-msgstr "Última fecha de conciliación"
-
-#. module: account_financial_report_webkit
-#: field:open.invoices.webkit,partner_ids:0
-#: field:partner.balance.webkit,partner_ids:0
-#: field:partners.ledger.webkit,partner_ids:0
-msgid "Filter on partner"
-msgstr "Filtro de empresa"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/general_ledger.py:47
-#: view:general.ledger.webkit:0
-#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_general_ledger_menu_webkit
-#, python-format
-msgid "General Ledger"
-msgstr "Libro mayor"
-
-#. module: account_financial_report_webkit
-#: view:trial.balance.webkit:0
-msgid ""
-"This report allows you to print or generate a pdf of your trial balance "
-"allowing you to quickly check the balance of each of your accounts in a "
-"single report"
-msgstr ""
-"Este informe le permite imprimir o generar un PDF de su balance de sumas y "
-"saldos para comprobar con rapidez el saldo de cada una de sus cuentas en un "
-"único informe."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:89
-msgid "Periods : "
-msgstr "Periodos: "
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/partner_balance.py:40
-#, python-format
-msgid "PARTNER BALANCE"
-msgstr "BALANCE DE EMPRESA"
-
-#. module: account_financial_report_webkit
-#: constraint:account.move.line:0
-msgid "Company must be the same for its related account and period."
-msgstr "La compañía debe ser la misma para su cuenta y periodo relacionados"
-
-#. module: account_financial_report_webkit
-#: help:open.invoices.webkit,partner_ids:0
-#: help:partner.balance.webkit,partner_ids:0
-#: help:partners.ledger.webkit,partner_ids:0
-msgid ""
-"Only selected partners will be printed. Leave empty to print all partners."
-msgstr ""
-"Sólo se imprimirán las empresas seleccionadas. Déjelo en blanco para "
-"imprimir todas las empresas."
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:165
-#, python-format
-msgid "Webkit Report template not found !"
-msgstr "¡Plantilla del informe Webkit no encontrada!"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,comp0_filter:0
-#: selection:account.common.balance.report,comp1_filter:0
-#: selection:account.common.balance.report,comp2_filter:0
-#: selection:account.common.balance.report,filter:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:91
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:104
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:100
-#: selection:general.ledger.webkit,filter:0
-#: selection:open.invoices.webkit,filter:0
-#: selection:partner.balance.webkit,comp0_filter:0
-#: selection:partner.balance.webkit,comp1_filter:0
-#: selection:partner.balance.webkit,comp2_filter:0
-#: selection:partner.balance.webkit,filter:0
-#: selection:partners.ledger.webkit,filter:0
-#: selection:trial.balance.webkit,comp0_filter:0
-#: selection:trial.balance.webkit,comp1_filter:0
-#: selection:trial.balance.webkit,comp2_filter:0
-#: selection:trial.balance.webkit,filter:0
-msgid "Date"
-msgstr "Fecha"
-
-#. module: account_financial_report_webkit
-#: help:general.ledger.webkit,centralize:0
-msgid "Uncheck to display all the details of centralized accounts."
-msgstr ""
-"Desmarque esta casilla para mostrar todos los detalles de las cuentas "
-"centralizadas"
-
-#. module: account_financial_report_webkit
-#: constraint:account.move.line:0
-msgid "You can not create journal items on an account of type view."
-msgstr "No puede crear asientos en una cuenta de tipo vista."
-
-#. module: account_financial_report_webkit
-#: view:account.move.line:0
-msgid "Internal Note"
-msgstr "Nota interna"
-
-#. module: account_financial_report_webkit
-#: constraint:account.common.balance.report:0
-#: constraint:general.ledger.webkit:0
-#: constraint:open.invoices.webkit:0
-#: constraint:partner.balance.webkit:0
-#: constraint:partners.ledger.webkit:0
-#: constraint:trial.balance.webkit:0
-msgid ""
-"When no Fiscal year is selected, you must choose to filter by periods or by "
-"date."
-msgstr ""
-"Cuando no se selecciona un ejercicio fiscal, debe escoger filtrar por "
-"periodos o por fecha."
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:50
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:55
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:64
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:51
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:62
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:75
-msgid "To:"
-msgstr "A:"
-
-#. module: account_financial_report_webkit
-#: sql_constraint:account.account:0
-msgid "The code of the account must be unique per company !"
-msgstr "¡El código de la cuenta debe ser único por compañía!"
-
-#. module: account_financial_report_webkit
-#: model:ir.ui.menu,name:account_financial_report_webkit.menu_account_open_invoices
-#: view:open.invoices.webkit:0
-msgid "Open Invoices"
-msgstr "Facturas abiertas"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,target_move:0
-#: code:addons/account_financial_report_webkit/report/common_reports.py:82
-#: selection:general.ledger.webkit,target_move:0
-#: selection:open.invoices.webkit,target_move:0
-#: selection:partner.balance.webkit,target_move:0
-#: selection:partners.ledger.webkit,target_move:0
-#: selection:trial.balance.webkit,target_move:0
-#, python-format
-msgid "All Posted Entries"
-msgstr "Todos los asientos asentados"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:87
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:84
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:97
-#: code:addons/account_financial_report_webkit/wizard/balance_common.py:144
-#, python-format
-msgid "Comparison %s"
-msgstr "Comparación %s"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:102
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:102
-#, python-format
-msgid "No accounts to print."
-msgstr "Sin cuentas que imprimir."
-
-#. module: account_financial_report_webkit
-#: help:account.common.balance.report,fiscalyear_id:0
-#: help:general.ledger.webkit,fiscalyear_id:0
-#: help:open.invoices.webkit,fiscalyear_id:0
-#: help:partner.balance.webkit,fiscalyear_id:0
-#: help:partners.ledger.webkit,fiscalyear_id:0
-#: help:trial.balance.webkit,fiscalyear_id:0
-msgid "Keep empty for all open fiscal year"
-msgstr "Dejarlo vacío para todos los ejercicios fiscales abiertos."
-
-#. module: account_financial_report_webkit
-#: help:account.move.line,last_rec_date:0
-msgid ""
-"the date of the last reconciliation (full or partial) account move line"
-msgstr "la fecha de la última conciliación (completa o parcial)"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:107
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:122
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:147
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:116
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:113
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:128
-msgid "Credit"
-msgstr "Haber"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,filter:0
-#: selection:general.ledger.webkit,filter:0
-#: selection:open.invoices.webkit,filter:0
-#: selection:partner.balance.webkit,filter:0
-#: selection:partners.ledger.webkit,filter:0
-#: selection:trial.balance.webkit,filter:0
-msgid "No Filters"
-msgstr "Sin filtros"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:102
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:102
-#, python-format
-msgid "Error"
-msgstr "Error"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:152
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:118
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:133
-msgid "Balance"
-msgstr "Saldo"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:103
-msgid "Counter part"
-msgstr "Contrapartida"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:168
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:134
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:149
-msgid "% Difference"
-msgstr "% diferencia"
-
-#. module: account_financial_report_webkit
-#: help:account.common.balance.report,filter:0
-#: help:open.invoices.webkit,filter:0
-#: help:partner.balance.webkit,filter:0
-#: help:partners.ledger.webkit,filter:0
-#: help:trial.balance.webkit,filter:0
-msgid ""
-"Filter by date : no opening balance will be displayed. (opening balance can "
-"only be calculated based on period to be correct)."
-msgstr ""
-"Filtrar por fecha: no se mostrará saldo inicial (El saldo de apertura sólo "
-"se puede calcular para que sea correcto basándose en el periodo)."
-
-#. module: account_financial_report_webkit
-#: constraint:account.account:0
-msgid ""
-"Configuration Error! \n"
-"You can not select an account type with a deferral method different of "
-"\"Unreconciled\" for accounts with internal type \"Payable/Receivable\"! "
-msgstr ""
-"¡Error de configuración! \n"
-"¡No puede seleccionar un tipo de cuenta con un método de cierre diferente de "
-"\"Reconciliado\" para las cuentas con tipo interno \"A pagar/A cobrar\"! "
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/partner_balance.py:47
-#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_partner_balance_menu_webkit
-#: view:partner.balance.webkit:0
-#, python-format
-msgid "Partner Balance"
-msgstr "Balance de empresa"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/general_ledger.py:146
-#, python-format
-msgid "Centralized Entries"
-msgstr "Entradas centralizadas"
-
-#. module: account_financial_report_webkit
-#: view:general.ledger.webkit:0
-#: view:partner.balance.webkit:0
-#: view:trial.balance.webkit:0
-msgid "Accounts Filters"
-msgstr "Filtros de cuentas"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:31
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:35
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:44
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:32
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:56
-msgid "Dates Filter"
-msgstr "Filtros de fechas"
-
-#. module: account_financial_report_webkit
-#: constraint:account.move.line:0
-msgid "You can not create journal items on closed account."
-msgstr "No puede crear asientos en cuentas cerradas."
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:64
-#: selection:general.ledger.webkit,display_account:0
-#, python-format
-msgid "With transactions or non zero balance"
-msgstr "Con movimientos o con saldo"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,comp0_filter:0
-#: selection:account.common.balance.report,comp1_filter:0
-#: selection:account.common.balance.report,comp2_filter:0
-#: selection:account.common.balance.report,filter:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:45
-#: code:addons/account_financial_report_webkit/wizard/balance_common.py:156
-#: selection:general.ledger.webkit,filter:0
-#: selection:open.invoices.webkit,filter:0
-#: selection:partner.balance.webkit,comp0_filter:0
-#: selection:partner.balance.webkit,comp1_filter:0
-#: selection:partner.balance.webkit,comp2_filter:0
-#: selection:partner.balance.webkit,filter:0
-#: selection:partners.ledger.webkit,filter:0
-#: selection:trial.balance.webkit,comp0_filter:0
-#: selection:trial.balance.webkit,comp1_filter:0
-#: selection:trial.balance.webkit,comp2_filter:0
-#: selection:trial.balance.webkit,filter:0
-#, python-format
-msgid "Periods"
-msgstr "Periodos"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:112
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:127
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:121
-msgid "Curr. Balance"
-msgstr "Saldo actual"
-
-#. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_account_move_line
-msgid "Journal Items"
-msgstr "Apuntes contables"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:416
-#, python-format
-msgid "Invalid query mode"
-msgstr "Modo de consulta no válido"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:161
-#, python-format
-msgid "Unsuported filter"
-msgstr "Filtro no soportado"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:62
-#, python-format
-msgid "All accounts"
-msgstr "Todas las cuentas"
-
-#. module: account_financial_report_webkit
-#: constraint:account.move.line:0
-msgid ""
-"The selected account of your Journal Entry forces to provide a secondary "
-"currency. You should remove the secondary currency on the account or select "
-"a multi-currency view on the journal."
-msgstr ""
-"La cuenta seleccionada en su asiento fuerza a tener una moneda secundaria. "
-"Debería eliminar la moneda secundaria de la cuenta o asignar al diario una "
-"vista multi-moneda"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:93
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:106
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:102
-msgid "Period"
-msgstr "Período"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/common_reports.py:424
-#, python-format
-msgid "No valid filter"
-msgstr "Sin filtro válido"
-
-#. module: account_financial_report_webkit
-#: view:open.invoices.webkit:0
-msgid "Clearance Analysis Options"
-msgstr "Opciones de análisis de liquidación"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:97
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:110
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:106
-msgid "Journal"
-msgstr "Diario"
-
-#. module: account_financial_report_webkit
-#: field:general.ledger.webkit,amount_currency:0
-#: field:open.invoices.webkit,amount_currency:0
-#: field:partners.ledger.webkit,amount_currency:0
-msgid "With Currency"
-msgstr "Con moneda"
-
-#. module: account_financial_report_webkit
-#: field:open.invoices.webkit,result_selection:0
-#: field:partner.balance.webkit,result_selection:0
-#: field:partners.ledger.webkit,result_selection:0
-msgid "Partner's"
-msgstr "De empresas"
-
-#. module: account_financial_report_webkit
-#: view:general.ledger.webkit:0
-msgid ""
-"This report allows you to print or generate a pdf of your general ledger "
-"with details of all your account journals"
-msgstr ""
-"Este informe le permite imprimir o generar un PDF de su libro mayor con el "
-"detalle de todos sus diarios contables."
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/profit_loss.py:39
-#, python-format
-msgid "PROFIT AND LOSS"
-msgstr "PÉRDIDAS Y GANANCIAS"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,chart_account_id:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:27
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:31
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:40
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:28
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:39
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:52
-#: field:general.ledger.webkit,chart_account_id:0
-#: field:open.invoices.webkit,chart_account_id:0
-#: field:partner.balance.webkit,chart_account_id:0
-#: field:partners.ledger.webkit,chart_account_id:0
-#: field:trial.balance.webkit,chart_account_id:0
-msgid "Chart of Account"
-msgstr "Árbol de cuentas"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:167
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:133
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:148
-msgid "Difference"
-msgstr "Diferencia"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,target_move:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:37
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:42
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:51
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:38
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:49
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:62
-#: field:general.ledger.webkit,target_move:0
-#: field:open.invoices.webkit,target_move:0
-#: field:partner.balance.webkit,target_move:0
-#: field:partners.ledger.webkit,target_move:0
-#: field:trial.balance.webkit,target_move:0
-msgid "Target Moves"
-msgstr "Movimientos destino"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:44
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:49
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:58
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:45
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:56
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:69
-msgid "From:"
-msgstr "De:"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,comp0_date_to:0
-#: field:account.common.balance.report,comp1_date_to:0
-#: field:account.common.balance.report,comp2_date_to:0
-#: field:account.common.balance.report,date_to:0
-#: field:general.ledger.webkit,date_to:0
-#: field:open.invoices.webkit,date_to:0
-#: field:partner.balance.webkit,comp0_date_to:0
-#: field:partner.balance.webkit,comp1_date_to:0
-#: field:partner.balance.webkit,comp2_date_to:0
-#: field:partner.balance.webkit,date_to:0
-#: field:partners.ledger.webkit,date_to:0
-#: field:trial.balance.webkit,comp0_date_to:0
-#: field:trial.balance.webkit,comp1_date_to:0
-#: field:trial.balance.webkit,comp2_date_to:0
-#: field:trial.balance.webkit,date_to:0
-msgid "End Date"
-msgstr "Fecha final"
-
-#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,period_from:0
 #: field:account.common.balance.report,comp0_period_from:0
 #: field:account.common.balance.report,comp1_period_from:0
 #: field:account.common.balance.report,comp2_period_from:0
@@ -1207,6 +1218,7 @@ msgstr "Fecha final"
 #: field:partner.balance.webkit,comp2_period_from:0
 #: field:partner.balance.webkit,period_from:0
 #: field:partners.ledger.webkit,period_from:0
+#: field:print.journal.webkit,period_from:0
 #: field:trial.balance.webkit,comp0_period_from:0
 #: field:trial.balance.webkit,comp1_period_from:0
 #: field:trial.balance.webkit,comp2_period_from:0
@@ -1215,160 +1227,310 @@ msgid "Start Period"
 msgstr "Periodo inicial"
 
 #. module: account_financial_report_webkit
-#: field:open.invoices.webkit,until_date:0
-msgid "Clearance date"
-msgstr "Fecha de liquidación"
+#: code:addons/account_financial_report_webkit/report/trial_balance.py:47
+#, python-format
+msgid "TRIAL BALANCE"
+msgstr "BALANCE DE SUMAS Y SALDOS"
 
 #. module: account_financial_report_webkit
-#: model:ir.model,name:account_financial_report_webkit.model_partners_ledger_webkit
-msgid "Partner Ledger Report"
-msgstr "Libro mayor de empresas"
+#: field:account.aged.trial.balance.webkit,target_move:0
+#: field:account.common.balance.report,target_move:0
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:42
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:44
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:55
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:39
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:34
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:50
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:63
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:60
+#: field:general.ledger.webkit,target_move:0
+#: field:open.invoices.webkit,target_move:0
+#: field:partner.balance.webkit,target_move:0
+#: field:partners.ledger.webkit,target_move:0
+#: field:print.journal.webkit,target_move:0
+#: field:trial.balance.webkit,target_move:0
+msgid "Target Moves"
+msgstr "Movimientos destino"
 
 #. module: account_financial_report_webkit
-#: view:open.invoices.webkit:0
-#: view:partner.balance.webkit:0
-#: view:partners.ledger.webkit:0
-msgid "Partners Filters"
-msgstr "Filtros de empresas"
+#: help:account.aged.trial.balance.webkit,until_date:0
+#: help:open.invoices.webkit,until_date:0
+msgid "The clearance date is essentially a tool used for debtors\n"
+"            provisionning calculation.\n"
+"\n"
+"By default, this date is equal to the the end date (ie: 31/12/2011 if you\n"
+"select fy 2011).\n"
+"\n"
+"By amending the clearance date, you will be, for instance, able to answer the\n"
+"question : 'based on my last year end debtors open invoices, which invoices\n"
+"are still unpaid today (today is my clearance date)?'\n"
+""
+msgstr "The clearance date is essentially a tool used for debtors\n"
+"            provisionning calculation.\n"
+"\n"
+"By default, this date is equal to the the end date (ie: 31/12/2011 if you\n"
+"select fy 2011).\n"
+"\n"
+"By amending the clearance date, you will be, for instance, able to answer the\n"
+"question : 'based on my last year end debtors open invoices, which invoices\n"
+"are still unpaid today (today is my clearance date)?'\n"
+""
 
 #. module: account_financial_report_webkit
-#: selection:account.common.balance.report,comp0_filter:0
-#: field:account.common.balance.report,comp0_fiscalyear_id:0
-#: selection:account.common.balance.report,comp1_filter:0
-#: field:account.common.balance.report,comp1_fiscalyear_id:0
-#: selection:account.common.balance.report,comp2_filter:0
-#: field:account.common.balance.report,comp2_fiscalyear_id:0
-#: field:account.common.balance.report,fiscalyear_id:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:28
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:32
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:41
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:29
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:40
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:53
-#: field:general.ledger.webkit,fiscalyear_id:0
-#: field:open.invoices.webkit,fiscalyear_id:0
-#: selection:partner.balance.webkit,comp0_filter:0
-#: field:partner.balance.webkit,comp0_fiscalyear_id:0
-#: selection:partner.balance.webkit,comp1_filter:0
-#: field:partner.balance.webkit,comp1_fiscalyear_id:0
-#: selection:partner.balance.webkit,comp2_filter:0
-#: field:partner.balance.webkit,comp2_fiscalyear_id:0
-#: field:partner.balance.webkit,fiscalyear_id:0
-#: field:partners.ledger.webkit,fiscalyear_id:0
-#: selection:trial.balance.webkit,comp0_filter:0
-#: field:trial.balance.webkit,comp0_fiscalyear_id:0
-#: selection:trial.balance.webkit,comp1_filter:0
-#: field:trial.balance.webkit,comp1_fiscalyear_id:0
-#: selection:trial.balance.webkit,comp2_filter:0
-#: field:trial.balance.webkit,comp2_fiscalyear_id:0
-#: field:trial.balance.webkit,fiscalyear_id:0
-msgid "Fiscal Year"
-msgstr "Ejercicio fiscal"
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:168
+#, python-format
+msgid "The command 'wkhtmltopdf' failed with                                  error code = %s. Message: %s"
+msgstr "The command 'wkhtmltopdf' failed with                                  error code = %s. Message: %s"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:77
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:94
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:163
+#, python-format
+msgid "The following diagnosis message was provided:\n"
+""
+msgstr "The following diagnosis message was provided:\n"
+""
+
+#. module: account_financial_report_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+msgid "This report allows you to print or generate a pdf of your general ledger with details of all your account journals"
+msgstr "Este informe le permite imprimir o generar un PDF de su libro mayor con el detalle de todos sus diarios contables."
+
+#. module: account_financial_report_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "This report allows you to print or generate a pdf of your open invoices per partner with details of all your payable/receivable account. Exclude full reconciled journal items."
+msgstr "Este informe permite imprimir o generar un PDF de las facturas abiertas (con deuda pendiente) por empresa con detalles de todas las cuentas a pagar/a cobrar. Excluye los apuntes totalmente conciliados."
+
+#. module: account_financial_report_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+msgid "This report allows you to print or generate a pdf of your partner ledger with details of all your payable/receivable account"
+msgstr "Este informe permite imprimir o generar un PDF de su libro mayor de empresas con detalles de todas sus cuentas a cobrar/a pagar."
+
+#. module: account_financial_report_webkit
+#: view:print.journal.webkit:account_financial_report_webkit.account_report_print_journal_view_webkit
+msgid "This report allows you to print or generate a pdf of your print journal with details of all your account journals"
+msgstr "This report allows you to print or generate a pdf of your print journal with details of all your account journals"
+
+#. module: account_financial_report_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "This report allows you to print or generate a pdf of your trial balance allowing you to quickly check the balance of each of your accounts in a single report"
+msgstr "Este informe le permite imprimir o generar un PDF de su balance de sumas y saldos para comprobar con rapidez el saldo de cada una de sus cuentas en un único informe."
+
+#. module: account_financial_report_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+msgid "This report is an analysis done by a partner, It is a PDF report containing one line per partner representing the cumulative credit balance"
+msgstr "Este informe es un análisis realizado por empresa. Es un informe PDF conteniendo una línea por empresa representando su saldo acumulado."
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+msgid "This report list partner open balances and indicate when payment is (or was) supposed to be completed"
+msgstr "This report list partner open balances and indicate when payment is (or was) supposed to be completed"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "Time Filters"
+msgstr "Filtros de tiempo"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:55
+#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:57
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:68
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:52
+#: report:addons/account_financial_report_webkit/report/templates/account_report_print_journal.mako:46
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:63
+#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:76
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:73
+msgid "To:"
+msgstr "A:"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:132
+msgid "Total"
+msgstr "Total"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/trial_balance.py:56
+#: model:ir.actions.act_window,name:account_financial_report_webkit.action_account_trial_balance_menu_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+#, python-format
+msgid "Trial Balance"
+msgstr "Balance de sumas y saldos"
+
+#. module: account_financial_report_webkit
+#: model:ir.model,name:account_financial_report_webkit.model_trial_balance_webkit
+msgid "Trial Balance Report"
+msgstr "Informe de sumas y saldos"
+
+#. module: account_financial_report_webkit
+#: model:ir.actions.report.xml,name:account_financial_report_webkit.account_report_trial_balance_webkit
+msgid "Trial Balance Webkit"
+msgstr "Balance de sumas y saldos webkit"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "True"
+msgstr "True"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:207
+msgid "Unallocated"
+msgstr "Sin asignar"
+
+#. module: account_financial_report_webkit
+#: help:general.ledger.webkit,centralize:0
+msgid "Uncheck to display all the details of centralized accounts."
+msgstr "Desmarque esta casilla para mostrar todos los detalles de las cuentas centralizadas"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:211
+#, python-format
+msgid "Unsuported filter"
+msgstr "Filtro no soportado"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:217
+#, python-format
+msgid "Webkit Report template not found !"
+msgstr "¡Plantilla del informe Webkit no encontrada!"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:167
+#, python-format
+msgid "Webkit error"
+msgstr "Webkit error"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:247
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:258
+#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:274
+#, python-format
+msgid "Webkit render"
+msgstr "Renderizador de Webkit"
+
+#. module: account_financial_report_webkit
+#: constraint:print.journal.webkit:0
+msgid "When no Fiscal year is selected, you must choose                              to filter by periods or by date."
+msgstr "When no Fiscal year is selected, you must choose                              to filter by periods or by date."
+
+#. module: account_financial_report_webkit
+#: constraint:account.common.balance.report:0
+#: constraint:general.ledger.webkit:0
+#: constraint:partner.balance.webkit:0
+#: constraint:trial.balance.webkit:0
+msgid "When no Fiscal year is selected, you must choose to filter by          periods or by date."
+msgstr "When no Fiscal year is selected, you must choose to filter by          periods or by date."
+
+#. module: account_financial_report_webkit
+#: constraint:account.aged.trial.balance.webkit:0
+#: constraint:open.invoices.webkit:0
+#: constraint:partners.ledger.webkit:0
+msgid "When no Fiscal year is selected, you must choose to filter by periods or by date."
+msgstr "Cuando no se selecciona un ejercicio fiscal, debe escoger filtrar por periodos o por fecha."
+
+#. module: account_financial_report_webkit
+#: field:account.aged.trial.balance.webkit,amount_currency:0
+#: field:general.ledger.webkit,amount_currency:0
+#: field:open.invoices.webkit,amount_currency:0
+#: field:partners.ledger.webkit,amount_currency:0
+#: field:print.journal.webkit,amount_currency:0
+msgid "With Currency"
+msgstr "Con moneda"
+
+#. module: account_financial_report_webkit
+#: selection:account.common.balance.report,display_account:0
+#: selection:partner.balance.webkit,display_account:0
+#: selection:print.journal.webkit,display_account:0
+#: selection:trial.balance.webkit,display_account:0
+msgid "With balance is not equal to 0"
+msgstr "Con saldo distinto a 0"
+
+#. module: account_financial_report_webkit
+#: selection:account.common.balance.report,display_account:0
+#: selection:partner.balance.webkit,display_account:0
+#: selection:print.journal.webkit,display_account:0
+#: selection:trial.balance.webkit,display_account:0
+msgid "With movements"
+msgstr "Con movimientos"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/common_reports.py:74
+#: selection:general.ledger.webkit,display_account:0
+#, python-format
+msgid "With transactions or non zero balance"
+msgstr "Con movimientos o con saldo"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:78
+#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:95
 msgid "Yes"
 msgstr "Sí"
 
 #. module: account_financial_report_webkit
-#: selection:account.common.balance.report,comp0_filter:0
-#: selection:account.common.balance.report,comp1_filter:0
-#: selection:account.common.balance.report,comp2_filter:0
-#: selection:partner.balance.webkit,comp0_filter:0
-#: selection:partner.balance.webkit,comp1_filter:0
-#: selection:partner.balance.webkit,comp2_filter:0
-#: selection:trial.balance.webkit,comp0_filter:0
-#: selection:trial.balance.webkit,comp1_filter:0
-#: selection:trial.balance.webkit,comp2_filter:0
-msgid "No Comparison"
-msgstr "Sin comparación"
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:general.ledger.webkit:account_financial_report_webkit.account_report_general_ledger_view_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:partners.ledger.webkit:account_financial_report_webkit.account_partner_ledger_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "[('fiscalyear_id', '=', fiscalyear_id), ('special', '=', False)]"
+msgstr "[('fiscalyear_id', '=', fiscalyear_id), ('special', '=', False)]"
 
 #. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/general_ledger.py:64
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:63
-#: code:addons/account_financial_report_webkit/report/partner_balance.py:63
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:64
-#: code:addons/account_financial_report_webkit/report/profit_loss.py:68
-#: code:addons/account_financial_report_webkit/report/trial_balance.py:64
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:68
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:105
+msgid "balance"
+msgstr "balance"
+
+#. module: account_financial_report_webkit
+#: report:addons/account_financial_report_webkit/report/templates/aged_trial_webkit.mako:103
+msgid "code"
+msgstr "code"
+
+#. module: account_financial_report_webkit
+#: code:addons/account_financial_report_webkit/report/aged_partner_balance.py:102
+#: code:addons/account_financial_report_webkit/report/general_ledger.py:70
+#: code:addons/account_financial_report_webkit/report/open_invoices.py:83
+#: code:addons/account_financial_report_webkit/report/partner_balance.py:71
+#: code:addons/account_financial_report_webkit/report/partners_ledger.py:71
+#: code:addons/account_financial_report_webkit/report/print_journal.py:75
+#: code:addons/account_financial_report_webkit/report/trial_balance.py:71
 #, python-format
-msgid "Page"
-msgstr "Página"
+msgid "of"
+msgstr "de"
 
 #. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:50
-msgid "Partners Filter"
-msgstr "Filtros de empresas"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,display_account:0
-#: report:addons/account_financial_report_webkit/report/templates/account_report_general_ledger.mako:61
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partner_balance.mako:75
-#: report:addons/account_financial_report_webkit/report/templates/account_report_profit_loss.mako:73
-#: report:addons/account_financial_report_webkit/report/templates/account_report_trial_balance.mako:86
-#: selection:general.ledger.webkit,display_account:0
-#: selection:partner.balance.webkit,display_account:0
-#: selection:trial.balance.webkit,display_account:0
-msgid "All"
-msgstr "Todas"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/profit_loss.py:46
-#, python-format
-msgid "Profit and Loss"
-msgstr "Pérdidas y ganancias"
-
-#. module: account_financial_report_webkit
-#: report:addons/account_financial_report_webkit/report/templates/account_report_open_invoices.mako:99
-#: report:addons/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako:95
-msgid "No Partner"
-msgstr "Sin empresa"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/open_invoices.py:41
-#, python-format
-msgid "OPEN INVOICES REPORT"
-msgstr "INFORME DE FACTURAS ABIERTAS"
-
-#. module: account_financial_report_webkit
-#: code:addons/account_financial_report_webkit/report/partners_ledger.py:41
-#: code:addons/account_financial_report_webkit/report/webkit_parser_header_fix.py:58
-#, python-format
-msgid "PARTNER LEDGER"
-msgstr "LIBRO MAYOR DE EMPRESAS"
-
-#. module: account_financial_report_webkit
-#: selection:account.common.balance.report,target_move:0
-#: code:addons/account_financial_report_webkit/report/common_reports.py:84
-#: selection:general.ledger.webkit,target_move:0
-#: selection:open.invoices.webkit,target_move:0
-#: selection:partner.balance.webkit,target_move:0
-#: selection:partners.ledger.webkit,target_move:0
-#: selection:trial.balance.webkit,target_move:0
-#, python-format
-msgid "All Entries"
-msgstr "Todos los asientos"
-
-#. module: account_financial_report_webkit
-#: sql_constraint:account.move.line:0
-msgid "Wrong credit or debit value in accounting entry !"
-msgstr "¡Valor haber o debe erróneo en el asiento contable!"
-
-#. module: account_financial_report_webkit
-#: field:account.common.balance.report,comp0_filter:0
-#: field:account.common.balance.report,comp1_filter:0
-#: field:account.common.balance.report,comp2_filter:0
-#: field:partner.balance.webkit,comp0_filter:0
-#: field:partner.balance.webkit,comp1_filter:0
-#: field:partner.balance.webkit,comp2_filter:0
-#: field:trial.balance.webkit,comp0_filter:0
-#: field:trial.balance.webkit,comp1_filter:0
-#: field:trial.balance.webkit,comp2_filter:0
-msgid "Compare By"
-msgstr "Comparar por"
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "onchange_date_to(fiscalyear_id, period_to, date_to, until_date)"
+msgstr "onchange_date_to(fiscalyear_id, period_to, date_to, until_date)"
 
 #. module: account_financial_report_webkit
 #: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
-msgid "At the end of"
-msgstr "Al final de"
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "onchange_fiscalyear(fiscalyear_id, period_to, date_to, until_date)"
+msgstr "onchange_fiscalyear(fiscalyear_id, period_to, date_to, until_date)"
+
+#. module: account_financial_report_webkit
+#: view:account.aged.trial.balance.webkit:account_financial_report_webkit.account_aged_trial_balance_webkit
+#: view:open.invoices.webkit:account_financial_report_webkit.account_open_invoices_view_webkit
+msgid "onchange_period_to(fiscalyear_id, period_to, date_to, until_date)"
+msgstr "onchange_period_to(fiscalyear_id, period_to, date_to, until_date)"
+
+#. module: account_financial_report_webkit
+#: help:account.move.line,last_rec_date:0
+msgid "the date of the last reconciliation (full or partial)                   account move line"
+msgstr "the date of the last reconciliation (full or partial)                   account move line"
+
+#. module: account_financial_report_webkit
+#: view:partner.balance.webkit:account_financial_report_webkit.account_partner_balance_view_webkit
+#: view:trial.balance.webkit:account_financial_report_webkit.account_trial_balance_view_webkit
+msgid "{'required': [('filter', '=', 'filter_opening')]}"
+msgstr "{'required': [('filter', '=', 'filter_opening')]}"
+

--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -230,8 +230,8 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         return start_period, stop_period, start, stop
 
     def compute_balance_data(self, data, filter_report_type=None):
-        new_ids = data['form']['account_ids'] or data[
-            'form']['chart_account_id']
+        new_ids = (data['form']['account_ids'] or
+                   [data['form']['chart_account_id']])
         max_comparison = self._get_form_param(
             'max_comparison', data, default=0)
         main_filter = self._get_form_param('filter', data, default='filter_no')
@@ -259,10 +259,14 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
             start) or False
 
         # Retrieving accounts
+        ctx = {}
+        if data['form'].get('account_level'):
+            # Filter by account level
+            ctx['account_level'] = int(data['form']['account_level'])
         account_ids = self.get_all_accounts(
-            new_ids, only_type=filter_report_type)
+            new_ids, only_type=filter_report_type, context=ctx)
 
-        # get details for each accounts, total of debit / credit / balance
+        # get details for each account, total of debit / credit / balance
         accounts_by_ids = self._get_account_details(
             account_ids, target_move, fiscalyear, main_filter, start, stop,
             initial_balance_mode)

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -195,8 +195,15 @@ class CommonReportHeaderWebkit(common_report_header):
         acc_obj = self.pool.get('account.account')
         for account_id in account_ids:
             accounts.append(account_id)
-            accounts += acc_obj._get_children_and_consol(
+            children_acc_ids = acc_obj._get_children_and_consol(
                 self.cursor, self.uid, account_id, context=context)
+            if context.get('account_level'):
+                domain = [('level', '<=', context['account_level']),
+                          ('id', 'in', children_acc_ids)]
+                accounts += self.pool['account.account'].search(
+                    self.cursor, self.uid, domain)
+            else:
+                accounts += children_acc_ids
         res_ids = list(set(accounts))
         res_ids = self.sort_accounts_with_structure(
             account_ids, res_ids, context=context)

--- a/account_financial_report_webkit/wizard/balance_common.py
+++ b/account_financial_report_webkit/wizard/balance_common.py
@@ -96,6 +96,11 @@ class AccountBalanceCommonWizard(orm.TransientModel):
             help='Filter by date: no opening balance will be displayed. '
             '(opening balance can only be computed based on period to be \
             correct).'),
+        # Set statically because of the impossibility of changing the selection
+        # field when changing chart_account_id
+        'account_level': fields.selection(
+            [('1', '1'), ('2', '2'), ('3', '3'), ('4', '4'), ('5', '5'),
+             ('6', '6')], string="Account level"),
     }
 
     for index in range(COMPARISON_LEVEL):
@@ -394,7 +399,7 @@ class AccountBalanceCommonWizard(orm.TransientModel):
         # will be used to attach the report on the main account
         data['ids'] = [data['form']['chart_account_id']]
 
-        fields_to_read = ['account_ids', ]
+        fields_to_read = ['account_ids', 'account_level']
         fields_to_read += self.DYNAMIC_FIELDS
         vals = self.read(cr, uid, ids, fields_to_read, context=context)[0]
 

--- a/account_financial_report_webkit/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/trial_balance_wizard_view.xml
@@ -22,6 +22,9 @@
                     <page name="filters" position="after">
                         <page string="Accounts Filters" name="accounts">
                             <separator string="Print only" colspan="4"/>
+                            <group>
+                                <field name="account_level"/>
+                            </group>
                             <field name="account_ids" colspan="4" nolabel="1" domain="[('type', '=', 'view')]">
                                 <tree>
                                     <field name="code"/>


### PR DESCRIPTION
This PR allows to select an account level to filter accounts by this criteria, which is very common here in Spain. The default behaviour is to leave it blank, so there's no different behaviour in this case. If you select one level, all the remaining accounts selected from the rest of the criteria will be filtered out if their account level is higher than the selected one.
