### PR TITLE
[10.0] account_financial_report_qweb: all accounts allowed in Open Items report

### DIFF
--- a/account_financial_report_qweb/report/open_items.py
+++ b/account_financial_report_qweb/report/open_items.py
@@ -201,8 +201,8 @@ WITH
         query_inject_account += """
             WHERE
                 a.company_id = %s
-            AND a.internal_type IN ('payable', 'receivable')
-                    """
+            AND a.reconcile IS true
+            """
         if self.filter_account_ids:
             query_inject_account += """
             AND

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -29,6 +29,7 @@ class OpenItemsReportWizard(models.TransientModel):
     account_ids = fields.Many2many(
         comodel_name='account.account',
         string='Filter accounts',
+        domain=[('reconcile', '=', True)],
     )
     hide_account_balance_at_0 = fields.Boolean(
         string='Hide account ending balance at 0',


### PR DESCRIPTION
The open items report can also be interesting for accounts with are not "payable" nor "receivable". For example, some companies like to reconcile their VAT accounts and want to use the Open Items report to inspect the unreconciled move lines in their VAT accounts.

This is a similar change as the one I introduced in v8 via this PR https://github.com/OCA/account-financial-reporting/pull/228