### PR TITLE
[9.0][IMP] mis_builder css improvements for compatibility with Odoo 9e

### DIFF
--- a/mis_builder/static/src/css/custom.css
+++ b/mis_builder/static/src/css/custom.css
@@ -1,21 +1,21 @@
-.openerp .mis_builder_amount {
+.o_web_client .mis_builder_amount {
   text-align: right;
 }
 
-.openerp .mis_builder_collabel {
+.o_web_client .mis_builder_collabel {
   text-align: center;
 }
 
-.openerp .mis_builder_rowlabel {
+.o_web_client .mis_builder_rowlabel {
   text-align: left;
 }
 
-.openerp .mis_builder a {
+.o_web_client .mis_builder a {
   /* we don't want the link color, to respect user styles */
   color: inherit;
 }
 
-.openerp .mis_builder a:hover {
+.o_web_client .mis_builder a:hover {
   /* underline links on hover to give a visual cue */
   text-decoration: underline;
 }
@@ -26,53 +26,5 @@
 }
 
 .oe_mis_builder_content {
-  padding: 20px;
-}
-
-/* 9e */
-
-.mis_builder_amount {
-  text-align: right;
-}
-
-.mis_builder_collabel {
-  text-align: center;
-}
-
-.mis_builder_rowlabel {
-  text-align: left;
-}
-
-.mis_builder a {
-  /* we don't want the link color, to respect user styles */
-  color: inherit;
-}
-
-.mis_builder a:hover {
-  /* underline links on hover to give a visual cue */
-  text-decoration: underline;
-}
-
-/* Table of contents for 9e */
-
-.mis_builder{
-  width:100%;
-}
-
-.mis_builder tbody{
-  border-top: 2px solid #D3D3D3;
-  border-bottom: 2px solid #D3D3D3;
-}
-
-.mis_builder thead>tr{
-  border: 0;
-}
-
-.mis_builder tr{
-  border-top: 1px solid #D3D3D3;
-}
-
-.mis_builder td{
-  padding-left:10px;
-  padding-right:10px;
+  padding: 10px;
 }

--- a/mis_builder/static/src/css/custom.css
+++ b/mis_builder/static/src/css/custom.css
@@ -28,3 +28,51 @@
 .oe_mis_builder_content {
   padding: 20px;
 }
+
+/* 9e */
+
+.mis_builder_amount {
+  text-align: right;
+}
+
+.mis_builder_collabel {
+  text-align: center;
+}
+
+.mis_builder_rowlabel {
+  text-align: left;
+}
+
+.mis_builder a {
+  /* we don't want the link color, to respect user styles */
+  color: inherit;
+}
+
+.mis_builder a:hover {
+  /* underline links on hover to give a visual cue */
+  text-decoration: underline;
+}
+
+/* Table of contents for 9e */
+
+.mis_builder{
+  width:100%;
+}
+
+.mis_builder tbody{
+  border-top: 2px solid #D3D3D3;
+  border-bottom: 2px solid #D3D3D3;
+}
+
+.mis_builder thead>tr{
+  border: 0;
+}
+
+.mis_builder tr{
+  border-top: 1px solid #D3D3D3;
+}
+
+.mis_builder td{
+  padding-left:10px;
+  padding-right:10px;
+}

--- a/mis_builder/static/src/xml/mis_widget.xml
+++ b/mis_builder/static/src/xml/mis_widget.xml
@@ -8,7 +8,7 @@
                     <button class="oe_mis_builder_export btn btn-sm oe_button"><img src="/web/static/src/img/icons/gtk-go-down.png"/>Export</button>
                     <button style="display: none;" class="oe_mis_builder_settings btn btn-sm oe_button"><img src="/web/static/src/img/icons/gtk-execute.png"/> Settings</button>
                 </div>
-                <table class="oe_list_content mis_builder">
+                <table class="oe_list_content o_list_view table table-condensed table-striped mis_builder">
                     <thead>
                         <tr t-foreach="widget.mis_report_data.header" t-as="row" class="oe_list_header_columns">
                             <th class="oe_list_header_char">


### PR DESCRIPTION
This PR adapts the stylesheet of MIS Builder instance to make it nicer in Odoo 9 Enterprise.
![screenshot from 2016-09-07 10-51-20](https://cloud.githubusercontent.com/assets/16916103/18306298/748e5596-74eb-11e6-92c4-01349f82d849.png)
![screenshot from 2016-09-07 11-08-13](https://cloud.githubusercontent.com/assets/16916103/18306312/843dc954-74eb-11e6-9bb7-48557edafcb3.png)
