### PR TITLE
[ADD] [account_financial_report_horizontal] special treatment for profit&loss reports

### DIFF
--- a/account_financial_report_horizontal/models/account_financial_report.py
+++ b/account_financial_report_horizontal/models/account_financial_report.py
@@ -41,6 +41,14 @@ class AccountFinancialReport(models.Model):
             for report in reports:
                 if not report.parent_id:
                     result += report
+                # special treatment for profit and loss if they have the
+                # standard configuration type='other'
+                elif side == 'right' and report == self.env.ref(
+                        'account.account_financial_report_income0'
+                ) or side == 'left' and report == self.env.ref(
+                        'account.account_financial_report_expense0'
+                ):
+                    last_bad_report = report
                 # don't check children if we already checked the parent
                 elif report.parent_id == last_bad_report:
                     continue


### PR DESCRIPTION
as the account types for profit and loss are of type `other` in v10, profit and loss will be duplicated (see
[Financial.report.pdf](https://github.com/OCA/account-financial-reporting/files/2165479/Financial.report.pdf)), so we need special treatment for this reports.