### PR TITLE
[IMP] account_financial_report_qweb: Remove unneeded dependency

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -16,7 +16,6 @@
     'depends': [
         'account',
         'date_range',
-        'account_fiscal_year',
         'report_xlsx',
         'report',
     ],


### PR DESCRIPTION
Module `account_fiscal_year` allows companies with fiscal years with duration different from 1 year to make financial reporting, but the method used is overwrting a standard method `compute_fiscalyear_dates` on company, so it's transparent for this module, and you don't need to have it installed for most of the companies, that have regular fiscal years.

This is the same as #372, but for 10.0

@Tecnativa