### PR TITLE
[11.0][account_financial_report] remove dependency with account_fiscal_year

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -16,7 +16,6 @@
     'depends': [
         'account',
         'date_range',
-        'account_fiscal_year',
         'report_xlsx',
     ],
     'data': [

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,4 +1,3 @@
 server-ux
-account-financial-tools https://github.com/Eficent/account-financial-tools 11.0-mig-account_fiscal_year
 reporting-engine https://github.com/OCA/reporting-engine
 server-ux https://github.com/OCA/server-ux


### PR DESCRIPTION
The dependency is not required for the reports to run correctly.

cc @sbidoul @pedrobaeza 