### PR TITLE
[8.0] Trial Balance breakdown by partner

### DIFF
--- a/account_financial_report_webkit/README.rst
+++ b/account_financial_report_webkit/README.rst
@@ -165,6 +165,7 @@ Contributors
 * Nicolas Bessi
 * Guewen Baconnier
 * David Dufresne <david.dufresne@savoirfairelinux.com>
+* Daniel Rodriguez <drl.9319@gmail.com>
 
 Maintainer
 ----------

--- a/account_financial_report_webkit/__openerp__.py
+++ b/account_financial_report_webkit/__openerp__.py
@@ -24,6 +24,7 @@
     'author': (
         "Camptocamp,"
         "Savoir-faire Linux,"
+        "Praxya,"
         "Odoo Community Association (OCA)"
     ),
     'license': 'AGPL-3',

--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -347,6 +347,15 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
             if breakdown_partner:
                 if len(account.code) > 1 and \
                         account.code[:2] in ['40', '41', '43']:
+
+                    # If the filter is period
+                    if main_filter != 'filter_date':
+                        partner_start_date = start.date_start
+                        partner_stop_date = stop.date_stop
+                    else:
+                        partner_start_date = start
+                        partner_stop_date = stop
+
                     if target_move == 'all':
                         query = """SELECT SUM(l.credit) AS CREDIT, SUM(l.debit)
                                     AS DEBIT, SUM(l.debit-l.credit) AS BALANCE,
@@ -357,13 +366,15 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                        FROM account_move_line aml
                                        WHERE aml.account_id =
                                        """ + str(account.id) + """
-                                       AND aml.date < '"""+str(start)+"""'::date
+                                       AND aml.date < '"""\
+                                        + str(partner_start_date)+"""'::date
                                        AND aml.partner_id = l.partner_id)
                                        AS INITIAL_BALANCE
                                       FROM account_move_line l
                                       WHERE (l.date <=
-                                        '"""+str(stop)+"""'::date AND
-                                        l.date >= '"""+str(start)+"""'::date)
+                                     '"""+str(partner_stop_date)+"""'::date AND
+                                        l.date >= '"""\
+                                        + str(partner_start_date)+"""'::date)
                                       AND l.partner_id IS NOT NULL
                                       AND l.account_id =
                                         """ + str(account.id) + """
@@ -380,12 +391,15 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                        FROM account_move_line aml
                                        WHERE aml.account_id =
                                             """ + str(account.id) + """
-                                       AND aml.date < '"""+str(start)+"""'::date
+                                       AND aml.date < '"""\
+                                       + str(partner_start_date)+"""'::date
                                        AND aml.partner_id = l.partner_id)
                                             AS INITIAL_BALANCE
                                       FROM account_move_line l
-                                      WHERE (l.date <= '"""+str(stop)+"""'::date
-                                       AND l.date >= '"""+str(start)+"""'::date)
+                                      WHERE (l.date <= '"""\
+                                      + str(partner_stop_date)+"""'::date
+                                       AND l.date >= '"""\
+                                       + str(partner_start_date)+"""'::date)
                                       AND (SELECT am.state
                                            FROM account_move am
                                            WHERE am.id = l.move_id) = 'posted'

--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -345,50 +345,59 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                 {account.id: display_account and
                  to_display_accounts[account.id]})
 
-        if breakdown_partner:
-             if len(account.code) > 1 and account.code[:2] in ['40', '41', '43']:
-                if target_move == 'all':
-                    query = """SELECT SUM(l.credit) AS CREDIT, SUM(l.debit)
-                                AS DEBIT, SUM(l.debit-l.credit) AS BALANCE,
-                                  (SELECT p.name
-                                   FROM res_partner p
-                                   WHERE p.id = l.partner_id)AS PARTNER,
-                                  (SELECT SUM(aml.debit-aml.credit)
-                                   FROM account_move_line aml
-                                   WHERE aml.account_id = """ + str(account.id) +"""
-                                   AND aml.date < '"""+str(start)+"""'::date
-                                   AND aml.partner_id = l.partner_id) AS INITIAL_BALANCE
-                                  FROM account_move_line l
-                                  WHERE (l.date <= '"""+str(stop)+"""'::date AND l.date >= '"""+str(start)+"""'::date)
-                                  AND l.partner_id IS NOT NULL
-                                  AND l.account_id = """ + str(account.id) +"""
-                                  GROUP BY l.partner_id
-                                  """
+            if breakdown_partner:
+                if len(account.code) > 1 and \
+                        account.code[:2] in ['40', '41', '43']:
+                    if target_move == 'all':
+                        query = """SELECT SUM(l.credit) AS CREDIT, SUM(l.debit)
+                                    AS DEBIT, SUM(l.debit-l.credit) AS BALANCE,
+                                      (SELECT p.name
+                                       FROM res_partner p
+                                       WHERE p.id = l.partner_id)AS PARTNER,
+                                      (SELECT SUM(aml.debit-aml.credit)
+                                       FROM account_move_line aml
+                                       WHERE aml.account_id =
+                                       """ + str(account.id) +"""
+                                       AND aml.date < '"""+str(start)+"""'::date
+                                       AND aml.partner_id = l.partner_id)
+                                       AS INITIAL_BALANCE
+                                      FROM account_move_line l
+                                      WHERE (l.date <=
+                                        '"""+str(stop)+"""'::date AND
+                                        l.date >= '"""+str(start)+"""'::date)
+                                      AND l.partner_id IS NOT NULL
+                                      AND l.account_id =
+                                        """ + str(account.id) +"""
+                                      GROUP BY l.partner_id
+                                      """
 
-                else:
-                    query = """SELECT SUM(l.credit) AS CREDIT, SUM(l.debit) AS DEBIT, SUM(l.debit-l.credit) AS BALANCE,
-                                  (SELECT p.name
-                                   FROM res_partner p
-                                   WHERE p.id = l.partner_id)AS PARTNER,
-                                  (SELECT SUM(aml.debit-aml.credit)
-                                   FROM account_move_line aml
-                                   WHERE aml.account_id = """ + str(account.id) +"""
-                                   AND aml.date < '"""+str(start)+"""'::date
-                                   AND aml.partner_id = l.partner_id) AS INITIAL_BALANCE
-                                  FROM account_move_line l
-                                  WHERE (l.date <= '"""+str(stop)+"""'::date AND l.date >= '"""+str(start)+"""'::date)
-                                  AND (SELECT am.state
-                                       FROM account_move am
-                                       WHERE am.id = l.move_id) = 'posted'
-                                  AND l.partner_id IS NOT NULL
-                                  AND l.account_id = """ + str(account.id) +"""
-                                  GROUP BY l.partner_id
-                                  """
-
-                self.cursor.execute(query)
-                account_partner_group = self.cursor.fetchall()
-                accounts_partner.update({account.id: account_partner_group})
-
+                    else:
+                        query = """SELECT SUM(l.credit) AS CREDIT, SUM(l.debit)
+                                    AS DEBIT, SUM(l.debit-l.credit) AS BALANCE,
+                                      (SELECT p.name
+                                       FROM res_partner p
+                                       WHERE p.id = l.partner_id)AS PARTNER,
+                                      (SELECT SUM(aml.debit-aml.credit)
+                                       FROM account_move_line aml
+                                       WHERE aml.account_id =
+                                            """ + str(account.id) +"""
+                                       AND aml.date < '"""+str(start)+"""'::date
+                                       AND aml.partner_id = l.partner_id)
+                                            AS INITIAL_BALANCE
+                                      FROM account_move_line l
+                                      WHERE (l.date <= '"""+str(stop)+"""'::date
+                                       AND l.date >= '"""+str(start)+"""'::date)
+                                      AND (SELECT am.state
+                                           FROM account_move am
+                                           WHERE am.id = l.move_id) = 'posted'
+                                      AND l.partner_id IS NOT NULL
+                                      AND l.account_id =
+                                            """ + str(account.id) +"""
+                                      GROUP BY l.partner_id
+                                      """
+                    self.cursor.execute(query)
+                    account_partner_group = self.cursor.fetchall()
+                    accounts_partner.update({account.id: account_partner_group})
         context_report_values = {
             'fiscalyear': fiscalyear,
             'start_date': start_date,

--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -257,7 +257,6 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         breakdown_partner = self._get_form_param('breakdown_partner', data)
         chart_account = self._get_chart_account_id_br(data)
 
-
         start_period, stop_period, start, stop = \
             self._get_start_stop_for_filter(main_filter, fiscalyear,
                                             start_date, stop_date,
@@ -357,7 +356,7 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                       (SELECT SUM(aml.debit-aml.credit)
                                        FROM account_move_line aml
                                        WHERE aml.account_id =
-                                       """ + str(account.id) +"""
+                                       """ + str(account.id) + """
                                        AND aml.date < '"""+str(start)+"""'::date
                                        AND aml.partner_id = l.partner_id)
                                        AS INITIAL_BALANCE
@@ -367,7 +366,7 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                         l.date >= '"""+str(start)+"""'::date)
                                       AND l.partner_id IS NOT NULL
                                       AND l.account_id =
-                                        """ + str(account.id) +"""
+                                        """ + str(account.id) + """
                                       GROUP BY l.partner_id
                                       """
 
