### PR TITLE
[10.0][FIX] Assign journal_ids instead of partner_ids

### DIFF
--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -158,7 +158,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
             'company_id': self.company_id.id,
             'filter_account_ids': [(6, 0, self.account_ids.ids)],
             'filter_partner_ids': [(6, 0, self.partner_ids.ids)],
-            'filter_journal_ids': [(6, 0, self.partner_ids.ids)],
+            'filter_journal_ids': [(6, 0, self.journal_ids.ids)],
             'filter_cost_center_ids': [(6, 0, self.cost_center_ids.ids)],
             'centralize': self.centralize,
             'fy_start_date': self.fy_start_date,

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -154,7 +154,7 @@ class TrialBalanceReportWizard(models.TransientModel):
             'company_id': self.company_id.id,
             'filter_account_ids': [(6, 0, self.account_ids.ids)],
             'filter_partner_ids': [(6, 0, self.partner_ids.ids)],
-            'filter_journal_ids': [(6, 0, self.partner_ids.ids)],
+            'filter_journal_ids': [(6, 0, self.journal_ids.ids)],
             'fy_start_date': self.fy_start_date,
             'show_partner_details': self.show_partner_details,
         }


### PR DESCRIPTION
Commit :
- [0715040eab1645a1b9c4ca15ed112bb59b0ef88a](https://github.com/OCA/account-financial-reporting/commit/0715040eab1645a1b9c4ca15ed112bb59b0ef88a)
- [b803646c8a854468c85d2f5e048f39c078525b54](https://github.com/OCA/account-financial-reporting/commit/b803646c8a854468c85d2f5e048f39c078525b54)
Broke the module by assigning partner_ids to filter_journal_ids instead of the newly added journal_ids