### PR TITLE
8.0 financial_report_webkit: Better Partner Ledger + Open Invoices report

### DIFF
--- a/account_financial_report_webkit/report/aged_partner_balance.py
+++ b/account_financial_report_webkit/report/aged_partner_balance.py
@@ -421,7 +421,7 @@ class AccountAgedTrialBalanceWebkit(PartnersOpenInvoicesWebkit):
         return dict((x[0], x[1]) for x in res)
 
 HeaderFooterTextWebKitParser(
-    'report.account.account_aged_trial_balance_webkit',
+    'report.account.aged_trial_balance_webkit',
     'account.account',
     'addons/account_financial_report_webkit/report/templates/\
                                                     aged_trial_webkit.mako',

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -84,6 +84,8 @@ class CommonReportHeaderWebkit(common_report_header):
             return _('Payable Accounts')
         elif val == 'customer_supplier':
             return _('Receivable and Payable Accounts')
+        elif val == 'all':
+            return _('All Account Types')
         else:
             return val
 

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -71,6 +71,7 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             'amount_currency': self._get_amount_currency,
             'display_partner_account': self._get_display_partner_account,
             'display_target_move': self._get_display_target_move,
+            'accounts': self._get_accounts_br,
             'additional_args': [
                 ('--header-font-name', 'Helvetica'),
                 ('--footer-font-name', 'Helvetica'),
@@ -101,7 +102,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
     def set_context(self, objects, data, ids, report_type=None):
         """Populate a ledger_lines attribute on each browse record that will
            be used by mako template"""
-        new_ids = data['form']['chart_account_id']
+        new_ids = data['form']['account_ids'] or\
+            data['form']['chart_account_id']
         # Account initial balance memoizer
         init_balance_memoizer = {}
         # Reading form
@@ -123,11 +125,13 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             stop_period = self.get_last_fiscalyear_period(fiscalyear)
 
         # Retrieving accounts
-        filter_type = ('payable', 'receivable')
+        filter_type = None
         if result_selection == 'customer':
             filter_type = ('receivable',)
-        if result_selection == 'supplier':
+        elif result_selection == 'supplier':
             filter_type = ('payable',)
+        elif result_selection == 'customer_supplier':
+            filter_type = ('payable', 'receivable')
 
         account_ids = self.get_all_accounts(
             new_ids, exclude_type=['view'], only_type=filter_type)

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -59,6 +59,7 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
             'amount_currency': self._get_amount_currency,
             'display_partner_account': self._get_display_partner_account,
             'display_target_move': self._get_display_target_move,
+            'accounts': self._get_accounts_br,
             'additional_args': [
                 ('--header-font-name', 'Helvetica'),
                 ('--footer-font-name', 'Helvetica'),
@@ -86,7 +87,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
     def set_context(self, objects, data, ids, report_type=None):
         """Populate a ledger_lines attribute on each browse record that will
            be used by mako template"""
-        new_ids = data['form']['chart_account_id']
+        new_ids = data['form']['account_ids'] or\
+            data['form']['chart_account_id']
 
         # account partner memoizer
         # Reading form
@@ -106,11 +108,13 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
             stop_period = self.get_last_fiscalyear_period(fiscalyear)
 
         # Retrieving accounts
-        filter_type = ('payable', 'receivable')
+        filter_type = None
         if result_selection == 'customer':
             filter_type = ('receivable',)
-        if result_selection == 'supplier':
+        elif result_selection == 'supplier':
             filter_type = ('payable',)
+        elif result_selection == 'customer_supplier':
+            filter_type = ('payable', 'receivable')
 
         accounts = self.get_all_accounts(new_ids, exclude_type=['view'],
                                          only_type=filter_type)

--- a/account_financial_report_webkit/report/report.xml
+++ b/account_financial_report_webkit/report/report.xml
@@ -131,7 +131,7 @@
 
         <record id="account_report_aged_trial_blanance_webkit" model="ir.actions.report.xml">
              <field name="report_type">webkit</field>
-             <field name="report_name">account.account_aged_trial_balance_webkit</field>
+             <field name="report_name">account.aged_trial_balance_webkit</field>
              <field eval="[(6,0,[])]" name="groups_id"/>
              <field eval="0" name="multi"/>
              <field eval="0" name="auto"/>
@@ -144,7 +144,7 @@
          </record>
 
         <record id="property_account_report_aged_trial_balance_webkit" model="ir.property">
-            <field name="name">account_aged_trial_balance_webkit</field>
+            <field name="name">aged_trial_balance_webkit</field>
             <field name="fields_id" ref="report_webkit.field_ir_act_report_xml_webkit_header"/>
             <field eval="'ir.header_webkit,'+str(ref('account_financial_report_webkit.financial_landscape_header'))"
                    model="ir.header_webkit"

--- a/account_financial_report_webkit/report/templates/account_report_open_invoices.mako
+++ b/account_financial_report_webkit/report/templates/account_report_open_invoices.mako
@@ -40,6 +40,8 @@
                     %endif
                 </div>
                 <div class="act_as_cell">${_('Clearance Date')}</div>
+                <div class="act_as_cell">${_('Account Types Filter')}</div>
+                <div class="act_as_cell">${_('Partners Filter')}</div>
                 <div class="act_as_cell">${_('Accounts Filter')}</div>
                 <div class="act_as_cell">${_('Target Moves')}</div>
 
@@ -62,11 +64,19 @@
                     %endif
                 </div>
                 <div class="act_as_cell">${ formatLang(date_until, date=True) }</div>
+                <div class="act_as_cell">${ display_partner_account(data) }</div>
                 <div class="act_as_cell">
                     %if partner_ids:
-                        ${_('Custom Filter')}
+                        ${_('Selected Partners')}
                     %else:
-                        ${ display_partner_account(data) }
+                        ${_('All Partners')}
+                    %endif
+                </div>
+                <div class="act_as_cell">
+                    %if accounts(data):
+                        ${', '.join([account.code for account in accounts(data)])}
+                    %else:
+                        ${_('All')}
                     %endif
                 </div>
                 <div class="act_as_cell">${ display_target_move(data) }</div>

--- a/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_partners_ledger.mako
@@ -35,6 +35,8 @@
                         ${_('Periods Filter')}
                     %endif
                 </div>
+                <div class="act_as_cell">${_('Account Types Filter')}</div>
+                <div class="act_as_cell">${_('Partners Filter')}</div>
                 <div class="act_as_cell">${_('Accounts Filter')}</div>
                 <div class="act_as_cell">${_('Target Moves')}</div>
                 <div class="act_as_cell">${_('Initial Balance')}</div>
@@ -56,11 +58,19 @@
                         ${stop_period.name if stop_period else u'' }
                     %endif
                 </div>
+                <div class="act_as_cell">${ display_partner_account(data) }</div>
                 <div class="act_as_cell">
                     %if partner_ids:
-                        ${_('Custom Filter')}
+                        ${_('Selected Partners')}
                     %else:
-                        ${ display_partner_account(data) }
+                        ${_('All Partners')}
+                    %endif
+                </div>
+                <div class="act_as_cell">
+                    %if accounts(data):
+                        ${', '.join([account.code for account in accounts(data)])}
+                    %else:
+                        ${_('All')}
                     %endif
                 </div>
                 <div class="act_as_cell">${ display_target_move(data) }</div>

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.py
@@ -23,14 +23,14 @@ from openerp.osv import orm, fields
 from openerp.tools import DEFAULT_SERVER_DATE_FORMAT as DATE_FORMAT
 
 
-class AccountAgedTrialBalance(orm.TransientModel):
+class AgedTrialBalance(orm.TransientModel):
     """Will launch age partner balance report.
     This report is based on Open Invoice Report
     and share a lot of knowledge with him
     """
 
     _inherit = "open.invoices.webkit"
-    _name = "account.aged.trial.balance.webkit"
+    _name = "aged.trial.balance.webkit"
     _description = "Aged partner balanced"
 
     def _get_current_fiscalyear(self, cr, uid, context=None):
@@ -69,7 +69,7 @@ class AccountAgedTrialBalance(orm.TransientModel):
     def onchange_fiscalyear(self, cr, uid, ids, fiscalyear=False,
                             period_id=False, date_to=False, until_date=False,
                             context=None):
-        res = super(AccountAgedTrialBalance, self).onchange_fiscalyear(
+        res = super(AgedTrialBalance, self).onchange_fiscalyear(
             cr, uid, ids, fiscalyear=fiscalyear, period_id=period_id,
             date_to=date_to, until_date=until_date, context=context
         )
@@ -86,5 +86,5 @@ class AccountAgedTrialBalance(orm.TransientModel):
         # we update form with display account value
         data = self.pre_print_report(cr, uid, ids, data, context=context)
         return {'type': 'ir.actions.report.xml',
-                'report_name': 'account.account_aged_trial_balance_webkit',
+                'report_name': 'account.aged_trial_balance_webkit',
                 'datas': data}

--- a/account_financial_report_webkit/wizard/aged_partner_balance_wizard.xml
+++ b/account_financial_report_webkit/wizard/aged_partner_balance_wizard.xml
@@ -2,9 +2,9 @@
 <openerp>
   <data>
 
-    <record id="account_aged_trial_balance_webkit" model="ir.ui.view">
+    <record id="aged_trial_balance_webkit" model="ir.ui.view">
       <field name="name">Aged Partner Balance Report</field>
-      <field name="model">account.aged.trial.balance.webkit</field>
+      <field name="model">aged.trial.balance.webkit</field>
       <field name="inherit_id" ref="account.account_common_report_view"/>
       <field name="arch" type="xml">
         <data>
@@ -65,10 +65,10 @@
             model="ir.actions.act_window">
       <field name="name">Aged partner balance</field>
       <field name="type">ir.actions.act_window</field>
-      <field name="res_model">account.aged.trial.balance.webkit</field>
+      <field name="res_model">aged.trial.balance.webkit</field>
       <field name="view_type">form</field>
       <field name="view_mode">form</field>
-      <field name="view_id" ref="account_aged_trial_balance_webkit"/>
+      <field name="view_id" ref="aged_trial_balance_webkit"/>
       <field name="target">new</field>
     </record>
   </data>

--- a/account_financial_report_webkit/wizard/open_invoices_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/open_invoices_wizard_view.xml
@@ -29,6 +29,17 @@
                             <separator string="Print only" colspan="4"/>
                             <field name="partner_ids" colspan="4" nolabel="1"/>
                         </page>
+                        <page string="Accounts Filters" name="accounts">
+                            <separator string="Print only" colspan="4"/>
+                            <field name="account_ids" colspan="4" nolabel="1">
+                                <tree>
+                                    <field name="code"/>
+                                    <field name="name"/>
+                                    <field name="type"/>
+                                    <field name="company_id"/>
+                                </tree>
+                            </field>
+                        </page>
                         <page string="Layout Options" name="layout_options">
                           <group>
                             <field name="amount_currency"/>

--- a/account_financial_report_webkit/wizard/partners_ledger_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/partners_ledger_wizard_view.xml
@@ -24,6 +24,17 @@
                             <separator string="Print only" colspan="4"/>
                             <field name="partner_ids" colspan="4" nolabel="1"/>
                         </page>
+                        <page string="Accounts Filters" name="accounts">
+                            <separator string="Print only" colspan="4"/>
+                            <field name="account_ids" colspan="4" nolabel="1">
+                                <tree>
+                                    <field name="code"/>
+                                    <field name="name"/>
+                                    <field name="type"/>
+                                    <field name="company_id"/>
+                                </tree>
+                            </field>
+                        </page>
                         <page string="Layout Options" name="layout_options">
                             <group colspan="4" col="2">
                                 <field name="amount_currency"/>

--- a/account_financial_report_webkit_xls/report/partner_ledger_xls.py
+++ b/account_financial_report_webkit_xls/report/partner_ledger_xls.py
@@ -32,10 +32,11 @@ from openerp.tools.translate import _
 
 _column_sizes = [
     ('date', 12),
-    ('period', 12),
+    ('period', 8),
     ('move', 20),
-    ('journal', 12),
+    ('journal', 8),
     ('partner', 30),
+    ('reference', 15),
     ('label', 58),
     ('rec', 12),
     ('debit', 15),
@@ -88,9 +89,9 @@ class partner_ledger_xls(report_xls):
             ws, row_pos, row_data, set_column_size=True)
 
         # Header Table
-        nbr_columns = 10
+        nbr_columns = 11
         if _p.amount_currency(data):
-            nbr_columns = 12
+            nbr_columns = 13
         cell_format = _xs['bold'] + _xs['fill_blue'] + _xs['borders_all']
         cell_style = xlwt.easyxf(cell_format)
         cell_style_center = xlwt.easyxf(cell_format + _xs['center'])
@@ -184,6 +185,7 @@ class partner_ledger_xls(report_xls):
             ('move', 1, 0, 'text', _('Entry'), None, c_hdr_cell_style),
             ('journal', 1, 0, 'text', _('Journal'), None, c_hdr_cell_style),
             ('partner', 1, 0, 'text', _('Partner'), None, c_hdr_cell_style),
+            ('reference', 1, 0, 'text', _('Reference'), None, c_hdr_cell_style),
             ('label', 1, 0, 'text', _('Label'), None, c_hdr_cell_style),
             ('rec', 1, 0, 'text', _('Rec.'), None, c_hdr_cell_style),
             ('debit', 1, 0, 'text', _('Debit'), None, c_hdr_cell_style_right),
@@ -284,7 +286,7 @@ class partner_ledger_xls(report_xls):
 
                         # Print row 'Initial Balance' by partn
                         c_specs = [('empty%s' % x, 1, 0, 'text', None)
-                                   for x in range(5)]
+                                   for x in range(6)]
                         c_specs += [
                             ('init_bal', 1, 0, 'text', _('Initial Balance')),
                             ('rec', 1, 0, 'text', None),
@@ -322,11 +324,11 @@ class partner_ledger_xls(report_xls):
 
                         if init_line or row_pos > row_start_partner:
                             cumbal_formula = rowcol_to_cell(
-                                row_pos - 1, 9) + '+'
+                                row_pos - 1, 10) + '+'
                         else:
                             cumbal_formula = ''
-                        debit_cell = rowcol_to_cell(row_pos, 7)
-                        credit_cell = rowcol_to_cell(row_pos, 8)
+                        debit_cell = rowcol_to_cell(row_pos, 8)
+                        credit_cell = rowcol_to_cell(row_pos, 9)
                         cumbal_formula += debit_cell + '-' + credit_cell
                         # Print row ledger line data #
 
@@ -348,6 +350,7 @@ class partner_ledger_xls(report_xls):
                             ('journal', 1, 0, 'text', line.get('jcode') or ''),
                             ('partner', 1, 0, 'text',
                              line.get('partner_name') or ''),
+                            ('reference', 1, 0, 'text', line.get('lref') or ''),
                             ('label', 1, 0, 'text', label),
                             ('rec_name', 1, 0, 'text',
                              line.get('rec_name') or ''),
@@ -390,7 +393,7 @@ class partner_ledger_xls(report_xls):
                         '-' + bal_partner_credit
 
                     c_specs = [('empty%s' % x, 1, 0, 'text', None)
-                               for x in range(5)]
+                               for x in range(6)]
                     c_specs += [
                         ('init_bal', 1, 0, 'text',
                          _('Cumulated balance on Partner')),
@@ -426,7 +429,7 @@ class partner_ledger_xls(report_xls):
 
                 #  Print row Cumulated Balance by account #
                 c_specs = [
-                    ('acc_title', 5, 0, 'text', ' - '.
+                    ('acc_title', 6, 0, 'text', ' - '.
                      join([account.code, account.name])), ]
                 c_specs += [
                     ('label', 1, 0, 'text', _('Cumulated balance on Account')),


### PR DESCRIPTION
I improved Partner Ledger and Open Invoices Report to allow the selection of all account types (not just receivable and/or payable) and I added a filter on accounts.

I also renamed the object account.aged.trial.balance.webkit to aged.trial.balance.webkit to make it shorter.
Postgres limits the length of table and index names to 63 characters cf https://til.hashrocket.com/posts/8f87c65a0a-postgresqls-max-identifier-length-is-63-bytes.
This causes a problem with a M2M field from account.aged.trial.balance.webkit to account.account (for account filter) because the names of the 2 indexes of the M2M table would be:
- account_account_account_aged_trial_balance_webkit_rel_account_aged_trial_balance_webkit_id_index
- account_account_account_aged_trial_balance_webkit_rel_account_account_id_index

The labels are longer than 63 characters and the 63 first caracters are identical:

account_account_account_aged_trial_balance_webkit_rel_account_a (63 chars)

Bad luck: the first different caracters is character 64 !
That's why I decided to reduce the size of the object name 'account.aged.trial.balance.webkit'.
