### PR TITLE
[IMP] mis_builder: removed unused argument

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -6,6 +6,13 @@ Changelog
 ..
 .. *
 
+9.0.2.0.1 (2016-05-26)
+~~~~~~~~~~~~~~~~~~~~~~
+
+* [IMP] remove unused argument in declare_and_compute_period()
+  for a cleaner API. This is a breaking API changing merged in
+  urgency before it is used by other modules.
+
 9.0.2.0.0 (2016-05-24)
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/mis_builder/__openerp__.py
+++ b/mis_builder/__openerp__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'MIS Builder',
-    'version': '9.0.2.0.0',
+    'version': '9.0.2.0.1',
     'category': 'Reporting',
     'summary': """
         Build 'Management Information System' Reports and Dashboards

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -872,7 +872,6 @@ class MisReport(models.Model):
                                    aep,
                                    date_from, date_to,
                                    target_move,
-                                   company,
                                    subkpis_filter=None,
                                    get_additional_move_line_filter=None,
                                    get_additional_query_filter=None):
@@ -885,7 +884,6 @@ class MisReport(models.Model):
                     using _prepare_aep()
         :param date_from, date_to: the starting and ending date
         :param target_move: all|posted
-        :param company:
         :param get_additional_move_line_filter: a bound method that takes
                                                 no arguments and returns
                                                 a domain compatible with

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -376,7 +376,6 @@ class MisReportInstance(models.Model):
                 period.date_from,
                 period.date_to,
                 self.target_move,
-                self.company_id,
                 period.subkpi_ids,
                 period._get_additional_move_line_filter,
                 period._get_additional_query_filter)


### PR DESCRIPTION
Was forgotten in 53192385fb67590b83ae0f425b7ed7dda49f4a35

The company is now part of AEP properties.