@@ -380,7 +379,7 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                       (SELECT SUM(aml.debit-aml.credit)
                                        FROM account_move_line aml
                                        WHERE aml.account_id =
-                                            """ + str(account.id) +"""
+                                            """ + str(account.id) + """
                                        AND aml.date < '"""+str(start)+"""'::date
                                        AND aml.partner_id = l.partner_id)
                                             AS INITIAL_BALANCE
@@ -392,12 +391,14 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                                            WHERE am.id = l.move_id) = 'posted'
                                       AND l.partner_id IS NOT NULL
                                       AND l.account_id =
-                                            """ + str(account.id) +"""
+                                            """ + str(account.id) + """
                                       GROUP BY l.partner_id
                                       """
                     self.cursor.execute(query)
                     account_partner_group = self.cursor.fetchall()
-                    accounts_partner.update({account.id: account_partner_group})
+                    accounts_partner.update({
+                        account.id: account_partner_group
+                        })
         context_report_values = {
             'fiscalyear': fiscalyear,
             'start_date': start_date,

--- a/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
@@ -200,7 +200,7 @@
                                 <div class="act_as_cell amount">${formatLang(comp_account['balance']) | amount}</div>
                                 %if comparison_mode == 'single':  ## no diff in multiple comparisons because it shows too data
                                     <div class="act_as_cell amount">${formatLang(comp_account['diff']) | amount}</div>
-                                    <div class="act_as_cell amount"> 
+                                    <div class="act_as_cell amount">
                                     %if comp_account['percent_diff'] is False:
                                      ${ '-' }
                                     %else:
@@ -211,6 +211,30 @@
                             %endfor
                         %endif
                     </div>
+                    ## view partner details
+                    %if current_account.id in accounts_partner:
+                        %for partner in accounts_partner[current_account.id]:
+                          <div class="act_as_row">
+                              ## code
+                              <div class="act_as_cell first_column"> </div>
+                              ## account name
+                              <div class="act_as_cell"> ${partner[3]}</div>
+                              %if comparison_mode == 'no_comparison':
+                                  %if initial_balance_mode:
+                                      ## opening balance
+                                      <div class="act_as_cell amount">${formatLang(partner[4])}</div>
+                                  %endif
+                                  ## debit
+                                  <div class="act_as_cell amount">${formatLang(partner[1])}</div>
+                                  ## credit
+                                  <div class="act_as_cell amount">${formatLang(partner[0])}</div>
+                              %endif
+                              ## balance
+                              <div class="act_as_cell amount">${formatLang(partner[2])}</div>
+                          </div>
+                        %endfor
+                    %endif
+                    ## End partner details
                 %endfor
             </div>
         </div>

--- a/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
+++ b/account_financial_report_webkit/report/templates/account_report_trial_balance.mako
@@ -222,7 +222,7 @@
                               %if comparison_mode == 'no_comparison':
                                   %if initial_balance_mode:
                                       ## opening balance
-                                      <div class="act_as_cell amount">${formatLang(partner[4])}</div>
+                                      <div class="act_as_cell amount"></div>
                                   %endif
                                   ## debit
                                   <div class="act_as_cell amount">${formatLang(partner[1])}</div>

--- a/account_financial_report_webkit/wizard/trial_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/trial_balance_wizard.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-from openerp.osv import orm
+from openerp.osv import orm, fields
 
 
 class AccountTrialBalanceWizard(orm.TransientModel):
@@ -28,6 +28,21 @@ class AccountTrialBalanceWizard(orm.TransientModel):
     _inherit = "account.common.balance.report"
     _name = "trial.balance.webkit"
     _description = "Trial Balance Report"
+
+    _columns = {
+        'breakdown_partner': fields.boolean('Breakdown for partner',
+            help="If you select this option in Trial balance report the "
+            "account 43.., 40... and 41.. is breakdown for Partner"),
+    }
+
+    def pre_print_report(self, cr, uid, ids, data, context=None):
+        vals = {}
+        data = super(AccountTrialBalanceWizard, self).pre_print_report(
+            cr, uid, ids, data, context=context)
+        report_data = self.browse(cr, uid, ids)
+        vals['breakdown_partner'] = report_data.breakdown_partner
+        data['form'].update(vals)
+        return data
 
     def _print_report(self, cursor, uid, ids, data, context=None):
         context = context or {}

--- a/account_financial_report_webkit/wizard/trial_balance_wizard.py
+++ b/account_financial_report_webkit/wizard/trial_balance_wizard.py
@@ -31,8 +31,10 @@ class AccountTrialBalanceWizard(orm.TransientModel):
 
     _columns = {
         'breakdown_partner': fields.boolean('Breakdown for partner',
-            help="If you select this option in Trial balance report the "
-            "account 43.., 40... and 41.. is breakdown for Partner"),
+                                            help="If you select this option "
+                                            "in Trial balance report the "
+                                            "account 43.., 40... and 41.. is "
+                                            "breakdown for Partner"),
     }
 
     def pre_print_report(self, cr, uid, ids, data, context=None):

--- a/account_financial_report_webkit/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/trial_balance_wizard_view.xml
@@ -23,6 +23,9 @@
                         <page string="Accounts Filters" name="accounts">
                             <separator string="Print only" colspan="4"/>
                             <group>
+                                <field name="breakdown_partner"/>
+                            </group>
+                            <group>
                                 <field name="account_level"/>
                             </group>
                             <field name="account_ids" colspan="4" nolabel="1" domain="[('type', '=', 'view')]">


### PR DESCRIPTION
In Spain many clients need obtain the trial balance breakdown for their clients and customers, in accounts 40, 41, 43. This pull request add new checkbox in the tap Account filters in Trial Balance view with name is "Breakdown for partner" , if this check is activate the Trial balance report is the same like old versión but add the breakdown form partner.

![captura de pantalla de 2017-06-05 10-41-37](https://cloud.githubusercontent.com/assets/19977041/26776989/cbee2d14-49db-11e7-8d06-20fb55e4fa03.png)
