### PR TITLE
[Fix] #57 Fixed accented characters in report names

### DIFF
--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -138,6 +138,18 @@ class HeaderFooterTextWebKitParser(webkit_report.WebKitParser):
         if parser_instance.localcontext.get('additional_args', False):
             for arg in parser_instance.localcontext['additional_args']:
                 command.extend(arg)
+                if isinstance(arg, tuple):
+                    new_arg = tuple()
+                    for i in arg:
+                        if isinstance(i, unicode):
+                            i = i.encode('ascii', 'replace')
+                            i = (str(i), )
+                            new_arg += i
+                        else:
+                            new_arg += (i, )
+                    command.extend(new_arg)
+                else:
+                    command.extend(arg)
 
         count = 0
         for html in html_list:


### PR DESCRIPTION
I stole this solution to issue #57 from martini97, who doesn't seem to have made a pull request. It solved the issue for our customer.
