### PR TITLE
Fix comparison between balances

### DIFF
--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -312,7 +312,8 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
             for comp_account_by_id in comp_accounts_by_ids:
                 values = comp_account_by_id.get(account.id)
                 values.update(
-                    self._get_diff(account.balance, values['balance']))
+                    self._get_diff(balance_accounts[account.id],
+                                   values['balance']))
                 display_account = any((values.get('credit', 0.0),
                                        values.get('debit', 0.0),
                                        values.get('balance', 0.0),

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -306,7 +306,7 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
                 values = comp_account_by_id.get(account.id)
 
                 values['account'].update(
-                    self._get_diff(account.balance,
+                    self._get_diff(balance_accounts[account.id],
                                    values['account'].get('balance', 0.0)))
                 comp_accounts.append(values)
 


### PR DESCRIPTION
Small PR to fix an issue in 8.0 comparison reports : the account's current balance was used instead of the computed one (for example, if you filtered on some periods).
