### PR TITLE
[IMP][mis_builder] Improve usability : Display directly report instance instead of report instance settings.

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -636,7 +636,7 @@ class MisReportInstance(models.Model):
             'view_mode': 'form',
             'view_type': 'form',
             'view_id': view_id.id,
-            'target': 'new',
+            'target': 'current',
         }
 
     @api.multi
@@ -663,6 +663,21 @@ class MisReportInstance(models.Model):
             'report_name': 'mis.report.instance.xls',
             'report_type': 'xls',
             'context': self.env.context,
+        }
+
+    @api.multi
+    def display_settings(self):
+        self.ensure_one()
+        view_id = self.env.ref('mis_builder.mis_report_instance_view_form')
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'mis.report.instance',
+            'res_id': self.id,
+            'view_mode': 'form',
+            'view_type': 'form',
+            'views': [(view_id.id, 'form')],
+            'view_id': view_id.id,
+            'target': 'current',
         }
 
     @api.multi

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -667,12 +667,12 @@ class MisReportInstance(models.Model):
 
     @api.multi
     def display_settings(self):
-        self.ensure_one()
+        assert len(self._ids) <= 1
         view_id = self.env.ref('mis_builder.mis_report_instance_view_form')
         return {
             'type': 'ir.actions.act_window',
             'res_model': 'mis.report.instance',
-            'res_id': self.id,
+            'res_id': self.id if self.id else False,
             'view_mode': 'form',
             'view_type': 'form',
             'views': [(view_id.id, 'form')],

--- a/mis_builder/static/src/css/custom.css
+++ b/mis_builder/static/src/css/custom.css
@@ -11,3 +11,7 @@
   /* underline links on hover to give a visual cue */
   text-decoration: underline;
 }
+
+.openerp .oe_mis_builder_buttons {
+  padding-bottom: 10px;
+}

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -7,13 +7,20 @@ openerp.mis_builder = function(instance) {
             this._super.apply(this, arguments);
             this.mis_report_data = null;
             this.mis_report_instance_id = false;
+            this.field_manager.on("view_content_has_changed", this, this.reload_widget);
+        },
+
+        reload_widget: function() {
+            var self = this
+            self.mis_report_instance_id = self.getParent().datarecord.id
+            self.generate_content();
         },
         
         start: function() {
             this._super.apply(this, arguments);
             var self = this;
-            self.mis_report_instance_id = self.getParent().dataset.context.active_id
-            self.getParent().dataset.context['no_destroy'] = true;
+            self.mis_report_instance_id = self.getParent().datarecord.id
+            //self.getParent().dataset.context['no_destroy'] = true;
             self.generate_content();
         },
         
