### PR TITLE
[8.0] [FIX] open invoices report: Include open invoices from previous years still to be paid

### DIFF
--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -120,7 +120,7 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
         group_by_currency = self._get_form_param('group_by_currency', data)
 
         if main_filter == 'filter_no' and fiscalyear:
-            start_period = self.get_first_fiscalyear_period(fiscalyear)
+            start_period = self._get_first_special_period()
             stop_period = self.get_last_fiscalyear_period(fiscalyear)
 
         # Retrieving accounts


### PR DESCRIPTION
When a fiscal year is selected, start from the first special period instead of the first period of the fiscal year.  Otherwise outstanding invoices from previous years are not shown.

README states that it "shows open invoices from previous years"

When starting from the first period of the year, the report does not include outstanding invoices of previous years. The first special period is the first opening period in odoo having the initial partner balance.