### PR TITLE
[9.0] fix mis_builder menus in Odoo enterprise

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -164,7 +164,8 @@
             <field name="view_mode">tree,form</field>
         </record>
 
-        <menuitem id="mis_report_view_menu" parent="account.menu_account_reports" name="MIS Report Templates" action="mis_report_view_action" sequence="21"/>
+        <menuitem id="mis_report_conf_menu" parent="account.menu_finance_configuration" name="MIS Reporting" sequence="90"/>
+        <menuitem id="mis_report_view_menu" parent="mis_report_conf_menu" name="MIS Report Templates" action="mis_report_view_action" sequence="21"/>
 
     </data>
 </openerp>

--- a/mis_builder/views/mis_report_style.xml
+++ b/mis_builder/views/mis_report_style.xml
@@ -74,7 +74,7 @@
             <field name="view_mode">tree,form</field>
         </record>
 
-        <menuitem id="mis_report_style_view_menu" parent="account.menu_account_reports" name="MIS Report Styles" action="mis_report_style_view_action" sequence="22"/>
+        <menuitem id="mis_report_style_view_menu" parent="mis_report_conf_menu" name="MIS Report Styles" action="mis_report_style_view_action" sequence="22"/>
 
     </data>
 </openerp>


### PR DESCRIPTION
Put configuration items on configuration menu which is not dropped by the
enterprise install.

Fixes #208
