### PR TITLE
OCA reports XLSX: Better override to define workbook creation options

### DIFF
--- a/account_financial_report_qweb/__openerp__.py
+++ b/account_financial_report_qweb/__openerp__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '9.0.1.0.1',
+    'version': '9.0.1.0.2',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'
@@ -35,11 +35,6 @@
         'report/templates/trial_balance.xml',
         'view/account_view.xml'
     ],
-    'external_dependencies': {
-        "python": [
-            "xlsxwriter",
-        ],
-    },
     'installable': True,
     'application': True,
     'auto_install': False,

--- a/account_financial_report_qweb/report/abstract_report_xlsx.py
+++ b/account_financial_report_qweb/report/abstract_report_xlsx.py
@@ -2,15 +2,6 @@
 # Author: Julien Coux
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-try:
-    import xlsxwriter
-except ImportError:  # pragma: no cover
-    import logging
-    _logger = logging.getLogger(__name__)
-    _logger.info("Missing dependency: xlsxwriter.")
-    _logger.debug("ImportError details:", exc_info=True)
-
-from cStringIO import StringIO
 
 from openerp.addons.report_xlsx.report.report_xlsx import ReportXlsx
 
@@ -42,20 +33,8 @@ class AbstractReportXslx(ReportXlsx):
         self.format_amount = None
         self.format_percent_bold_italic = None
 
-    def create_xlsx_report(self, ids, data, report):
-        """ Overrides method to add constant_memory option used for large files
-        """
-        self.parser_instance = self.parser(
-            self.env.cr, self.env.uid, self.name2, self.env.context)
-        objs = self.getObjects(
-            self.env.cr, self.env.uid, ids, self.env.context)
-        self.parser_instance.set_context(objs, data, ids, 'xlsx')
-        file_data = StringIO()
-        workbook = xlsxwriter.Workbook(file_data, {'constant_memory': True})
-        self.generate_xlsx_report(workbook, data, objs)
-        workbook.close()
-        file_data.seek(0)
-        return (file_data.read(), 'xlsx')
+    def get_workbook_options(self):
+        return {'constant_memory': True}
 
     def generate_xlsx_report(self, workbook, data, objects):
         report = objects


### PR DESCRIPTION
Little modification to fix this issue:
https://github.com/OCA/account-financial-reporting/issues/241

Depends of PR:
https://github.com/OCA/reporting-engine/pull/77

This PR contains a revert of https://github.com/OCA/account-financial-reporting/pull/229 which is useless now.
