### PR TITLE
add an option in partner balance for non-zero only

### DIFF
--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -23,6 +23,8 @@
 from collections import defaultdict
 from operator import add
 
+from openerp.tools.float_utils import float_is_zero
+
 from .common_balance_reports import CommonBalanceReportHeaderWebkit
 from .common_partner_reports import CommonPartnersReportHeaderWebkit
 
@@ -83,9 +85,11 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
                     details[partner_id].get('credit', 0.0)
 
             if display_partner == 'non-zero_balance':
-                details = {k: v
-                           for k, v in details.iteritems()
-                           if abs(v['balance']) > 0.0001}
+                details = {
+                    k: v
+                    for k, v in details.iteritems()
+                    if not float_is_zero(v['balance'], precision_digits=5)
+                }
             res[account_id] = details
 
         return res

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -36,7 +36,8 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
     def _get_account_partners_details(self, account_by_ids, main_filter,
                                       target_move, start, stop,
                                       initial_balance_mode,
-                                      partner_filter_ids=False):
+                                      partner_filter_ids=False,
+                                      display_partner='all'):
         res = {}
         filter_from = False
         if main_filter in ('filter_period', 'filter_no', 'filter_opening'):
@@ -80,6 +81,11 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
                     get('init_balance', 0.0) + \
                     details[partner_id].get('debit', 0.0) - \
                     details[partner_id].get('credit', 0.0)
+
+            if display_partner == 'non-zero_balance':
+                details = {k: v
+                           for k, v in details.iteritems()
+                           if abs(v['balance']) > 0.0001}
             res[account_id] = details
 
         return res
@@ -201,7 +207,9 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
             partner_details_by_ids = self._get_account_partners_details(
                 accounts_by_ids, details_filter,
                 target_move, start, stop, initial_balance_mode,
-                partner_filter_ids=partner_filter_ids)
+                partner_filter_ids=partner_filter_ids,
+                display_partner=data['form']['display_partner']
+            )
 
             for account_id in account_ids:
                 accounts_details_by_ids[account_id][
@@ -263,7 +271,8 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
 
         partner_details_by_ids = self._get_account_partners_details(
             accounts_by_ids, main_filter, target_move, start, stop,
-            initial_balance_mode, partner_filter_ids=partner_ids)
+            initial_balance_mode, partner_filter_ids=partner_ids,
+            display_partner=data['form']['display_partner'])
 
         comparison_params = []
         comp_accounts_by_ids = []

--- a/account_financial_report_webkit/wizard/partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard.py
@@ -28,7 +28,7 @@ class AccountPartnerBalanceWizard(models.TransientModel):
     # same field in the module account
     display_partner = fields.Selection(
         [
-            ('non-zero_balance', 'With balance is not equal to 0'),
+            ('non-zero_balance', 'With non-zero balance'),
             ('all', 'All Partners')
         ], 'Display Partners', default='all')
 

--- a/account_financial_report_webkit/wizard/partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard.py
@@ -1,28 +1,11 @@
-# -*- encoding: utf-8 -*-
-##############################################################################
-#
-#    Author: Guewen Baconnier
-#    Copyright Camptocamp SA 2011
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# -*- coding: utf-8 -*-
+# Author: Guewen Baconnier, Leonardo Pistone
+# © 2011-2016 Camptocamp
 
-from openerp.osv import fields, orm
+from openerp import fields, models, api
 
 
-class AccountPartnerBalanceWizard(orm.TransientModel):
+class AccountPartnerBalanceWizard(models.TransientModel):
 
     """Will launch partner balance report and pass required args"""
 
@@ -30,34 +13,29 @@ class AccountPartnerBalanceWizard(orm.TransientModel):
     _name = "partner.balance.webkit"
     _description = "Partner Balance Report"
 
