### PR TITLE
Change OpenERP to Odoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Coverage Status](https://coveralls.io/repos/OCA/account-financial-reporting/badge.png?branch=10.0)](https://coveralls.io/r/OCA/account-financial-reporting?branch=10.0)
 
 Odoo account financial reports
-=================================
+==============================
 
 This project aims to deal with modules related to financial reports. You'll 
 find modules that print legal and official reports. This includes, among 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/OCA/account-financial-reporting.svg?branch=10.0)](https://travis-ci.org/OCA/account-financial-reporting)
 [![Coverage Status](https://coveralls.io/repos/OCA/account-financial-reporting/badge.png?branch=10.0)](https://coveralls.io/r/OCA/account-financial-reporting?branch=10.0)
 
-OpenERP account financial reports
+Odoo account financial reports
 =================================
 
 This project aims to deal with modules related to financial reports. You'll 


### PR DESCRIPTION
The name OpenERP doesn't exists anymore. It's called Odoo now.