### PR TITLE
[9.0][mis_builder] add self, date_from and date_to on mis_builder localcontext

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -809,6 +809,9 @@ class MisReport(models.Model):
             'max': _max,
             'len': len,
             'avg': _avg,
+            'time': time,
+            'datetime': datetime,
+            'dateutil': dateutil,
             'AccountingNone': AccountingNone,
             'SimpleArray': SimpleArray,
         }

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -803,6 +803,7 @@ class MisReport(models.Model):
 
     def prepare_locals_dict(self):
         return {
+            'self': self,
             'sum': _sum,
             'min': _min,
             'max': _max,
@@ -918,6 +919,7 @@ class MisReport(models.Model):
             locals_dict = {}
 
         locals_dict.update(self.prepare_locals_dict())
+        locals_dict.update({'date_from': date_from, 'date_to': date_to})
 
         # fetch non-accounting queries
         locals_dict.update(self._fetch_queries(


### PR DESCRIPTION
Add self, date_from and date_to varaibles on local context for more flexibility on kpis design.
