### PR TITLE
[FIX] Fix debit formula on partner balance xls report

### DIFF
--- a/account_financial_report_webkit_xls/report/partners_balance_xls.py
+++ b/account_financial_report_webkit_xls/report/partners_balance_xls.py
@@ -368,17 +368,15 @@ class partners_balance_xls(report_xls):
                              partner_ref if partner_ref else '')]
                 if _p.comparison_mode == 'no_comparison':
                     bal_formula = ''
+                    debit_col = 4
                     if _p.initial_balance_mode:
                         init_bal_cell = rowcol_to_cell(row_pos, 3)
                         bal_formula = init_bal_cell + '+'
-                        debit_col = 4
                         c_specs += [
                             ('init_bal', 1, 0, 'number', partner.get(
                                 'init_balance', 0.0), None,
                              regular_cell_style_decimal),
                         ]
-                    else:
-                        debit_col = 3
                     c_specs += [
                         ('debit', 1, 0, 'number', partner.get('debit', 0.0),
                          None, regular_cell_style_decimal),


### PR DESCRIPTION
Fixes the debit col position on this report when is computed with the date filter.

In the cases that the date filter is set the initial balance is not shown but the debit and credit columns position are the same because of the span set in partner name column.

In the balance formula the column position changes if initial balance is present or not, so the formula is wrong in this cases, because is using the partner reference column as the start column in the formula instead of the debit column.
