### PR TITLE
[10.0][FIX] mis_builder: local variable 'ctx' referenced before assignment

### DIFF
--- a/mis_builder/report/mis_report_instance_qweb.py
+++ b/mis_builder/report/mis_report_instance_qweb.py
@@ -14,10 +14,10 @@ class Report(models.Model):
 
     @api.model
     def get_pdf(self, docids, report_name, html=None, data=None):
+        ctx = self.env.context.copy()
         if docids:
             report = self._get_report_from_name(report_name)
             obj = self.env[report.model].browse(docids)[0]
-            ctx = self.env.context.copy()
             if hasattr(obj, 'landscape_pdf') and obj.landscape_pdf:
                 ctx.update({'landscape': True})
         return super(Report, self.with_context(ctx)).get_pdf(


### PR DESCRIPTION
Fixes the following:
```Traceback (most recent call last):
  File "/opt/odoo-10.0/addons/report/controllers/main.py", line 100, in report_download
    response = self.report_routes(reportname, converter='pdf', **dict(data))
  File "/opt/odoo-10.0/src/odoo-10.0/odoo/http.py", line 504, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo-10.0/src/odoo-10.0/addons/report/controllers/main.py", line 45, in report_routes
    pdf = report_obj.with_context(context).get_pdf(docids, reportname, data=data)
  File "/opt/odoo-10.0/src/oca/mis_builder/report/mis_report_instance_qweb.py", line 23, in get_pdf
    return super(Report, self.with_context(ctx)).get_pdf(
UnboundLocalError: local variable 'ctx' referenced before assignment
```
Got the stacktrace while generating an empty report.