### PR TITLE
[ADD] compute parent_store before running tests

### DIFF
--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -23,6 +23,7 @@
 from operator import add
 
 from .common_reports import CommonReportHeaderWebkit
+from openerp import tools
 
 
 class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
@@ -87,6 +88,12 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         elif main_filter == 'filter_date':
             ctx.update({'date_from': start,
                         'date_to': stop})
+
+        # in tests (when installing and testing at the same time),
+        # the read below might fail because it relies on the order
+        # given by parent_store
+        if tools.config['test_enable']:
+            account_obj._parent_store_compute(self.cursor)
 
         accounts = account_obj.read(
             self.cursor,


### PR DESCRIPTION
this one is to fix a problem with tests on runbot (not travis):

Runbot does only one run, with `-i $all_my_module --test-enable`. Then problem is that the tests for this module heavily relies on https://github.com/OCA/OCB/blob/8.0/addons/account/account.py#L278 which in turn relies on the parent order fields being filled, otherwise you'll end up with key errors in https://github.com/OCA/OCB/blob/8.0/addons/account/account.py#L364 (children need to come before their parents, ordering by parent_left guarantees that), as all `parent_left` fields will be empty and the order is undefined