### PR TITLE
[9.0][mis_builder] remove  version="7.0" tag as it breaks save button

### DIFF
--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -95,7 +95,7 @@
             <field name="name">mis.report.view.kpi.form</field>
             <field name="model">mis.report.kpi</field>
             <field name="arch" type="xml">
-                <form string="MIS Report KPI" version="7.0">
+                <form string="MIS Report KPI">
                     <group col="4">
                         <field name="description"/>
                         <field name="name"/>


### PR DESCRIPTION
It seems that this  version="7.0" tag is breaking save buttons for this form. I've manually removed the tag and everything is working fine. Is this tag really needed?