### PR TITLE
[11.0][IMP] account_financial_report: adapt the wizards to multicompany

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -54,6 +54,7 @@ Contributors
 * Akim Juillerat <akim.juillerat@camptocamp.com>
 * Alexis de Lattre <alexis@via.ecp.fr>
 * Mihai Fekete <feketemihai@gmail.com>
+* Miquel Raïch <miquel.raich@eficent.com>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '11.0.2.0.0',
+    'version': '11.0.2.1.0',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -18,6 +18,7 @@ class AgedPartnerBalance(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
+        required=True,
         string='Company'
     )
     date_at = fields.Date(required=True,
@@ -39,11 +40,22 @@ class AgedPartnerBalance(models.TransientModel):
     )
     show_move_line_details = fields.Boolean()
 
+    @api.onchange('company_id')
+    def onchange_company_id(self):
+        """Handle company change."""
+        if self.company_id and self.partner_ids:
+            self.partner_ids = self.partner_ids.filtered(
+                lambda p: p.company_id == self.company_id or
+                not p.company_id)
+        if self.company_id and self.account_ids:
+            self.account_ids = self.account_ids.filtered(
+                lambda a: a.company_id == self.company_id)
+
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = []
+            domain = [('company_id', '=', self.company_id.id)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [('internal_type', 'in', ('receivable', 'payable'))]
             elif self.receivable_accounts_only:

--- a/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
@@ -20,14 +20,14 @@
                     </group>
                 </group>
                 <label for="partner_ids"/>
-                <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
+                <field name="partner_ids" nolabel="1" options="{'no_create': True}" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                 <group/>
                 <label for="account_ids"/>
                 <group col="4">
                     <field name="receivable_accounts_only"/>
                     <field name="payable_accounts_only"/>
                 </group>
-                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}" domain="[('company_id','=',company_id)]"/>
                 <footer>
                     <button name="button_export_html" string="View"
                             type="object" default_focus="1" class="oe_highlight"/>

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -7,9 +7,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.tools.safe_eval import safe_eval
 from odoo.tools import pycompat
+from odoo.exceptions import ValidationError
 
 
 class GeneralLedgerReportWizard(models.TransientModel):
@@ -21,6 +22,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
+        required=True,
         string='Company'
     )
     date_range_id = fields.Many2one(
@@ -81,6 +83,19 @@ class GeneralLedgerReportWizard(models.TransientModel):
                 ('company_id', '=', self.company_id.id)
             ])
         self.not_only_one_unaffected_earnings_account = count != 1
+        if self.company_id and self.date_range_id.company_id and \
+                self.date_range_id.company_id != self.company_id:
+            self.date_range_id = False
+        if self.company_id and self.partner_ids:
+            self.partner_ids = self.partner_ids.filtered(
+                lambda p: p.company_id == self.company_id or
+                not p.company_id)
+        if self.company_id and self.account_ids:
+            self.account_ids = self.account_ids.filtered(
+                lambda a: a.company_id == self.company_id)
+        if self.company_id and self.cost_center_ids:
+            self.cost_center_ids = self.cost_center_ids.filtered(
+                lambda c: c.company_id == self.company_id)
 
     @api.onchange('date_range_id')
     def onchange_date_range_id(self):
@@ -88,11 +103,21 @@ class GeneralLedgerReportWizard(models.TransientModel):
         self.date_from = self.date_range_id.date_start
         self.date_to = self.date_range_id.date_end
 
+    @api.multi
+    @api.constrains('company_id', 'date_range_id')
+    def _check_company_id_date_range_id(self):
+        for rec in self.sudo():
+            if rec.company_id and rec.date_range_id.company_id and\
+                    rec.company_id != rec.date_range_id.company_id:
+                raise ValidationError(
+                    _('The Company in the General Ledger Report Wizard and in '
+                      'Date Range must be the same.'))
+
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = []
+            domain = [('company_id', '=', self.company_id.id)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [('internal_type', 'in', ('receivable', 'payable'))]
             elif self.receivable_accounts_only:

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -25,17 +25,17 @@
                         </group>
                     </group>
                     <label for="cost_center_ids" groups="analytic.group_analytic_accounting"/>
-                    <field name="cost_center_ids" nolabel="1" options="{'no_create': True}" groups="analytic.group_analytic_accounting"/>
+                    <field name="cost_center_ids" nolabel="1" options="{'no_create': True}" groups="analytic.group_analytic_accounting" domain="[('company_id','=',company_id)]"/>
                     <group/>
                     <label for="partner_ids"/>
-                    <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
+                    <field name="partner_ids" nolabel="1" options="{'no_create': True}" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                     <group/>
                     <label for="account_ids"/>
                     <group col="4">
                         <field name="receivable_accounts_only"/>
                         <field name="payable_accounts_only"/>
                     </group>
-                    <field name="account_ids" widget="many2many_tags"  nolabel="1" options="{'no_create': True}"/>
+                    <field name="account_ids" widget="many2many_tags"  nolabel="1" options="{'no_create': True}" domain="[('company_id','=',company_id)]"/>
                 </div>
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}">
                     <field name="not_only_one_unaffected_earnings_account" invisible="1"/>

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -18,6 +18,7 @@ class OpenItemsReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
+        required=True,
         string='Company'
     )
     date_at = fields.Date(required=True,
@@ -46,11 +47,22 @@ class OpenItemsReportWizard(models.TransientModel):
         string='Filter partners',
     )
 
