### PR TITLE
8.0 Fix bug #200 "execv() arg 2 must contain only strings"

### DIFF
--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -151,6 +151,9 @@ class HeaderFooterTextWebKitParser(webkit_report.WebKitParser):
         stderr_fd, stderr_path = tempfile.mkstemp(text=True)
         file_to_del.append(stderr_path)
         try:
+            from unidecode import unidecode
+            command = [unidecode(entry) for entry in command]
+            _logger.debug('subprocess called with command=%s', command)
             status = subprocess.call(command, stderr=stderr_fd)
             os.close(stderr_fd)  # ensure flush before reading
             stderr_fd = None  # avoid closing again in finally block


### PR DESCRIPTION
This is a possible fix for bug #200 Crash in account_financial_report_webkit "execv() arg 2 must contain only strings" 

It is certainly not the best solution to the problem, but at least it fixes the issue.
You need to have the unidecode lib installed
