### PR TITLE
[FIX] use account's fiscal year for tests

### DIFF
--- a/account_journal_report_xls/tests/export_csv_journal_by_period.yml
+++ b/account_journal_report_xls/tests/export_csv_journal_by_period.yml
@@ -3,7 +3,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -29,7 +29,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -56,7 +56,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -83,7 +83,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),

--- a/account_journal_report_xls/tests/print_journal_by_period.yml
+++ b/account_journal_report_xls/tests/print_journal_by_period.yml
@@ -3,7 +3,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -29,7 +29,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -56,7 +56,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),
@@ -83,7 +83,7 @@
 -
     !python {model: account.account}: |
         ctx = {}
-        fiscalyear_id = self.pool['account.fiscalyear'].search(cr, uid, [])[0]
+        fiscalyear_id = ref('account.data_fiscalyear')
         wizard = self.pool['account.print.journal.xls']
         period_ids = wizard.fy_period_ids(cr, uid, fiscalyear_id)
         data_dict = {'chart_account_id': ref('account.chart0'),


### PR DESCRIPTION
the test relies on `account.fiscalyear`'s order, and assumes that the first fiscal year will be the one `account` created. But as soon as you also install `account_bank_statement_import` and it happens to be loaded before this module, we'll end up with the fiscal year defined in https://github.com/OCA/bank-statement-import/blob/8.0/account_bank_statement_import/demo/fiscalyear_period.xml and the test fails. Better to explicitly request the fiscal year created by `account`.