### PR TITLE
[10.0] account_financial_report_qweb: support date_range shared between companies

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.1.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
@@ -13,7 +13,7 @@
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}">
                     <group name="filters">
                         <group name="date_range">
-                            <field name="date_range_id" domain="[('company_id','=',company_id)]"/>
+                            <field name="date_range_id" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>

--- a/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
@@ -13,7 +13,7 @@
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}">
                     <group name="filters">
                         <group name="date_range">
-                            <field name="date_range_id" domain="[('company_id','=',company_id)]"/>
+                            <field name="date_range_id" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>


### PR DESCRIPTION
In a multi-company context it is interesting to share a set of date_range between all companies of the group.
This PR allows to use them in financial reports.