### PR TITLE
[10.0] AFR Aged partner balance : columns and datas consistency.

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.1.2.0',
+    'version': '10.0.1.3.0',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/report/aged_partner_balance.py
+++ b/account_financial_report_qweb/report/aged_partner_balance.py
@@ -307,12 +307,11 @@ WITH
     date_range AS
         (
             SELECT
-                %s AS date_current,
+                DATE %s AS date_current,
                 DATE %s - INTEGER '30' AS date_less_30_days,
                 DATE %s - INTEGER '60' AS date_less_60_days,
                 DATE %s - INTEGER '90' AS date_less_90_days,
-                DATE %s - INTEGER '120' AS date_less_120_days,
-                DATE %s - INTEGER '150' AS date_older
+                DATE %s - INTEGER '120' AS date_less_120_days
         )
 INSERT INTO
     report_aged_partner_balance_qweb_line
@@ -337,45 +336,45 @@ SELECT
     SUM(rlo.amount_residual) AS amount_residual,
     SUM(
         CASE
-            WHEN rlo.date_due > date_range.date_less_30_days
+            WHEN rlo.date_due >= date_range.date_current
             THEN rlo.amount_residual
         END
     ) AS current,
     SUM(
         CASE
             WHEN
-                rlo.date_due > date_range.date_less_60_days
-                AND rlo.date_due <= date_range.date_less_30_days
+                rlo.date_due >= date_range.date_less_30_days
+                AND rlo.date_due < date_range.date_current
             THEN rlo.amount_residual
         END
     ) AS age_30_days,
     SUM(
         CASE
             WHEN
-                rlo.date_due > date_range.date_less_90_days
-                AND rlo.date_due <= date_range.date_less_60_days
+                rlo.date_due >= date_range.date_less_60_days
+                AND rlo.date_due < date_range.date_less_30_days
             THEN rlo.amount_residual
         END
     ) AS age_60_days,
     SUM(
         CASE
             WHEN
-                rlo.date_due > date_range.date_less_120_days
-                AND rlo.date_due <= date_range.date_less_90_days
+                rlo.date_due >= date_range.date_less_90_days
+                AND rlo.date_due < date_range.date_less_60_days
             THEN rlo.amount_residual
         END
     ) AS age_90_days,
     SUM(
         CASE
             WHEN
-                rlo.date_due > date_range.date_older
-                AND rlo.date_due <= date_range.date_less_120_days
+                rlo.date_due >= date_range.date_less_120_days
+                AND rlo.date_due < date_range.date_less_90_days
             THEN rlo.amount_residual
         END
     ) AS age_120_days,
     SUM(
         CASE
-            WHEN rlo.date_due <= date_range.date_older
+            WHEN rlo.date_due < date_range.date_less_120_days
             THEN rlo.amount_residual
         END
     ) AS older
@@ -409,7 +408,7 @@ AND ra.report_id = %s
 GROUP BY
     rp.id
         """
-        query_inject_line_params = (self.date_at,) * 6
+        query_inject_line_params = (self.date_at,) * 5
         query_inject_line_params += (
             self.env.uid,
             self.open_items_id.id,
@@ -428,12 +427,11 @@ WITH
     date_range AS
         (
             SELECT
-                %s AS date_current,
+                DATE %s AS date_current,
                 DATE %s - INTEGER '30' AS date_less_30_days,
                 DATE %s - INTEGER '60' AS date_less_60_days,
                 DATE %s - INTEGER '90' AS date_less_90_days,
-                DATE %s - INTEGER '120' AS date_less_120_days,
-                DATE %s - INTEGER '150' AS date_older
+                DATE %s - INTEGER '120' AS date_less_120_days
         )
 INSERT INTO
     report_aged_partner_balance_qweb_move_line
@@ -469,35 +467,35 @@ SELECT
     rlo.label,
     rlo.amount_residual AS amount_residual,
     CASE
-        WHEN rlo.date_due > date_range.date_less_30_days
+        WHEN rlo.date_due >= date_range.date_current
         THEN rlo.amount_residual
     END AS current,
     CASE
         WHEN
-            rlo.date_due > date_range.date_less_60_days
-            AND rlo.date_due <= date_range.date_less_30_days
+            rlo.date_due >= date_range.date_less_30_days
+            AND rlo.date_due < date_range.date_current
         THEN rlo.amount_residual
     END AS age_30_days,
     CASE
         WHEN
-            rlo.date_due > date_range.date_less_90_days
-            AND rlo.date_due <= date_range.date_less_60_days
+            rlo.date_due >= date_range.date_less_60_days
+            AND rlo.date_due < date_range.date_less_30_days
         THEN rlo.amount_residual
     END AS age_60_days,
     CASE
         WHEN
-            rlo.date_due > date_range.date_less_120_days
-            AND rlo.date_due <= date_range.date_less_90_days
+            rlo.date_due >= date_range.date_less_90_days
+            AND rlo.date_due < date_range.date_less_60_days
         THEN rlo.amount_residual
     END AS age_90_days,
     CASE
         WHEN
-            rlo.date_due > date_range.date_older
-            AND rlo.date_due <= date_range.date_less_120_days
+            rlo.date_due >= date_range.date_less_120_days
+            AND rlo.date_due < date_range.date_less_90_days
         THEN rlo.amount_residual
     END AS age_120_days,
     CASE
-        WHEN rlo.date_due <= date_range.date_older
+        WHEN rlo.date_due < date_range.date_less_120_days
         THEN rlo.amount_residual
     END AS older
 FROM
@@ -528,7 +526,7 @@ WHERE
     rao.report_id = %s
 AND ra.report_id = %s
         """
