### PR TITLE
[8.0][mis_builder][ADD] mis_builder_analytic_filter

### DIFF
--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -1,3 +1,7 @@
+/* © 2014-2016 ACSONE SA/NV
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). 
+ */
+
 openerp.mis_builder = function(instance) {
 
     instance.mis_builder.MisReport = instance.web.form.FormWidget.extend({

--- a/mis_builder_analytic_filter/README.rst
+++ b/mis_builder_analytic_filter/README.rst
@@ -1,0 +1,74 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+===========================
+MIS Builder Analytic Filter
+===========================
+
+This module extends the functionality of mis_builder to
+provide filtering on analytic axis.
+
+Installation
+============
+
+There is no specific installation procedure for this module.
+
+Configuration and Usage
+=======================
+
+In Accounting > Reporting > MIS Reports, there is a new field
+'Analytic Account' which can be used to filter move line on an
+analytic axis and it's children.
+
+This filter is also available on the MIS Report widget, so the user
+can change the filter in the preview and dashboard views.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/91/8.0
+
+Known issues / Roadmap
+======================
+
+While useful as is, we are aware that such analytic filtering may need
+to be customized heavily depending on the customer context. This module can
+be extended or considered as an example.
+
+* at the moment, no filtering is done on other queries than move lines
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-financial-reporting/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+account-financial-reporting/issues/new?body=module:%20
+mis_builder_analytic_filter%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Adrien Peiffer <adrien.peiffer@acsone.eu>
+* Stéphane Bidoul <stephane.bidoul@acsone.eu>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/mis_builder_analytic_filter/README.rst
+++ b/mis_builder_analytic_filter/README.rst
@@ -18,7 +18,7 @@ Configuration and Usage
 =======================
 
 In Accounting > Reporting > MIS Reports, there is a new field
-'Analytic Account' which can be used to filter move line on an
+'Analytic Account' which can be used to filter move lines on an
 analytic axis and it's children.
 
 This filter is also available on the MIS Report widget, so the user
@@ -31,11 +31,11 @@ can change the filter in the preview and dashboard views.
 Known issues / Roadmap
 ======================
 
-While useful as is, we are aware that such analytic filtering may need
-to be customized heavily depending on the customer context. This module can
-be extended or considered as an example.
+* While useful as is, we are aware that such analytic filtering may need
+  to be customized heavily depending on the customer context. This module can
+  be extended or considered as an example.
 
-* at the moment, no filtering is done on other queries than move lines
+* At the moment, no filtering is done on other queries than move lines.
 
 Bug Tracker
 ===========

--- a/mis_builder_analytic_filter/__init__.py
+++ b/mis_builder_analytic_filter/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/mis_builder_analytic_filter/__openerp__.py
+++ b/mis_builder_analytic_filter/__openerp__.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': "MIS Builder Analytic Axis Filter",
+    'version': '8.0.1.0.0',
+    'category': 'Reporting',
+    'summary': """
+        Add analytic filters to MIS Reports
+    """,
+    'author': 'ACSONE SA/NV,'
+              'Odoo Community Association (OCA)',
+    'website': "http://acsone.eu",
+    'license': 'AGPL-3',
+    'depends': [
+        'mis_builder',
+    ],
+    'data': [
+        'views/mis_report_view.xml',
+        'views/mis_builder_analytic.xml',
+    ],
+    'qweb': [
+        'static/src/xml/mis_widget.xml'
+    ],
+}

--- a/mis_builder_analytic_filter/models/__init__.py
+++ b/mis_builder_analytic_filter/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import mis_report

--- a/mis_builder_analytic_filter/models/mis_report.py
+++ b/mis_builder_analytic_filter/models/mis_report.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models
+
+
+class MisReportInstance(models.Model):
+    _inherit = 'mis.report.instance'
+
+    account_analytic_id = fields.Many2one(
+        comodel_name='account.analytic.account', string='Analytic Account')
+
+    @api.multi
+    def preview(self):
+        self.ensure_one()
+        res = super(MisReportInstance, self).preview()
+        res['context'] = {
+            'account_analytic_id': self.account_analytic_id.id,
+        }
+        return res
+
+
+class MisReportInstancePeriod(models.Model):
+    _inherit = 'mis.report.instance.period'
+
+    @api.multi
+    def _get_additional_move_line_filter(self):
+        self.ensure_one()
+        res = super(MisReportInstancePeriod, self).\
+            _get_additional_move_line_filter()
+        val = self.env.context.get('account_analytic_id')
+        if val:
+            res.append(('analytic_account_id', 'child_of', val))
+        return res
+
+    @api.multi
+    def _get_additional_query_filter(self, query):
+        self.ensure_one()
+        res = super(MisReportInstancePeriod, self).\
+            _get_additional_move_line_filter()
+        # TODO filter on analytic account if query.model_id has
+        #      a field of type account.analytic.account
+        return res

--- a/mis_builder_analytic_filter/static/src/js/mis_builder.js
+++ b/mis_builder_analytic_filter/static/src/js/mis_builder.js
@@ -30,7 +30,12 @@ openerp.mis_builder_analytic_filter = function(instance) {
             var self = this;
             if (self.dfm)
                 return;
-            self.$(".oe_mis_builder_analytic_axis").show();
+            var Users = new instance.web.Model('res.users');
+            Users.call('has_group', ['analytic.group_analytic_accounting']).done(function (res) {
+                if (res) {
+                    self.$(".oe_mis_builder_analytic_axis").css('visibility', 'visible');
+                }
+            });
             self.dfm = new instance.web.form.DefaultFieldManager(self);
             self.dfm.extend_field_desc({
                 account: {

--- a/mis_builder_analytic_filter/static/src/js/mis_builder.js
+++ b/mis_builder_analytic_filter/static/src/js/mis_builder.js
@@ -1,0 +1,72 @@
+openerp.mis_builder_analytic_filter = function(instance) {
+
+    instance.mis_builder.MisReport.include({
+
+        init: function() {
+            this._super.apply(this, arguments);
+            this.account_analytic_id = false;
+            this.initialized = false;
+            this.mis_report_instance_id = false;
+        },
+        initialize_field: function() {
+            var self = this;
+            self.destroy_content();
+            self.init_fields();
+        },
+        destroy_content: function() {
+            if (this.dfm) {
+                this.dfm.destroy();
+                this.dfm = undefined;
+            }
+        },
+        get_context: function() {
+            var self = this;
+            context = this._super.apply(this, arguments);
+            context['account_analytic_id'] = this.account_analytic_id;
+            return context
+        },
+        init_fields: function() {
+            var self = this;
+            if (self.dfm)
+                return;
+            self.$(".oe_mis_builder_analytic_axis").show();
+            self.dfm = new instance.web.form.DefaultFieldManager(self);
+            self.dfm.extend_field_desc({
+                account: {
+                    relation: "account.analytic.account",
+                },
+            });
+            self.account_m2o = new instance.web.form.FieldMany2One(self.dfm, {
+                attrs: {
+                    placeholder: _t("Analytic Account"),
+                    name: "account",
+                    type: "many2one",
+                    domain: [],
+                    context: {},
+                    modifiers: '{}',
+                },
+            });
+            if (this.initialized) {
+                self.account_m2o.set('value', this.account_analytic_id);
+            } else {
+                val = self.getParent().dataset.context.account_analytic_id
+                if (val) {
+                    self.account_m2o.set('value', val);
+                    this.account_analytic_id = val
+                }
+                this.initialized = true;
+            }
+            self.account_m2o.prependTo(self.$(".oe_mis_builder_analytic_axis"));
+            self.account_m2o.$input.focusout(function(){
+                self.account_analytic_id = self.account_m2o.get_value();
+            });
+            self.$(".oe_mis_builder_generate_content").click(_.bind(this.generate_content, this));
+        },
+        renderElement: function() {
+            this._super();
+            var self = this;
+            self.initialize_field();
+        },
+
+});
+}

--- a/mis_builder_analytic_filter/static/src/js/mis_builder.js
+++ b/mis_builder_analytic_filter/static/src/js/mis_builder.js
@@ -1,4 +1,5 @@
 openerp.mis_builder_analytic_filter = function(instance) {
+    var _t = instance.web._t;
 
     instance.mis_builder.MisReport.include({
 

--- a/mis_builder_analytic_filter/static/src/js/mis_builder.js
+++ b/mis_builder_analytic_filter/static/src/js/mis_builder.js
@@ -1,3 +1,7 @@
+/* © 2016 ACSONE SA/NV
+ * License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). 
+ */
+
 openerp.mis_builder_analytic_filter = function(instance) {
     var _t = instance.web._t;
 

--- a/mis_builder_analytic_filter/static/src/xml/mis_widget.xml
+++ b/mis_builder_analytic_filter/static/src/xml/mis_widget.xml
@@ -1,0 +1,10 @@
+<template>
+    <t t-extend="mis_builder.MisReport">
+        <t t-jquery=".oe_mis_builder_buttons" t-operation="prepend">
+            <button class="oe_mis_builder_generate_content"><img src="/web/static/src/img/icons/gtk-refresh.png"/> Refresh</button>
+        </t>
+        <t t-jquery=".oe_mis_builder_buttons" t-operation="after">
+            <div class="oe_mis_builder_analytic_axis" style="position: relative; display: inline-block;"></div>
+        </t>
+    </t>
+</template>

--- a/mis_builder_analytic_filter/static/src/xml/mis_widget.xml
+++ b/mis_builder_analytic_filter/static/src/xml/mis_widget.xml
@@ -4,7 +4,7 @@
             <button class="oe_mis_builder_generate_content"><img src="/web/static/src/img/icons/gtk-refresh.png"/> Refresh</button>
         </t>
         <t t-jquery=".oe_mis_builder_buttons" t-operation="after">
-            <div class="oe_mis_builder_analytic_axis" style="position: relative; display: inline-block;"></div>
+            <div class="oe_mis_builder_analytic_axis" style="visibility: hidden; position: relative; display: inline-block;"></div>
         </t>
     </t>
 </template>

--- a/mis_builder_analytic_filter/views/mis_builder_analytic.xml
+++ b/mis_builder_analytic_filter/views/mis_builder_analytic.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+       <template id="assets_backend" name="mis_builder_analytic_filter" inherit_id="web.assets_backend">
+            <xpath expr="." position="inside">
+                <script type="text/javascript" src="/mis_builder_analytic_filter/static/src/js/mis_builder.js"></script>
+            </xpath>
+        </template>
+    </data>
+</openerp>

--- a/mis_builder_analytic_filter/views/mis_report_view.xml
+++ b/mis_builder_analytic_filter/views/mis_report_view.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record model="ir.ui.view" id="mis_report_instance_view_form">
+            <field name="name">mis.report.instance.view.form (mis_builder_analytic_filter)</field>
+            <field name="model">mis.report.instance</field>
+            <field name="inherit_id" ref="mis_builder.mis_report_instance_view_form" />
+            <field name="arch" type="xml">
+                <field name='target_move' position="after">
+                    <field name="account_analytic_id" />
+                </field>
+            </field>
+         </record>
+    </data>
+</openerp>

--- a/mis_builder_analytic_filter/views/mis_report_view.xml
+++ b/mis_builder_analytic_filter/views/mis_report_view.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="mis_builder.mis_report_instance_view_form" />
             <field name="arch" type="xml">
                 <field name='target_move' position="after">
-                    <field name="account_analytic_id" />
+                    <field name="account_analytic_id" groups="analytic.group_analytic_accounting"/>
                 </field>
             </field>
          </record>


### PR DESCRIPTION
Add analytic filtering on mis_builder reports. The filter is static (in the MIS Report instance configuration form) but also dynamic (in the preview and dashboard view) so the user can change analytic account on the fly.
- [x] Depends on #151 

![image](https://cloud.githubusercontent.com/assets/692075/13554436/15ad4016-e3a8-11e5-8011-e88692eca0b5.png)
