### PR TITLE
[10.0][account_financial_report_qweb] fix multicurrency support

### DIFF
--- a/account_financial_report_qweb/report/general_ledger.py
+++ b/account_financial_report_qweb/report/general_ledger.py
@@ -976,7 +976,7 @@ INNER JOIN
 LEFT JOIN
     account_full_reconcile fr ON ml.full_reconcile_id = fr.id
 LEFT JOIN
-    res_currency c ON a.currency_id = c.id
+    res_currency c ON ml.currency_id = c.id
                     """
         if self.filter_cost_center_ids:
             query_inject_move_line += """
@@ -1086,7 +1086,8 @@ WITH
                 )::date AS date,
                 SUM(ml.debit) AS debit,
                 SUM(ml.credit) AS credit,
-                SUM(ml.balance) AS balance
+                SUM(ml.balance) AS balance,
+                ml.currency_id AS currency_id
             FROM
                 report_general_ledger_qweb_account ra
             INNER JOIN
@@ -1119,7 +1120,7 @@ WITH
             """
         query_inject_move_line_centralized += """
             GROUP BY
-                ra.id, ml.account_id, a.code, 2
+                ra.id, ml.account_id, a.code, 2, ml.currency_id
         )
 INSERT INTO
     report_general_ledger_qweb_move_line
@@ -1154,7 +1155,7 @@ INNER JOIN
 INNER JOIN
     account_account a ON ml.account_id = a.id
 LEFT JOIN
-    res_currency c ON a.currency_id = c.id
+    res_currency c ON ml.currency_id = c.id
 WHERE
     ra.report_id = %s
 AND

--- a/account_financial_report_qweb/report/open_items.py
+++ b/account_financial_report_qweb/report/open_items.py
@@ -361,7 +361,8 @@ FROM
                         THEN pr.amount_currency
                         ELSE NULL
                     END
-                ) AS partial_amount_currency
+                ) AS partial_amount_currency,
+                ml.currency_id
             FROM
                 report_open_items_qweb_partner rp
             INNER JOIN
@@ -469,13 +470,15 @@ WITH
                             ELSE amount_currency + SUM(partial_amount_currency)
                         END
                     ELSE amount_currency
-                END AS amount_residual_currency
+                END AS amount_residual_currency,
+                currency_id
             FROM
                 move_lines_amount
             GROUP BY
                 id,
                 balance,
-                amount_currency
+                amount_currency,
+                currency_id
         )
 INSERT INTO
     report_open_items_qweb_move_line
@@ -557,7 +560,7 @@ INNER JOIN
 LEFT JOIN
     account_full_reconcile fr ON ml.full_reconcile_id = fr.id
 LEFT JOIN
-    res_currency c ON a.currency_id = c.id
+    res_currency c ON ml2.currency_id = c.id
 WHERE
     ra.report_id = %s
 AND

--- a/account_financial_report_qweb/report/templates/general_ledger.xml
+++ b/account_financial_report_qweb/report/templates/general_ledger.xml
@@ -126,12 +126,10 @@
                     <div class="act_as_cell amount" style="width: 75px;">Credit</div>
                     <!--## balance cumulated-->
                     <div class="act_as_cell amount" style="width: 75px;">Cumul. Bal.</div>
-                    <t t-if="has_second_currency">
-                        <!--## currency_name-->
-                        <div class="act_as_cell" style="width: 35px;">Cur.</div>
-                        <!--## amount_currency-->
-                        <div class="act_as_cell amount" style="width: 75px;">Amount cur.</div>
-                    </t>
+                    <!--## currency_name-->
+                    <div class="act_as_cell" style="width: 35px;">Cur.</div>
+                    <!--## amount_currency-->
+                    <div class="act_as_cell amount" style="width: 75px;">Amount cur.</div>
                 </div>
             </div>
 
@@ -161,12 +159,10 @@
                 <div class="act_as_cell amount"><span t-field="account_or_partner_object.initial_credit"/></div>
                 <!--## balance cumulated-->
                 <div class="act_as_cell amount"><span t-field="account_or_partner_object.initial_balance"/></div>
-                <t t-if="has_second_currency">
-                    <!--## currency_name-->
-                    <div class="act_as_cell"></div>
-                    <!--## amount_currency-->
-                    <div class="act_as_cell"></div>
-                </t>
+                <!--## currency_name-->
+                <div class="act_as_cell"></div>
+                <!--## amount_currency-->
+                <div class="act_as_cell"></div>
             </div>
 
             <!-- Display each lines -->
@@ -197,17 +193,15 @@
                     <div class="act_as_cell amount"><span t-field="line.credit"/></div>
                     <!--## balance cumulated-->
                     <div class="act_as_cell amount"><span t-field="line.cumul_balance"/></div>