-        query_inject_move_line_params = (self.date_at,) * 6
+        query_inject_move_line_params = (self.date_at,) * 5
         query_inject_move_line_params += (
             self.env.uid,
             self.open_items_id.id,

--- a/account_financial_report_qweb/report/templates/aged_partner_balance.xml
+++ b/account_financial_report_qweb/report/templates/aged_partner_balance.xml
@@ -100,7 +100,7 @@
                 <!--## amount_residual-->
                 <div class="act_as_cell" style="width: 110px;">Residual</div>
                 <!--## current-->
-                <div class="act_as_cell" style="width: 110px;">Current</div>
+                <div class="act_as_cell" style="width: 110px;">Not due</div>
                 <!--## age_30_days-->
                 <div class="act_as_cell" style="width: 110px;">Age ≤ 30 d.</div>
                 <!--## age_60_days-->

--- a/account_financial_report_qweb/report/templates/aged_partner_balance.xml
+++ b/account_financial_report_qweb/report/templates/aged_partner_balance.xml
@@ -102,15 +102,15 @@
                 <!--## current-->
                 <div class="act_as_cell" style="width: 110px;">Not due</div>
                 <!--## age_30_days-->
-                <div class="act_as_cell" style="width: 110px;">Age ≤ 30 d.</div>
+                <div class="act_as_cell" style="width: 110px;">1 - 30 d.</div>
                 <!--## age_60_days-->
-                <div class="act_as_cell" style="width: 110px;">Age ≤ 60 d.</div>
+                <div class="act_as_cell" style="width: 110px;">31 - 60 d.</div>
                 <!--## age_90_days-->
-                <div class="act_as_cell" style="width: 110px;">Age ≤ 90 d.</div>
+                <div class="act_as_cell" style="width: 110px;">61 - 90 d.</div>
                 <!--## age_120_days-->
-                <div class="act_as_cell" style="width: 110px;">Age ≤ 120 d.</div>
+                <div class="act_as_cell" style="width: 110px;">91 - 120 d.</div>
                 <!--## older-->
-                <div class="act_as_cell" style="width: 110px;">Older</div>
+                <div class="act_as_cell" style="width: 110px;"> > 120 d.</div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
I created some invoices with those datas

| Date  | Due date | Amount |
| ---------------- | ---------------- | --------------|
| 15/12/2017  | 15/01/2018  | 500     |
| 15/11/2017  | 15/12/2017  | 1000     |
| 15/10/2017  | 15/11/2017  | 2000     |
| 15/09/2017  | 15/10/2017  | 4000     |
| 15/08/2017  | 15/09/2017  | 8000     |
| 15/07/2017  | 15/08/2017  | 160000     |

So, when I print the aged partner balance at the 31/12/2017 I except this kind of result :

| Current (means not due ?)  | <= 30 days (until 01/12/2017) | <= 60 days (until 01/11/2017) | <= 90 days (until 02/10/2017) | <= 120 days (until 02/09/2017) | Older (> 120 days) |
| ---------------- | ---------------- | --------------| ---------------- | ---------------- | --------------|
| 500 | 1000 | 2000 | 4000 | 8000 | 160000 |

I got the following result

![aged1](https://user-images.githubusercontent.com/8035793/36467877-16e919dc-16e1-11e8-9110-b62208fac155.png)

So, in the current column, we have a mix between not due amount and amount with a due date <= 30 days. On the <= 30 days column with have amount with a due date between 30 and 60 days. And so on.

I got this result with this PR

![aged2](https://user-images.githubusercontent.com/8035793/36467991-b916eb1c-16e1-11e8-88b6-a6a03d43d110.png)

