### PR TITLE
[9.0][FIX] fix qweb financial reports takes company from user not from wizard

### DIFF
--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -77,7 +77,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
         self.date_from = self.date_range_id.date_start
         self.date_to = self.date_range_id.date_end
         if self.date_from:
-            self.fy_start_date = self.env.user.company_id.find_daterange_fy(
+            self.fy_start_date = self.company_id.find_daterange_fy(
                 fields.Date.from_string(self.date_range_id.date_start)
             ).date_start
 

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -71,7 +71,7 @@ class TrialBalanceReportWizard(models.TransientModel):
         self.date_from = self.date_range_id.date_start
         self.date_to = self.date_range_id.date_end
         if self.date_from:
-            self.fy_start_date = self.env.user.company_id.find_daterange_fy(
+            self.fy_start_date = self.company_id.find_daterange_fy(
                 fields.Date.from_string(self.date_range_id.date_start)
             ).date_start
 


### PR DESCRIPTION
Step to reproduce:
1. User working on a parent company (parent company don't have date ranges defined)
2. User request general ledger of a child company
3. Error with empty "fy_start_date"

This happens because when computing "self.fy_start_date" the user company is used instead of the company of the wizard.