### PR TITLE
[8.0] Add group by partner in general Ledger

### DIFF
--- a/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
@@ -125,94 +125,274 @@
                     </div>
                 </div>
 
-                <div class="act_as_tbody">
-                      %if display_initial_balance:
-                        <%
-                        cumul_debit = init_balance[account.id].get('debit') or 0.0
-                        cumul_credit = init_balance[account.id].get('credit') or 0.0
-                        cumul_balance = init_balance[account.id].get('init_balance') or 0.0
-                        cumul_balance_curr = init_balance[account.id].get('init_balance_currency') or 0.0
-                        %>
-                        <div class="act_as_row initial_balance">
-                          ## date
-                          <div class="act_as_cell first_column"></div>
-                          ## period
-                          <div class="act_as_cell"></div>
-                          ## move
-                          <div class="act_as_cell"></div>
-                          ## journal
-                          <div class="act_as_cell"></div>
-                          ## account code
-                          <div class="act_as_cell"></div>
-                          ## partner
-                          <div class="act_as_cell"></div>
-                          ## move reference
-                          <div class="act_as_cell"></div>
-                          ## label
-                          <div class="act_as_cell">${_('Initial Balance')}</div>
-                          ## counterpart
-                          <div class="act_as_cell"></div>
-                          ## debit
-                          <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('debit')) | amount}</div>
-                          ## credit
-                          <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('credit')) | amount}</div>
-                          ## balance cumulated
-                          <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
-                         %if amount_currency(data):
-                              ## currency balance
-                              <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr) | amount }</div>
-                              ## curency code
-                              <div class="act_as_cell amount"></div>
-                         %endif
+                %if  account.id not in clients_dict:
+                  <div class="act_as_tbody">
+                        %if display_initial_balance:
+                          <%
+                          cumul_debit = init_balance[account.id].get('debit') or 0.0
+                          cumul_credit = init_balance[account.id].get('credit') or 0.0
+                          cumul_balance = init_balance[account.id].get('init_balance') or 0.0
+                          cumul_balance_curr = init_balance[account.id].get('init_balance_currency') or 0.0
+                          %>
+                          <div class="act_as_row initial_balance">
+                            ## date
+                            <div class="act_as_cell first_column"></div>
+                            ## period
+                            <div class="act_as_cell"></div>
+                            ## move
+                            <div class="act_as_cell"></div>
+                            ## journal
+                            <div class="act_as_cell"></div>
+                            ## account code
+                            <div class="act_as_cell"></div>
+                            ## partner
+                            <div class="act_as_cell"></div>
+                            ## move reference
+                            <div class="act_as_cell"></div>
+                            ## label
+                            <div class="act_as_cell">${_('Initial Balance')}</div>
+                            ## counterpart
+                            <div class="act_as_cell"></div>
+                            ## debit
+                            <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('debit')) | amount}</div>
+                            ## credit
+                            <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('credit')) | amount}</div>
+                            ## balance cumulated
+                            <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                           %if amount_currency(data):
+                                ## currency balance
+                                <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr) | amount }</div>
+                                ## curency code
+                                <div class="act_as_cell amount"></div>
+                           %endif
 
+                          </div>
+                        %endif
+                        %for line in ledger_lines[account.id]:
+                          <%
+                          cumul_debit += line.get('debit') or 0.0
+                          cumul_credit += line.get('credit') or 0.0
+                          cumul_balance_curr += line.get('amount_currency') or 0.0
+                          cumul_balance += line.get('balance') or 0.0
+                          label_elements = [line.get('lname') or '']
+                          if line.get('invoice_number'):
+                            label_elements.append("(%s)" % (line['invoice_number'],))
+                          label = ' '.join(label_elements)
+                          %>
+
+                        <div class="act_as_row lines">
+                            ## date
+                            <div class="act_as_cell first_column">${formatLang(line.get('ldate') or '', date=True)}</div>
+                            ## period
+                            <div class="act_as_cell">${line.get('period_code') or ''}</div>
+                            ## move
+                            <div class="act_as_cell">${line.get('move_name') or ''}</div>
+                            ## journal
+                            <div class="act_as_cell">${line.get('jcode') or ''}</div>
+                            ## account code
+                            <div class="act_as_cell">${account.code}</div>
+                            ## partner
+                            <div class="act_as_cell overflow_ellipsis">${line.get('partner_name') or ''}</div>
+                            ## move reference
+                            <div class="act_as_cell">${line.get('lref') or ''}</div>
+                            ## label
+                            <div class="act_as_cell">${label}</div>
+                            ## counterpart
+                            <div class="act_as_cell">${line.get('counterparts') or ''}</div>
+                            ## debit
+                            <div class="act_as_cell amount">${ formatLang(line.get('debit', 0.0)) | amount }</div>
+                            ## credit
+                            <div class="act_as_cell amount">${ formatLang(line.get('credit', 0.0)) | amount }</div>
+                            ## balance cumulated
+                            <div class="act_as_cell amount" style="padding-right: 1px;">${ formatLang(cumul_balance) | amount }</div>
+                            %if amount_currency(data):
+                                ## currency balance
+                                <div class="act_as_cell amount sep_left">${formatLang(line.get('amount_currency') or 0.0)  | amount }</div>
+                                ## curency code
+                                <div class="act_as_cell amount" style="text-align: right;">${line.get('currency_code') or ''}</div>
+                            %endif
                         </div>
