### PR TITLE
[10.0] mis_builder: fix indent style and other small improvements

### DIFF
--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 10.0.2.0.3 (unreleased)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+* [IMP] more robust behaviour in presence of missing expressions
 * [FIX] indent style
 * [FIX] local variable 'ctx' referenced before assignment when generating
   reports with no objects

--- a/mis_builder/CHANGES.rst
+++ b/mis_builder/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 10.0.2.0.3 (unreleased)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
+* [FIX] indent style
 * [FIX] local variable 'ctx' referenced before assignment when generating
   reports with no objects
 * [IMP] use fontawesome icons

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -413,7 +413,7 @@ class KpiMatrix(object):
                         'val_r': cell.val_rendered,
                         'val_c': cell.val_comment,
                         'style': self._style_model.to_css_style(
-                            cell.style_props),
+                            cell.style_props, no_indent=True),
                     }
                     if cell.drilldown_arg:
                         col_data['drilldown_arg'] = cell.drilldown_arg

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -242,7 +242,7 @@ class KpiMatrix(object):
                     val_comment = u'{}.{} = {}'.format(
                         row.kpi.name,
                         subcol.subkpi.name,
-                        row.kpi.get_expression_for_subkpi(subcol.subkpi))
+                        row.kpi._get_expression_for_subkpi(subcol.subkpi))
                 else:
                     val_comment = u'{} = {}'.format(
                         row.kpi.name,
@@ -581,7 +581,7 @@ class MisReportKpi(models.Model):
         elif self.type == TYPE_STR:
             self.compare_method = CMP_NONE
 
-    def get_expression_for_subkpi(self, subkpi):
+    def _get_expression_for_subkpi(self, subkpi):
         for expression in self.expression_ids:
             if expression.subkpi_id == subkpi:
                 return expression.name or 'AccountingNone'
@@ -807,7 +807,7 @@ class MisReport(models.Model):
         return kpi_matrix
 
     @api.multi
-    def prepare_aep(self, company):
+    def _prepare_aep(self, company):
         self.ensure_one()
         aep = AEP(company)
         for kpi in self.kpi_ids:

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -658,7 +658,7 @@ class MisReportKpiExpression(models.Model):
         store=True,
         readonly=True)
     name = fields.Char(string='Expression')
-    kpi_id = fields.Many2one('mis.report.kpi')
+    kpi_id = fields.Many2one('mis.report.kpi', required=True)
     # TODO FIXME set readonly=True when onchange('subkpi_ids') below works
     subkpi_id = fields.Many2one(
         'mis.report.subkpi',

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -517,6 +517,7 @@ class MisReportKpi(models.Model):
             }
 
     @api.multi
+    @api.depends('expression_ids.subkpi_id.name', 'expression_ids.name')
     def _compute_expression(self):
         for kpi in self:
             l = []

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -140,7 +140,7 @@ class MisReportInstancePeriod(models.Model):
     ]
 
     @api.onchange('date_range_id')
-    def onchange_date_range(self):
+    def _onchange_date_range(self):
         for record in self:
             record.manual_date_from = record.date_range_id.date_start
             record.manual_date_to = record.date_range_id.date_end
@@ -297,7 +297,7 @@ class MisReportInstance(models.Model):
                 record.date_to = None
 
     @api.onchange('date_range_id')
-    def onchange_date_range(self):
+    def _onchange_date_range(self):
         for record in self:
             record.date_from = record.date_range_id.date_start
             record.date_to = record.date_range_id.date_end
@@ -359,7 +359,7 @@ class MisReportInstance(models.Model):
     @api.multi
     def _compute_matrix(self):
         self.ensure_one()
-        aep = self.report_id.prepare_aep(self.company_id)
+        aep = self.report_id._prepare_aep(self.company_id)
         kpi_matrix = self.report_id.prepare_kpi_matrix()
         for period in self.period_ids:
             if period.date_from == period.date_to:

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -83,8 +83,8 @@ class MisReportInstancePeriod(models.Model):
 
     name = fields.Char(size=32, required=True,
                        string='Description', translate=True)
