### PR TITLE
[9.0] [account_tax_balance] add init hook to speed up install

### DIFF
--- a/account_tax_balance/__init__.py
+++ b/account_tax_balance/__init__.py
@@ -4,3 +4,4 @@
 
 from . import models
 from . import wizard
+from .hooks import pre_init_hook

--- a/account_tax_balance/__openerp__.py
+++ b/account_tax_balance/__openerp__.py
@@ -24,5 +24,6 @@
     ],
     "images": [
         'images/tax_balance.png',
-    ]
+    ],
+    "pre_init_hook": "pre_init_hook",
 }

--- a/account_tax_balance/hooks.py
+++ b/account_tax_balance/hooks.py
@@ -56,7 +56,8 @@ def store_field_move_type(cr):
         ON acc.id = aml.account_id
         where aml.move_id = am.id
         and acc.internal_type ='payable' 
-        and aml.balance < 0)
+        group by aml.move_id
+        having sum(aml.balance) < 0)
         and am.move_type is null;
         """
     )
@@ -70,8 +71,9 @@ def store_field_move_type(cr):
         INNER JOIN account_account acc
         ON acc.id = aml.account_id
         where aml.move_id = am.id
-        and acc.internal_type ='payable' 
-        and aml.balance >= 0)
+        and acc.internal_type ='payable'
+        group by aml.move_id
+        having sum(aml.balance) >= 0)
         and am.move_type is null;
         """
     )
@@ -86,7 +88,8 @@ def store_field_move_type(cr):
         ON acc.id = aml.account_id
         where aml.move_id = am.id
         and acc.internal_type ='receivable' 
-        and aml.balance > 0)
+        group by aml.move_id
+        having sum(aml.balance) > 0)
         and am.move_type is null;
         """
     )
@@ -101,7 +104,8 @@ def store_field_move_type(cr):
         ON acc.id = aml.account_id
         where aml.move_id = am.id
         and acc.internal_type ='receivable' 
-        and aml.balance <= 0)
+        group by aml.move_id
+        having sum(aml.balance) <= 0)
         and am.move_type is null;
         """
     )

--- a/account_tax_balance/hooks.py
+++ b/account_tax_balance/hooks.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+# © 2017 Eficent Business and IT Consulting Services, S.L.
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+try:
+    from openerp.addons.mail_tracking.hooks import column_add_with_value
+except ImportError:
+    column_add_with_value = False
+
+_logger = logging.getLogger(__name__)
+
+
+def store_field_move_type(cr):
+    cr.execute(
+        """
+        SELECT column_name 
+        FROM information_schema.columns 
+        WHERE table_name='account_move' and column_name='move_type';
+        """
+    )
+    if not cr.fetchone():
+        _logger.info('Adding column move_type to table account_move')
+        cr.execute(
+            """
+            ALTER TABLE account_move 
+            ADD COLUMN move_type 
+            varchar(30);
+            COMMENT ON COLUMN account_move.move_type IS
+            'Move type';
+            """)
+
+    _logger.info('Computing field move_type on account.move')
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'liquidity'
+        WHERE am.id IN (SELECT aml.move_id
+        FROM account_move_line aml
+        INNER JOIN account_account acc
+        ON acc.id = aml.account_id
+        where aml.move_id = am.id
+        and acc.internal_type ='liquidity')
+        and am.move_type is null;
+        """
+    )
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'payable'
+        WHERE am.id IN (SELECT aml.move_id
+        FROM account_move_line aml
+        INNER JOIN account_account acc
+        ON acc.id = aml.account_id
+        where aml.move_id = am.id
+        and acc.internal_type ='payable' 
+        and aml.balance < 0)
+        and am.move_type is null;
+        """
+    )
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'payable_refund'
+        WHERE am.id IN (SELECT aml.move_id
+        FROM account_move_line aml
+        INNER JOIN account_account acc
+        ON acc.id = aml.account_id
+        where aml.move_id = am.id
+        and acc.internal_type ='payable' 
+        and aml.balance >= 0)
+        and am.move_type is null;
+        """
+    )
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'receivable'
+        WHERE am.id IN (SELECT aml.move_id
+        FROM account_move_line aml
+        INNER JOIN account_account acc
+        ON acc.id = aml.account_id
+        where aml.move_id = am.id
+        and acc.internal_type ='receivable' 
+        and aml.balance > 0)
+        and am.move_type is null;
+        """
+    )
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'receivable_refund'
+        WHERE am.id IN (SELECT aml.move_id
+        FROM account_move_line aml
+        INNER JOIN account_account acc
+        ON acc.id = aml.account_id
+        where aml.move_id = am.id
+        and acc.internal_type ='receivable' 
+        and aml.balance <= 0)
+        and am.move_type is null;
+        """
+    )
+
+    cr.execute(
+        """
+        UPDATE account_move am
+        SET move_type = 'other'
+        WHERE am.move_type is null;
+        """
+    )
+
+
+def pre_init_hook(cr):
+    """
+    The objective of this hook is to speed up the installation
+    of the module on an existing Odoo instance.
+
+    Without this script, if a database has a few hundred thousand
+    journal entries, which is not unlikely, the update will take
+    at least a few hours.
+    """
+    store_field_move_type(cr)

--- a/account_tax_balance/hooks.py
+++ b/account_tax_balance/hooks.py
@@ -14,8 +14,8 @@ _logger = logging.getLogger(__name__)
 def store_field_move_type(cr):
     cr.execute(
         """
-        SELECT column_name 
-        FROM information_schema.columns 
+        SELECT column_name
+        FROM information_schema.columns
         WHERE table_name='account_move' and column_name='move_type';
         """
     )
@@ -23,8 +23,8 @@ def store_field_move_type(cr):
         _logger.info('Adding column move_type to table account_move')
         cr.execute(
             """
-            ALTER TABLE account_move 
-            ADD COLUMN move_type 
+            ALTER TABLE account_move
+            ADD COLUMN move_type
             varchar(30);
             COMMENT ON COLUMN account_move.move_type IS
             'Move type';
@@ -55,7 +55,7 @@ def store_field_move_type(cr):
         INNER JOIN account_account acc
         ON acc.id = aml.account_id
         where aml.move_id = am.id
-        and acc.internal_type ='payable' 
+        and acc.internal_type ='payable'
         group by aml.move_id
         having sum(aml.balance) < 0)
         and am.move_type is null;
@@ -87,7 +87,7 @@ def store_field_move_type(cr):
         INNER JOIN account_account acc
         ON acc.id = aml.account_id
         where aml.move_id = am.id
-        and acc.internal_type ='receivable' 
+        and acc.internal_type ='receivable'
         group by aml.move_id
         having sum(aml.balance) > 0)
         and am.move_type is null;
@@ -103,7 +103,7 @@ def store_field_move_type(cr):
         INNER JOIN account_account acc
         ON acc.id = aml.account_id
         where aml.move_id = am.id
-        and acc.internal_type ='receivable' 
+        and acc.internal_type ='receivable'
         group by aml.move_id
         having sum(aml.balance) <= 0)
         and am.move_type is null;


### PR DESCRIPTION
The objective of this hook is to speed up the installation of the module on an existing Odoo instance.

Without this script, if a database has a few hundred thousand journal entries, which is not unlikely, the update will take at least a few hours.