### PR TITLE
[8.0] [FIX] Partner balance - Initial balance and first special period

### DIFF
--- a/account_financial_report_webkit/README.rst
+++ b/account_financial_report_webkit/README.rst
@@ -165,6 +165,7 @@ Contributors
 * Nicolas Bessi
 * Guewen Baconnier
 * David Dufresne <david.dufresne@savoirfairelinux.com>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Maintainer
 ----------


### PR DESCRIPTION
The partner balance initial balance is wrongly computed when you have moves on periods before your first special period.
The first special period is the period where you have your initial balance of each partner. (i.e start point of computation for partner balance)
The initial balance was computed taking also into account all moves before the start date of your partner balance report.
This fix ensure you do not go beyond the first special period.