### PR TITLE
OCA reports XLSX: Better override to define workbook creation options

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.0.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'
@@ -33,8 +33,6 @@
         'report/templates/open_items.xml',
         'report/templates/trial_balance.xml',
         'view/account_view.xml'
-    ],
-    'test': [
     ],
     'installable': True,
     'application': True,

--- a/account_financial_report_qweb/report/abstract_report_xlsx.py
+++ b/account_financial_report_qweb/report/abstract_report_xlsx.py
@@ -3,8 +3,6 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from cStringIO import StringIO
-import xlsxwriter
 from odoo.addons.report_xlsx.report.report_xlsx import ReportXlsx
 
 
@@ -35,20 +33,8 @@ class AbstractReportXslx(ReportXlsx):
         self.format_amount = None
         self.format_percent_bold_italic = None
 
-    def create_xlsx_report(self, ids, data, report):
-        """ Overrides method to add constant_memory option used for large files
-        """
-        self.parser_instance = self.parser(
-            self.env.cr, self.env.uid, self.name2, self.env.context)
-        objs = self.getObjects(
-            self.env.cr, self.env.uid, ids, self.env.context)
-        self.parser_instance.set_context(objs, data, ids, 'xlsx')
-        file_data = StringIO()
-        workbook = xlsxwriter.Workbook(file_data, {'constant_memory': True})
-        self.generate_xlsx_report(workbook, data, objs)
-        workbook.close()
-        file_data.seek(0)
-        return (file_data.read(), 'xlsx')
+    def get_workbook_options(self):
+        return {'constant_memory': True}
 
     def generate_xlsx_report(self, workbook, data, objects):
         report = objects


### PR DESCRIPTION
applies #242 to 10.0

I have no idea does it work, but it shall fix import issue. If it breaks system someway, consider to merge #274 for a while to prevent import error for ones who has account-financial-reporting in addons path, but don't use ``account_financial_report_qweb`` module