### PR TITLE
8.0 account_financial_report_webkit: FIX the order of accounts in trial balance

### DIFF
--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -28,6 +28,7 @@ from openerp.osv import osv
 from openerp.tools.translate import _
 from openerp.addons.account.report.common_report_header \
     import common_report_header
+from collections import OrderedDict
 
 _logger = logging.getLogger('financial.reports.webkit')
 
@@ -204,7 +205,11 @@ class CommonReportHeaderWebkit(common_report_header):
                     self.cursor, self.uid, domain)
             else:
                 accounts += children_acc_ids
-        res_ids = list(set(accounts))
+        # remove duplicate account IDs in accounts
+        # We don't use list(set(accounts)) to keep the order
+        # cf http://stackoverflow.com/questions/7961363/
+        # removing-duplicates-in-lists
+        res_ids = list(OrderedDict.fromkeys(accounts))
         res_ids = self.sort_accounts_with_structure(
             account_ids, res_ids, context=context)
 


### PR DESCRIPTION
Here is the scenario of the bug on Odoo v8:
1) go to Accounting > Reporting > Legal Reports > Accounting Reports > Trial balance
2) Go to the "Accounts Filter" tab : select all accounts (to maximise the chance to see the problem)
3) Click on "Print"
-> You will probably get some view accounts that are not in the right order

Here is an example of a Trial balance of Akretion France filtered on 2 view accounts that is impacted by the bug: the view account 511 should be after view account 418: https://people.via.ecp.fr/~alexis/bug_order_trial_balance_odoo8.pdf 

This is caused by the use of list(set(accounts))  to remove duplicates in "accounts" which doesn't preserve the order, as explained in the second answer on http://stackoverflow.com/questions/7961363/removing-duplicates-in-lists I have simply impemented the solution explained in the second answer of the stackoverflow post.