-    mode = fields.Selection([('fix', 'Fix'),
-                             ('relative', 'Relative'),
+    mode = fields.Selection([('fix', 'Fixed dates'),
+                             ('relative', 'Relative to report base date'),
                              ], required=True,
                             default='fix')
     type = fields.Selection([('d', _('Day')),

--- a/mis_builder/models/mis_report_instance.py
+++ b/mis_builder/models/mis_report_instance.py
@@ -23,6 +23,7 @@ class MisReportInstancePeriod(models.Model):
     @api.multi
     @api.depends('report_instance_id.pivot_date',
                  'report_instance_id.comparison_mode',
+                 'date_range_type_id',
                  'type', 'offset', 'duration', 'mode')
     def _compute_dates(self):
         for record in self:

--- a/mis_builder/models/mis_report_style.py
+++ b/mis_builder/models/mis_report_style.py
@@ -240,7 +240,7 @@ class MisReportKpiStyle(models.Model):
             return AccountingNone, '', style_r
 
     @api.model
-    def to_xlsx_style(self, props):
+    def to_xlsx_style(self, props, no_indent=False):
         num_format = '0'
         if props.dp:
             num_format += '.'
@@ -256,21 +256,25 @@ class MisReportKpiStyle(models.Model):
             ('size', self._font_size_to_xlsx_size.get(props.font_size, 11)),
             ('font_color', props.color),
             ('bg_color', props.background_color),
-            ('indent', props.indent_level),
             ('num_format', num_format),
         ]
+        if props.indent_level is not None and not no_indent:
+            xlsx_attributes.append(
+                ('indent', props.indent_level))
         return dict([a for a in xlsx_attributes
                      if a[1] is not None])
 
     @api.model
-    def to_css_style(self, props):
+    def to_css_style(self, props, no_indent=False):
         css_attributes = [
             ('font-style', props.font_style),
             ('font-weight', props.font_weight),
             ('font-size',  props.font_size),
             ('color', props.color),
             ('background-color', props.background_color),
-            ('indent-level', props.indent_level)
         ]
+        if props.indent_level is not None and not no_indent:
+            css_attributes.append(
+                ('text-indent', '{}em'.format(props.indent_level)))
         return '; '.join(['%s: %s' % a for a in css_attributes
                           if a[1] is not None]) or None

--- a/mis_builder/report/mis_report_instance_xlsx.py
+++ b/mis_builder/report/mis_report_instance_xlsx.py
@@ -114,7 +114,8 @@ class MisBuilderXlsx(ReportXlsx):
                     # TODO col/subcol format
                     sheet.write(row_pos, col_pos, '', row_format)
                     continue
-                cell_xlsx_style = style_obj.to_xlsx_style(cell.style_props)
+                cell_xlsx_style = style_obj.to_xlsx_style(
+                    cell.style_props, no_indent=True)
                 cell_xlsx_style['align'] = 'right'
                 cell_format = workbook.add_format(cell_xlsx_style)
                 if isinstance(cell.val, DataError):

--- a/mis_builder/views/mis_report_instance.xml
+++ b/mis_builder/views/mis_report_instance.xml
@@ -78,7 +78,7 @@
                             </group>
                         </group>
                     </group>
-                    <group name="comparison_mode" string="Comparison"
+                    <group name="comparison_mode" string="Columns"
                            attrs="{'invisible': [('comparison_mode', '=', False)]}" colspan="4">
                         <field name="period_ids" colspan="4" nolabel="1" attrs="{'required': [('comparison_mode', '=', True)]}">
                             <tree string="KPI's" colors="red:valid==False">
@@ -160,11 +160,18 @@
             <field name="model">mis.report.instance.period</field>
             <field name="priority" eval="16"/>
             <field name="arch" type="xml">
-                <form string="KPI's">
-                    <sheet>
-                        <group>
-                            <field name="mode" widget="radio"/>
-                            <field name="valid" invisible="1"/>
+                <form>
+                    <group>
+                        <field name="name" placeholder="Name"/>
+                        <field name="valid" invisible="1"/>
+                        <field name="report_instance_id" invisible="1"/>
+                        <field name="id" invisible="1"/>
+                    </group>
+                    <notebook>
+                        <page string="Dates">
+                            <group>
+                                <field name="mode" widget="radio"/>
+                            </group>
                             <group name="relative" attrs="{'invisible': [('mode', '!=', 'relative')]}" colspan="4">
                                 <group>
                                     <field name="type" attrs="{'required': [('mode', '=', 'relative')]}"/>
@@ -185,18 +192,19 @@
                                 <field name="manual_date_to"
                                        attrs="{'required': [('mode', '=', 'fix')]}"/>
                             </group>
-                            <field name="name" placeholder="Name"/>
-                            <field name="normalize_factor"/>
-                            <field name="report_instance_id" invisible="1"/>
-                            <field name="id" invisible="1"/>
-                            <field name="subkpi_ids"
-                                   domain="[('report_id', '=', parent.report_id)]"
-                                   widget="many2many_tags"/>
-                            <field name="comparison_column_ids"
-                                   domain="[('report_instance_id', '=', report_instance_id), ('id', '!=', id)]"
-                                   widget="many2many_tags"/>
-                        </group>
-                    </sheet>
+                        </page>
+                        <page string="Advanced">
+                            <group>
+                                <field name="subkpi_ids"
+                                       domain="[('report_id', '=', parent.report_id)]"
+                                       widget="many2many_tags"/>
+                                <field name="normalize_factor"/>
+                                <field name="comparison_column_ids"
+                                       domain="[('report_instance_id', '=', report_instance_id), ('id', '!=', id)]"
+                                       widget="many2many_tags"/>
+                            </group>
+                        </page>
+                    </notebook>
                 </form>
             </field>
         </record>


### PR DESCRIPTION
- fixes #271 
- improve robustness in presence of missing expressions
- add some missing `depends` in compute methods
- make some methods protected (these should never have been public in the first place)
- better form for report column declaration