@@ -44,9 +51,18 @@ openerp.mis_builder = function(instance) {
                 [self.mis_report_instance_id], 
                 {'context': context}
             ).then(function(result){
-                self.do_action(result).done(function(result){
-                    a = 2;
-                });
+                self.do_action(result);
+            });
+        },
+        display_settings: function() {
+            var self = this
+            context = new instance.web.CompoundContext(self.build_context(), self.get_context()|| {})
+            new instance.web.Model("mis.report.instance").call(
+                "display_settings", 
+                [self.mis_report_instance_id], 
+                {'context': context}
+            ).then(function(result){
+                self.do_action(result);
             });
         },
         generate_content: function() {
@@ -66,6 +82,7 @@ openerp.mis_builder = function(instance) {
             var self = this;
             self.$(".oe_mis_builder_print").click(_.bind(this.print, this));
             self.$(".oe_mis_builder_export").click(_.bind(this.export_pdf, this));
+            self.$(".oe_mis_builder_settings").click(_.bind(this.display_settings, this));
         },
         events: {
             "click a.mis_builder_drilldown": "drilldown",

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -83,6 +83,12 @@ openerp.mis_builder = function(instance) {
             self.$(".oe_mis_builder_print").click(_.bind(this.print, this));
             self.$(".oe_mis_builder_export").click(_.bind(this.export_pdf, this));
             self.$(".oe_mis_builder_settings").click(_.bind(this.display_settings, this));
+            var Users = new instance.web.Model('res.users');
+            Users.call('has_group', ['account.group_account_user']).done(function (res) {
+                if (res) {
+                    self.$(".oe_mis_builder_settings").show();
+                }
+            });
         },
         events: {
             "click a.mis_builder_drilldown": "drilldown",

--- a/mis_builder/static/src/js/mis_builder.js
+++ b/mis_builder/static/src/js/mis_builder.js
@@ -13,15 +13,23 @@ openerp.mis_builder = function(instance) {
         reload_widget: function() {
             var self = this
             self.mis_report_instance_id = self.getParent().datarecord.id
-            self.generate_content();
+            if (self.mis_report_instance_id) {
+                self.generate_content();
+            } else {
+                self.display_settings();
+            }
         },
         
         start: function() {
             this._super.apply(this, arguments);
             var self = this;
             self.mis_report_instance_id = self.getParent().datarecord.id
-            //self.getParent().dataset.context['no_destroy'] = true;
-            self.generate_content();
+            if (self.mis_report_instance_id) {
+                self.getParent().dataset.context['no_destroy'] = true;
+                self.generate_content();
+            } else {
+                self.display_settings();
+            }
         },
         
         get_context: function() {

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -4,7 +4,7 @@
             <div class="oe_mis_builder_buttons oe_right">
                 <button class="oe_mis_builder_print"><img src="/web/static/src/img/icons/gtk-print.png"/> Print</button>
                 <button class="oe_mis_builder_export"><img src="/web/static/src/img/icons/gtk-go-down.png"/>Export</button>
-                <button class="oe_mis_builder_settings"><img src="/web/static/src/img/icons/gtk-execute.png"/> Settings</button>
+                <button style="display: none;" class="oe_mis_builder_settings"><img src="/web/static/src/img/icons/gtk-execute.png"/> Settings</button>
             </div>
             <table t-if="widget.mis_report_data" class="oe_list_content mis_builder">
                 <thead>

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -3,7 +3,8 @@
         <div class="oe_mis_builder_content">
             <div class="oe_mis_builder_buttons oe_right">
                 <button class="oe_mis_builder_print"><img src="/web/static/src/img/icons/gtk-print.png"/> Print</button>
-                <button class="oe_mis_builder_export"><img src="/web/static/src/img/icons/gtk-execute.png"/>Export</button>
+                <button class="oe_mis_builder_export"><img src="/web/static/src/img/icons/gtk-go-down.png"/>Export</button>
+                <button class="oe_mis_builder_settings"><img src="/web/static/src/img/icons/gtk-execute.png"/> Settings</button>
             </div>
             <table t-if="widget.mis_report_data" class="oe_list_content mis_builder">
                 <thead>

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -120,7 +120,7 @@
         <record model="ir.ui.view" id="mis_report_instance_result_view_form">
             <field name="name">mis.report.instance.result.view.form</field>
             <field name="model">mis.report.instance</field>
-            <field name="priority" eval="17"/>
+            <field name="priority" eval="15 "/>
             <field name="arch" type="xml">
                 <form string="MIS Report Result" version="7.0">
                     <widget type="mis_report"></widget>
@@ -139,6 +139,7 @@
                     <field name="target_move"/>
                     <field name="pivot_date"/>
                     <field name="company_id"/>
+                    <button name="display_settings" type="object" icon="gtk-execute" />
                 </tree>
             </field>
         </record>
@@ -161,7 +162,7 @@
                     <div class="oe_right oe_button_box" name="buttons"> 
                         <button type="object" name="preview" string="Preview" icon="gtk-print-preview" />
                         <button type="object" name="print_pdf" string="Print" icon="gtk-print" />
-                        <button type="object" name="export_xls" string="Export" icon="gtk-execute" />
+                        <button type="object" name="export_xls" string="Export" icon="gtk-go-down" />
                         <button type="action" name="%(mis_report_instance_add_to_dashboard_action)d" string="Add to dashboard" icon="gtk-add" />
                     </div>
                     <group col="4">


### PR DESCRIPTION
Currently on mis.report.instance list view, when the user click on a mis.report.instance that open a form which mise.report.instance configuration. This PR changes this behavior to open directly the report (Currently, this is the preview). It also adds a button on mis.report.instance list to directly access to the parameters.
