### PR TITLE
[10.0][mis_builder] Allow empty date_field for queries and period behavior

### DIFF
--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -698,7 +698,7 @@ class MisReportQuery(models.Model):
                                   ('min', _('Min')),
                                   ('max', _('Max'))],
                                  string='Aggregate')
-    date_field = fields.Many2one('ir.model.fields', required=True,
+    date_field = fields.Many2one('ir.model.fields'
                                  string='Date field',
                                  domain=[('ttype', 'in',
                                          ('date', 'datetime'))])
@@ -848,10 +848,10 @@ class MisReport(models.Model):
                 safe_eval(query.domain, eval_context) or []
             if get_additional_query_filter:
                 domain.extend(get_additional_query_filter(query))
-            if query.date_field.ttype == 'date':
+            if query.date_field and query.date_field.ttype == 'date':
                 domain.extend([(query.date_field.name, '>=', date_from),
                                (query.date_field.name, '<=', date_to)])
-            else:
+            elif query.date_field:
                 datetime_from = _utc_midnight(
                     date_from, self._context.get('tz', 'UTC'))
                 datetime_to = _utc_midnight(

--- a/mis_builder/models/mis_report.py
+++ b/mis_builder/models/mis_report.py
@@ -854,9 +854,9 @@ class MisReport(models.Model):
                 safe_eval(query.domain, eval_context) or []
             if get_additional_query_filter:
                 domain.extend(get_additional_query_filter(query))
-            if query.period_filter != 'none':
+            if query.period_filter != 'none' and query.date_field:
                 date_field = query.date_field.name
-                if query.date_field and query.date_field.ttype == 'date':
+                if query.date_field.ttype == 'date':
                     if query.period_filter == 'both':
                         domain.extend([(date_field, '>=', date_from),
                                        (date_field, '<=', date_to)])
@@ -864,7 +864,7 @@ class MisReport(models.Model):
                         domain.extend([(date_field, '>=', date_from)])
                     elif query.period_filter == 'to':
                         domain.extend([(date_field, '<=', date_to)])
-                elif query.date_field:
+                else:
                     datetime_from = _utc_midnight(
                         date_from, self._context.get('tz', 'UTC'))
                     datetime_to = _utc_midnight(

--- a/mis_builder/views/mis_report.xml
+++ b/mis_builder/views/mis_report.xml
@@ -42,6 +42,7 @@
                                 <field name="field_names"/>
                                 <field name="aggregate"/>
                                 <field name="date_field" domain="[('model_id', '=', model_id), ('ttype', 'in', ('date', 'datetime'))]"/>
+                                <field name="period_filter"/>
                                 <field name="domain"/>
                             </tree>
                         </field>


### PR DESCRIPTION
So that it's possible to search things independently from period.
For example if you want to get the number of employees.