-                      %endif
-                      %for line in ledger_lines[account.id]:
-                        <%
-                        cumul_debit += line.get('debit') or 0.0
-                        cumul_credit += line.get('credit') or 0.0
-                        cumul_balance_curr += line.get('amount_currency') or 0.0
-                        cumul_balance += line.get('balance') or 0.0
-                        label_elements = [line.get('lname') or '']
-                        if line.get('invoice_number'):
-                          label_elements.append("(%s)" % (line['invoice_number'],))
-                        label = ' '.join(label_elements)
-                        %>
+                        %endfor
+                  </div>
+                %endif ## finish if initial for report
 
-                      <div class="act_as_row lines">
-                          ## date
-                          <div class="act_as_cell first_column">${formatLang(line.get('ldate') or '', date=True)}</div>
-                          ## period
-                          <div class="act_as_cell">${line.get('period_code') or ''}</div>
-                          ## move
-                          <div class="act_as_cell">${line.get('move_name') or ''}</div>
-                          ## journal
-                          <div class="act_as_cell">${line.get('jcode') or ''}</div>
-                          ## account code
-                          <div class="act_as_cell">${account.code}</div>
-                          ## partner
-                          <div class="act_as_cell overflow_ellipsis">${line.get('partner_name') or ''}</div>
-                          ## move reference
-                          <div class="act_as_cell">${line.get('lref') or ''}</div>
-                          ## label
-                          <div class="act_as_cell">${label}</div>
-                          ## counterpart
-                          <div class="act_as_cell">${line.get('counterparts') or ''}</div>
-                          ## debit
-                          <div class="act_as_cell amount">${ formatLang(line.get('debit', 0.0)) | amount }</div>
-                          ## credit
-                          <div class="act_as_cell amount">${ formatLang(line.get('credit', 0.0)) | amount }</div>
-                          ## balance cumulated
-                          <div class="act_as_cell amount" style="padding-right: 1px;">${ formatLang(cumul_balance) | amount }</div>
-                          %if amount_currency(data):
-                              ## currency balance
-                              <div class="act_as_cell amount sep_left">${formatLang(line.get('amount_currency') or 0.0)  | amount }</div>
-                              ## curency code
-                              <div class="act_as_cell amount" style="text-align: right;">${line.get('currency_code') or ''}</div>
-                          %endif
-                      </div>
-                      %endfor
-                </div>
+                ## Init group by partner
+                %if  account.id in clients_dict:
+                  <div class="act_as_tbody">
+                        %if display_initial_balance:
+                          <%
+                          cumul_debit = init_balance[account.id].get('debit') or 0.0
+                          cumul_credit = init_balance[account.id].get('credit') or 0.0
+                          cumul_balance = init_balance[account.id].get('init_balance') or 0.0
+                          cumul_balance_curr = init_balance[account.id].get('init_balance_currency') or 0.0
+                          %>
+                          <div class="act_as_row initial_balance">
+                            ## date
+                            <div class="act_as_cell first_column"></div>
+                            ## period
+                            <div class="act_as_cell"></div>
+                            ## move
+                            <div class="act_as_cell"></div>
+                            ## journal
+                            <div class="act_as_cell"></div>
+                            ## account code
+                            <div class="act_as_cell"></div>
+                            ## partner
+                            <div class="act_as_cell"></div>
+                            ## move reference
+                            <div class="act_as_cell"></div>
+                            ## label
+                            <div class="act_as_cell">${_('Initial Balance')}</div>
+                            ## counterpart
+                            <div class="act_as_cell"></div>
+                            ## debit
+                            <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('debit')) | amount}</div>
+                            ## credit
+                            <div class="act_as_cell amount">${formatLang(init_balance[account.id].get('credit')) | amount}</div>
+                            ## balance cumulated
+                            <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(cumul_balance) | amount }</div>
+                           %if amount_currency(data):
+                                ## currency balance
+                                <div class="act_as_cell amount sep_left">${formatLang(cumul_balance_curr) | amount }</div>
+                                ## curency code
+                                <div class="act_as_cell amount"></div>
+                           %endif
+
+                          </div>
+                        %endif
+
+                        <%
+                          old_client_name = False
+                          client_cumul_debit = 0.0
+                          client_cumul_credit = 0.0
+                          client_cumul_balance_curr = 0.0
+                          client_cumul_balance = 0.0
+                          balance_line = 0.0
+                          label_elements = []
+                          label = ' '.join(label_elements)
+                        %>
+                        %for name_line in clients_dict[account.id]:
+
+                          %for client_line in clients_dict[account.id][name_line]:
+
+                              %if old_client_name != False and old_client_name != client_line.get('partner_name'):
+                                ## Client sumatory
+                                <div class="act_as_row labels">
+                                    ## client name
+                                    <div class="act_as_cell first_column"></div>
+                                    ## period
+                                    <div class="act_as_cell"></div>
+                                    ## move
+                                    <div class="act_as_cell"></div>
+                                    ## journal
+                                    <div class="act_as_cell"></div>
+                                    ## account code
+                                    <div class="act_as_cell"></div>
+                                    ## partner
+                                    <div class="act_as_cell overflow_ellipsis"></div>
+                                    ## move reference
+                                    <div class="act_as_cell"></div>
+                                    ## label
+                                    <div class="act_as_cell"></div>
+                                    ## counterpart
+                                    <div class="act_as_cell"></div>
+                                    ## debit
+                                    <div class="act_as_cell amount">${formatLang(client_cumul_debit)}</div>
+                                    ## credit
+                                    <div class="act_as_cell amount">${formatLang(client_cumul_credit)}</div>
+                                    ## balance cumulated
+                                    <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(client_cumul_balance)}</div>
+                                </div>
+                                ## End Client sumatory
+                                <%
+                                  old_client_name = False
+                                  client_cumul_debit = 0.0
+                                  client_cumul_credit = 0.0
+                                  client_cumul_balance_curr = 0.0
+                                  client_cumul_balance = 0.0
+                                  balance_line = 0.0
+                                %>
+                              %endif ## End if client sumatory
+
+                            %if old_client_name != client_line.get('partner_name'):
+                              ## Client header
+                              <div class="act_as_row labels">
+                                  ## client name
+                                  <div class="act_as_cell first_column"></div>
+                                  ## period
+                                  <div class="act_as_cell"></div>
+                                  ## move
+                                  <div class="act_as_cell" style="font-weight: bold;">${client_line.get('partner_name')}</div>
+                                  ## journal
+                                  <div class="act_as_cell"></div>
+                                  ## account code
+                                  <div class="act_as_cell"></div>
+                                  ## partner
+                                  <div class="act_as_cell overflow_ellipsis"></div>
+                                  ## move reference
+                                  <div class="act_as_cell"></div>
+                                  ## label
+                                  <div class="act_as_cell"></div>
+                                  ## counterpart
+                                  <div class="act_as_cell"></div>
+                                  ## debit
+                                  <div class="act_as_cell amount"></div>
+                                  ## credit
+                                  <div class="act_as_cell amount"></div>
+                                  ## balance cumulated
+                                  <div class="act_as_cell amount" style="padding-right: 1px;"></div>
+                              </div>
+                              ## End Client header
+                            %endif ## End if client name
+                            <%
+                              balance_line = balance_line + client_line.get('debit', 0.0) - client_line.get('credit', 0.0)
+                            %>
+                            <div class="act_as_row lines">
+                                ## date
+                                <div class="act_as_cell first_column">${formatLang(client_line.get('ldate') or '', date=True)}</div>
+                                ## period
+                                <div class="act_as_cell">${client_line.get('period_code') or ''}</div>
+                                ## move
+                                <div class="act_as_cell">${client_line.get('move_name') or ''}</div>
+                                ## journal
+                                <div class="act_as_cell">${client_line.get('jcode') or ''}</div>
+                                ## account code
+                                <div class="act_as_cell">${account.code}</div>
+                                ## partner
+                                <div class="act_as_cell overflow_ellipsis">${client_line.get('partner_name') or ''}</div>
+                                ## move reference
+                                <div class="act_as_cell">${client_line.get('lref') or ''}</div>
+                                ## label
+                                <div class="act_as_cell">${label}</div>
+                                ## counterpart
+                                <div class="act_as_cell">${client_line.get('counterparts') or ''}</div>
+                                ## debit
+                                <div class="act_as_cell amount">${ formatLang(client_line.get('debit', 0.0)) | amount }</div>
+                                ## credit
+                                <div class="act_as_cell amount">${ formatLang(client_line.get('credit', 0.0)) | amount }</div>
+                                ## balance cumulated
+                                <div class="act_as_cell amount" style="padding-right: 1px;">${formatLang(balance_line)}</div>
+                                %if amount_currency(data):
+                                    ## currency balance
+                                    <div class="act_as_cell amount sep_left">${formatLang(client_line.get('amount_currency') or 0.0)  | amount }</div>
+                                    ## curency code
+                                    <div class="act_as_cell amount" style="text-align: right;">${client_line.get('currency_code') or ''}</div>
+                                %endif
+                            </div>
+
+                            <%
+                              old_client_name = client_line.get('partner_name')
+                              client_cumul_debit += client_line.get('debit')
+                              client_cumul_credit += client_line.get('credit')
+                              client_cumul_balance_curr += client_line.get('amount_currency')
+                              client_cumul_balance += client_line.get('balance')
+                              label_elements = [client_line.get('lname') or '']
+                            %>
+                          %endfor ## End for de cliente line
+                        %endfor ## en for de account
+                  </div> ## End client group by
+                %endif ## End client group by
+
                 <div class="act_as_table list_table">
                     <div class="act_as_row labels" style="font-weight: bold;">
                         ## date

