### PR TITLE
[fix] index errors when we acces to list if the are not lines 

### DIFF
--- a/account_journal_report_xls/report/nov_account_journal.py
+++ b/account_journal_report_xls/report/nov_account_journal.py
@@ -182,6 +182,8 @@ class nov_journal_print(report_sxw.rml_parse):
                         (tuple(period_ids), journal_id,
                          tuple(self.move_states)))
         lines = self.cr.dictfetchall()
+        if not lines:
+            return lines
 
         # add reference of corresponding origin document
         if journal.type in ('sale', 'sale_refund', 'purchase',


### PR DESCRIPTION
If we check to group lines and one journal contains no move lines, access by index raise an exception 
ex:  lines_in[0] in this method def _group_lines(self, lines_in)