### PR TITLE
[FIX] account_financial_report_qweb: Move tests to post mode

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.1.5.0',
+    'version': '10.0.1.5.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/tests/abstract_test.py
+++ b/account_financial_report_qweb/tests/abstract_test.py
@@ -13,7 +13,7 @@ _logger = logging.getLogger(__name__)
 
 class AbstractTest(common.TransactionCase):
     """Common technical tests for all reports."""
-    at_install = True
+    at_install = False
     post_install = True
 
     accounts = {}


### PR DESCRIPTION
This fixes failing tests in integration environments where `account_analytic_required` is installed, which fail with:

    IntegrityError: null value in column "analytic_policy" violates not-null constraint

@Tecnativa