+    @api.onchange('company_id')
+    def onchange_company_id(self):
+        """Handle company change."""
+        if self.company_id and self.partner_ids:
+            self.partner_ids = self.partner_ids.filtered(
+                lambda p: p.company_id == self.company_id or
+                not p.company_id)
+        if self.company_id and self.account_ids:
+            self.account_ids = self.account_ids.filtered(
+                lambda a: a.company_id == self.company_id)
+
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = []
+            domain = [('company_id', '=', self.company_id.id)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [('internal_type', 'in', ('receivable', 'payable'))]
             elif self.receivable_accounts_only:

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -20,14 +20,14 @@
                     </group>
                 </group>
                 <label for="partner_ids"/>
-                <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
+                <field name="partner_ids" nolabel="1" options="{'no_create': True}" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                 <group/>
                 <label for="account_ids"/>
                 <group col="4">
                     <field name="receivable_accounts_only"/>
                     <field name="payable_accounts_only"/>
                 </group>
-                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}" domain="[('company_id','=',company_id)]"/>
                 <footer>
                     <button name="button_export_html" string="View"
                             type="object" default_focus="1" class="oe_highlight"/>

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -3,9 +3,10 @@
 # Copyright 2017 Akretion - Alexis de Lattre
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields, api
+from odoo import api, fields, models, _
 from odoo.tools.safe_eval import safe_eval
 from odoo.tools import pycompat
+from odoo.exceptions import ValidationError
 
 
 class TrialBalanceReportWizard(models.TransientModel):
@@ -17,6 +18,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
+        required=True,
         string='Company'
     )
     date_range_id = fields.Many2one(
@@ -77,6 +79,16 @@ class TrialBalanceReportWizard(models.TransientModel):
                 ('company_id', '=', self.company_id.id)
             ])
         self.not_only_one_unaffected_earnings_account = count != 1
+        if self.company_id and self.date_range_id.company_id and \
+                self.date_range_id.company_id != self.company_id:
+            self.date_range_id = False
+        if self.company_id and self.partner_ids:
+            self.partner_ids = self.partner_ids.filtered(
+                lambda p: p.company_id == self.company_id or
+                not p.company_id)
+        if self.company_id and self.account_ids:
+            self.account_ids = self.account_ids.filtered(
+                lambda a: a.company_id == self.company_id)
 
     @api.onchange('date_range_id')
     def onchange_date_range_id(self):
@@ -84,11 +96,21 @@ class TrialBalanceReportWizard(models.TransientModel):
         self.date_from = self.date_range_id.date_start
         self.date_to = self.date_range_id.date_end
 
+    @api.multi
+    @api.constrains('company_id', 'date_range_id')
+    def _check_company_id_date_range_id(self):
+        for rec in self.sudo():
+            if rec.company_id and rec.date_range_id.company_id and\
+                    rec.company_id != rec.date_range_id.company_id:
+                raise ValidationError(
+                    _('The Company in the Trial Balance Report Wizard and in '
+                      'Date Range must be the same.'))
+
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = []
+            domain = [('company_id', '=', self.company_id.id)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [('internal_type', 'in', ('receivable', 'payable'))]
             elif self.receivable_accounts_only:

--- a/account_financial_report/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report/wizard/trial_balance_wizard_view.xml
@@ -26,14 +26,14 @@
                         </group>
                     </group>
                     <label for="partner_ids" attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
-                    <field name="partner_ids" nolabel="1" options="{'no_create': True}" attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
+                    <field name="partner_ids" nolabel="1" options="{'no_create': True}" attrs="{'invisible':[('show_partner_details','!=',True)]}" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
                     <group attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
                     <label for="account_ids"/>
                     <group col="4">
                         <field name="receivable_accounts_only"/>
                         <field name="payable_accounts_only"/>
                     </group>
-                    <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                    <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}" domain="[('company_id','=',company_id)]"/>
                 </div>
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}">
                     <field name="not_only_one_unaffected_earnings_account" invisible="1"/>


### PR DESCRIPTION
This PR adapts the `account_financial_report `'s wizards to multicompany.

In multicompany, the company of the wizard is visible and can be changed. Thus, if in the wizard the company is changed, all the other data in the wizard should be adapted accordingly.