--- a/account_financial_report_webkit/wizard/general_ledger_wizard.py
+++ b/account_financial_report_webkit/wizard/general_ledger_wizard.py
@@ -54,7 +54,14 @@ class AccountReportGeneralLedgerWizard(orm.TransientModel):
                     print all accounts."""),
         'centralize': fields.boolean(
             'Activate Centralization',
-            help='Uncheck to display all the details of centralized accounts.')
+            help='Uncheck to display all the details '
+            'of centralized accounts.'),
+
+        'group_by_partner': fields.boolean('Group by partner',
+                                           help="If you select this option "
+                                           "in General ledger report the "
+                                           "account 43.., 40... and 41.. is "
+                                           "group by Partner"),
     }
     _defaults = {
         'amount_currency': False,
@@ -85,7 +92,8 @@ class AccountReportGeneralLedgerWizard(orm.TransientModel):
                          ['amount_currency',
                           'display_account',
                           'account_ids',
-                          'centralize'],
+                          'centralize',
+                          'group_by_partner'],
                          context=context)[0]
         data['form'].update(vals)
         return data

--- a/account_financial_report_webkit/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_webkit/wizard/general_ledger_wizard_view.xml
@@ -21,6 +21,10 @@
                     <page name="filters" position="after">
                         <page string="Accounts Filters" name="accounts">
                             <separator string="Print only" colspan="4"/>
+                            <group name="group_by_partner">
+                                <field name="group_by_partner"/>
+                            </group>
+
                             <field name="account_ids" colspan="4" nolabel="1">
                                 <tree>
                                     <field name="code"/>


### PR DESCRIPTION
This pull request add new checkbox (Group by partner) in tab account from General ledger.
![general-ledger](https://cloud.githubusercontent.com/assets/19977041/26781484/07d10e24-49ef-11e7-9e0c-96a9aa0b7ec7.png)
If this check is active, when you print a General ledger, the accounts 40, 41 and 43 is group by the partner with their sums and their partner name with title.