### PR TITLE
[FIX] account_financial_report_webkit: General Ledger, HTML escaping

### DIFF
--- a/account_financial_report_webkit/__openerp__.py
+++ b/account_financial_report_webkit/__openerp__.py
@@ -20,7 +20,7 @@
 ##############################################################################
 {
     'name': 'Financial Reports - Webkit',
-    'version': '8.0.1.2.0',
+    'version': '8.0.1.2.1',
     'author': (
         "Camptocamp,"
         "Savoir-faire Linux,"

--- a/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
+++ b/account_financial_report_webkit/report/templates/account_report_general_ledger.mako
@@ -195,7 +195,7 @@
                           ## move reference
                           <div class="act_as_cell">${line.get('lref') or ''}</div>
                           ## label
-                          <div class="act_as_cell">${label}</div>
+                          <div class="act_as_cell">${label | h}</div>
                           ## counterpart
                           <div class="act_as_cell">${line.get('counterparts') or ''}</div>
                           ## debit


### PR DESCRIPTION
We have to escape the HTML characters when printing the label (e.g. '<' and '>' characters mess up the report layout).