-                    <t t-if="has_second_currency">
-                        <!--## currency_name-->
-                        <div class="act_as_cell"><span t-field="line.currency_name"/></div>
-                        <t t-if="line.currency_name">
-                            <!--## amount_currency-->
-                            <div class="act_as_cell amount"><span t-field="line.amount_currency"/></div>
-                        </t>
-                        <t t-if="not line.currency_name">
-                            <!--## amount_currency-->
-                            <div class="act_as_cell"></div>
-                        </t>
+                    <!--## currency_name-->
+                    <div class="act_as_cell"><span t-field="line.currency_name"/></div>
+                    <t t-if="line.currency_name">
+                        <!--## amount_currency-->
+                        <div class="act_as_cell amount"><span t-field="line.amount_currency"/></div>
+                    </t>
+                    <t t-if="not line.currency_name">
+                        <!--## amount_currency-->
+                        <div class="act_as_cell"></div>
                     </t>
                 </div>
             </t>
@@ -239,10 +233,8 @@
                 <div class="act_as_cell amount" style="width: 75px;"><span t-field="account_or_partner_object.final_credit"/></div>
                 <!--## balance cumulated-->
                 <div class="act_as_cell amount" style="width: 75px; padding-right: 1px;"><span t-field="account_or_partner_object.final_balance"/></div>
-                <t t-if="has_second_currency">
-                    <!--## currency_name + amount_currency-->
-                    <div class="act_as_cell" style="width: 110px;"></div>
-                </t>
+                <!--## currency_name + amount_currency-->
+                <div class="act_as_cell" style="width: 110px;"></div>
             </div>
         </div>
     </template>

--- a/account_financial_report_qweb/report/templates/open_items.xml
+++ b/account_financial_report_qweb/report/templates/open_items.xml
@@ -103,14 +103,12 @@
                     <div class="act_as_cell" style="width: 75px;">Original</div>
                     <!--## amount_residual-->
                     <div class="act_as_cell" style="width: 75px;">Residual</div>
-                    <t t-if="has_second_currency">
-                        <!--## currency_name-->
-                        <div class="act_as_cell" style="width: 35px;">Cur.</div>
-                        <!--## amount_total_due_currency-->
-                        <div class="act_as_cell amount" style="width: 75px;">Cur. Original</div>
-                        <!--## amount_residual_currency-->
-                        <div class="act_as_cell amount" style="width: 75px;">Cur. Residual</div>
-                    </t>
+                    <!--## currency_name-->
+                    <div class="act_as_cell" style="width: 35px;">Cur.</div>
+                    <!--## amount_total_due_currency-->
+                    <div class="act_as_cell amount" style="width: 75px;">Cur. Original</div>
+                    <!--## amount_residual_currency-->
+                    <div class="act_as_cell amount" style="width: 75px;">Cur. Residual</div>
                 </div>
             </div>
 
@@ -136,21 +134,19 @@
                     <div class="act_as_cell amount"><span t-field="line.amount_total_due"/></div>
                     <!--## amount_residual-->
                     <div class="act_as_cell amount"><span t-field="line.amount_residual"/></div>
-                    <t t-if="has_second_currency">
-                        <!--## currency_name-->
-                        <div class="act_as_cell"><span t-field="line.currency_name"/></div>
-                        <t t-if="line.currency_name">
-                            <!--## amount_total_due_currency-->
-                            <div class="act_as_cell amount"><span t-field="line.amount_total_due_currency"/></div>
-                            <!--## amount_residual_currency-->
-                            <div class="act_as_cell amount"><span t-field="line.amount_residual_currency"/></div>
-                        </t>
-                        <t t-if="not line.currency_name">
-                            <!--## amount_total_due_currency-->
-                            <div class="act_as_cell"></div>
-                            <!--## amount_residual_currency-->
-                            <div class="act_as_cell"></div>
-                        </t>
+                    <!--## currency_name-->
+                    <div class="act_as_cell"><span t-field="line.currency_name"/></div>
+                    <t t-if="line.currency_name">
+                        <!--## amount_total_due_currency-->
+                        <div class="act_as_cell amount"><span t-field="line.amount_total_due_currency"/></div>
+                        <!--## amount_residual_currency-->
+                        <div class="act_as_cell amount"><span t-field="line.amount_residual_currency"/></div>
+                    </t>
+                    <t t-if="not line.currency_name">
+                        <!--## amount_total_due_currency-->
+                        <div class="act_as_cell"></div>
+                        <!--## amount_residual_currency-->
+                        <div class="act_as_cell"></div>
                     </t>
                 </div>
             </t>
@@ -176,10 +172,8 @@
                 <div class="act_as_cell amount" style="width: 75px;"></div>
                 <!--## amount_currency-->
                 <div class="act_as_cell amount" style="width: 75px;"><span t-field="account_or_partner_object.final_amount_residual"/></div>
-                <t t-if="has_second_currency">
-                    <!--## currency_name + amount_total_due_currency + amount_residual_currency -->
-                    <div class="act_as_cell" style="width: 185px;"></div>
-                </t>
+                <!--## currency_name + amount_total_due_currency + amount_residual_currency -->
+                <div class="act_as_cell" style="width: 185px;"></div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
This PR fixes the support for multicurrency.

Prior to this PR, the secondary currency would only appear in the general ledger and open items reports when the GL account had a secondary currency.

But this does not make sense because you often post transaction using another currency, to an account that is held in the company currency, and in those cases you still want to evaluate the general ledger and open items reports in terms of also the currency of the transaction, in addition to the company currency.

cc @fclementic2c 

