### PR TITLE
[8.0][FIX] open invoices - last_rec_date field value cannot be before the period start date

### DIFF
--- a/account_financial_report_webkit/migrations/8.0.1.2.0/post-migration.py
+++ b/account_financial_report_webkit/migrations/8.0.1.2.0/post-migration.py
@@ -17,13 +17,15 @@ def migrate(cr, version):
         """
         UPDATE account_move_line SET last_rec_date = rec_data.aml_date
         FROM (
-            SELECT rec.id, max(aml.date) as aml_date
+            SELECT rec.id, max(greatest(aml.date,ap.date_start)) as aml_date
             FROM account_move_line aml
+            JOIN account_period ap ON aml.period_id=ap.id
             JOIN account_move_reconcile rec
             ON rec.id = aml.reconcile_id
             GROUP BY rec.id
         ) as rec_data
         WHERE rec_data.id = account_move_line.reconcile_id
+        AND account_move_line.reconcile_id IS NOT NULL
         """
     )
 
@@ -31,12 +33,14 @@ def migrate(cr, version):
         """
         UPDATE account_move_line SET last_rec_date = rec_data.aml_date
         FROM (
-            SELECT rec.id, max(aml.date) as aml_date
+            SELECT rec.id, max(greatest(aml.date,ap.date_start)) as aml_date
             FROM account_move_line aml
+            JOIN account_period ap ON aml.period_id=ap.id
             JOIN account_move_reconcile rec
             ON rec.id = aml.reconcile_partial_id
             GROUP BY rec.id
         ) as rec_data
         WHERE rec_data.id = account_move_line.reconcile_partial_id
+        AND account_move_line.reconcile_partial_id IS NOT NULL
         """
     )

--- a/account_financial_report_webkit/models/account_move_line.py
+++ b/account_financial_report_webkit/models/account_move_line.py
@@ -30,10 +30,14 @@ class AccountMoveLine(models.Model):
         for line in self:
             if line.reconcile_id:
                 move_lines = line.reconcile_id.line_id
-                last_line = move_lines.sorted(lambda l: l.date)[-1]
-                line.last_rec_date = last_line.date
+                last_line = move_lines.sorted(
+                    lambda l: max(l.date, l.period_id.date_start))[-1]
+                line.last_rec_date = max(
+                    last_line.date, last_line.period_id.date_start)
 
             elif line.reconcile_partial_id:
                 move_lines = line.reconcile_partial_id.line_partial_ids
-                last_line = move_lines.sorted(lambda l: l.date)[-1]
-                line.last_rec_date = last_line.date
+                last_line = move_lines.sorted(
+                    lambda l: max(l.date, l.period_id.date_start))[-1]
+                line.last_rec_date = max(
+                    last_line.date, last_line.period_id.date_start)


### PR DESCRIPTION
The last_rec_date is used in the open invoices report.

If you allow to have account move line dates outside the related period boundaries, then you need to take care of the period dates when computing the last_rec_date.
Consider a purchase where you get an invoice dated on 2016 and you pay it in 2016 but you encode the invoice only in 2017. Looking at the move lines, the payment is declared in 2016 (debit) and the purchase is declared in 2017 (credit). However, looking only at the move lines dates, they both are dated in 2016. So it is important to not consider the 2 lines as reconciled in 2016 and keep the payment as open on 2016.

Note also this previous merged fix https://github.com/OCA/account-financial-reporting/pull/213
On both cases, you need to force the re-computation of the field (see migration script)