-    _columns = {
-        'result_selection': fields.selection(
+    result_selection = fields.Selection(
             [('customer', 'Receivable Accounts'),
              ('supplier', 'Payable Accounts'),
              ('customer_supplier', 'Receivable and Payable Accounts')],
-            "Partner's", required=True),
-        'partner_ids': fields.many2many(
+            "Partner's", required=True, default='customer_supplier')
+    partner_ids = fields.Many2many(
             'res.partner', string='Filter on partner',
-            help="Only selected partners will be printed. \
-                  Leave empty to print all partners."),
-    }
+            help="Only selected partners will be printed. "
+                 "Leave empty to print all partners.")
 
-    _defaults = {
-        'result_selection': 'customer_supplier',
-    }
+    @api.multi
+    def pre_print_report(self, data):
+        self.ensure_one()
 
-    def pre_print_report(self, cr, uid, ids, data, context=None):
-        data = super(AccountPartnerBalanceWizard, self).\
-            pre_print_report(cr, uid, ids, data, context)
-        vals = self.read(cr, uid, ids,
-                         ['result_selection', 'partner_ids'],
-                         context=context)[0]
+        data = super(AccountPartnerBalanceWizard, self).pre_print_report(data)
+        vals = self.read(['result_selection', 'partner_ids'])[0]
         data['form'].update(vals)
         return data
 
-    def _print_report(self, cursor, uid, ids, data, context=None):
+    @api.multi
+    def _print_report(self, data):
         # we update form with display account value
-        data = self.pre_print_report(cursor, uid, ids, data, context=context)
+        data = self.pre_print_report(data)
 
         return {'type': 'ir.actions.report.xml',
                 'report_name': 'account.account_report_partner_balance_webkit',

--- a/account_financial_report_webkit/wizard/partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard.py
@@ -14,21 +14,31 @@ class AccountPartnerBalanceWizard(models.TransientModel):
     _description = "Partner Balance Report"
 
     result_selection = fields.Selection(
-            [('customer', 'Receivable Accounts'),
-             ('supplier', 'Payable Accounts'),
-             ('customer_supplier', 'Receivable and Payable Accounts')],
-            "Partner's", required=True, default='customer_supplier')
+        [
+            ('customer', 'Receivable Accounts'),
+            ('supplier', 'Payable Accounts'),
+            ('customer_supplier', 'Receivable and Payable Accounts')
+        ],
+        "Partner's", required=True, default='customer_supplier')
     partner_ids = fields.Many2many(
-            'res.partner', string='Filter on partner',
-            help="Only selected partners will be printed. "
-                 "Leave empty to print all partners.")
+        'res.partner', string='Filter on partner',
+        help="Only selected partners will be printed. "
+        "Leave empty to print all partners.")
+
+    # same field in the module account
+    display_partner = fields.Selection(
+        [
+            ('non-zero_balance', 'With balance is not equal to 0'),
+            ('all', 'All Partners')
+        ], 'Display Partners', default='all')
 
     @api.multi
     def pre_print_report(self, data):
         self.ensure_one()
 
         data = super(AccountPartnerBalanceWizard, self).pre_print_report(data)
-        vals = self.read(['result_selection', 'partner_ids'])[0]
+        vals = self.read(['result_selection', 'partner_ids',
+                          'display_partner'])[0]
         data['form'].update(vals)
         return data
 

--- a/account_financial_report_webkit/wizard/partner_balance_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/partner_balance_wizard_view.xml
@@ -22,6 +22,8 @@
                     <field name="target_move" position="after">
                         <newline/>
                         <field name="result_selection" colspan="4"/>
+                        <newline/>
+                        <field name="display_partner" colspan="4"/>
                     </field>
                     <page name="filters" position="after">
                         <page string="Accounts Filters" name="accounts">


### PR DESCRIPTION
This options exists in the partner balance from the account module. It
was not there in the webkit module though. The naming is the same as
from the odoo module.

A very old commit message for the webkit report mentions this
functionality but apparently it is not there.

By default all partners are shown as before. This option works for both
PDF and XLS reports.
