### PR TITLE
[10.0][IMP] Improve transient models cleaning

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.1.5.2',
+    'version': '10.0.1.5.3',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/report/__init__.py
+++ b/account_financial_report_qweb/report/__init__.py
@@ -4,6 +4,7 @@
 # © 2016 Julien Coux (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
 
+from . import abstract_report
 from . import abstract_report_xlsx
 from . import aged_partner_balance
 from . import aged_partner_balance_xlsx

--- a/account_financial_report_qweb/report/abstract_report.py
+++ b/account_financial_report_qweb/report/abstract_report.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AbstractReport(models.AbstractModel):
+    _name = 'report_qweb_abstract'
+
+    def _transient_clean_rows_older_than(self, seconds):
+        assert self._transient, \
+            "Model %s is not transient, it cannot be vacuumed!" % self._name
+        # Never delete rows used in last 5 minutes
+        seconds = max(seconds, 300)
+        query = """
+DELETE FROM """ + self._table + """
+WHERE
+    COALESCE(write_date, create_date, (now() at time zone 'UTC'))::timestamp
+    < ((now() at time zone 'UTC') - interval %s)
+"""
+        self.env.cr.execute(query, ("%s seconds" % seconds,))

--- a/account_financial_report_qweb/report/aged_partner_balance.py
+++ b/account_financial_report_qweb/report/aged_partner_balance.py
@@ -19,6 +19,7 @@ class AgedPartnerBalanceReport(models.TransientModel):
     """
 
     _name = 'report_aged_partner_balance_qweb'
+    _inherit = 'report_qweb_abstract'
 
     # Filters fields, used for data computation
     date_at = fields.Date()
@@ -41,6 +42,7 @@ class AgedPartnerBalanceReport(models.TransientModel):
 class AgedPartnerBalanceReportAccount(models.TransientModel):
 
     _name = 'report_aged_partner_balance_qweb_account'
+    _inherit = 'report_qweb_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -84,6 +86,7 @@ class AgedPartnerBalanceReportAccount(models.TransientModel):
 class AgedPartnerBalanceReportPartner(models.TransientModel):
 
     _name = 'report_aged_partner_balance_qweb_partner'
+    _inherit = 'report_qweb_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_qweb_account',
@@ -128,6 +131,7 @@ ORDER BY
 class AgedPartnerBalanceReportLine(models.TransientModel):
 
     _name = 'report_aged_partner_balance_qweb_line'
+    _inherit = 'report_qweb_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_qweb_partner',
@@ -149,6 +153,7 @@ class AgedPartnerBalanceReportLine(models.TransientModel):
 class AgedPartnerBalanceReportMoveLine(models.TransientModel):
 
     _name = 'report_aged_partner_balance_qweb_move_line'
+    _inherit = 'report_qweb_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_qweb_partner',

--- a/account_financial_report_qweb/report/general_ledger.py
+++ b/account_financial_report_qweb/report/general_ledger.py
@@ -22,6 +22,7 @@ class GeneralLedgerReport(models.TransientModel):
     """
 
     _name = 'report_general_ledger_qweb'
+    _inherit = 'report_qweb_abstract'
 
     # Filters fields, used for data computation
     date_from = fields.Date()
@@ -72,6 +73,7 @@ class GeneralLedgerReport(models.TransientModel):
 class GeneralLedgerReportAccount(models.TransientModel):
 
     _name = 'report_general_ledger_qweb_account'
+    _inherit = 'report_qweb_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -116,6 +118,7 @@ class GeneralLedgerReportAccount(models.TransientModel):
 class GeneralLedgerReportPartner(models.TransientModel):
 
     _name = 'report_general_ledger_qweb_partner'
+    _inherit = 'report_qweb_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_general_ledger_qweb_account',
@@ -164,6 +167,7 @@ ORDER BY
 class GeneralLedgerReportMoveLine(models.TransientModel):
 
     _name = 'report_general_ledger_qweb_move_line'
+    _inherit = 'report_qweb_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_general_ledger_qweb_account',

--- a/account_financial_report_qweb/report/journal_report.py
+++ b/account_financial_report_qweb/report/journal_report.py
@@ -10,6 +10,7 @@ DIGITS = (16, 2)
 class ReportJournalQweb(models.TransientModel):
 
     _name = 'report_journal_qweb'
+    _inherit = 'report_qweb_abstract'
 
     date_from = fields.Date(
         required=True
@@ -622,6 +623,7 @@ class ReportJournalQweb(models.TransientModel):
 class ReportJournalQwebJournal(models.TransientModel):
 
     _name = 'report_journal_qweb_journal'
+    _inherit = 'report_qweb_abstract'
 
     name = fields.Char(
         required=True,
@@ -664,6 +666,7 @@ class ReportJournalQwebJournal(models.TransientModel):
 class ReportJournalQwebMove(models.TransientModel):
 
     _name = 'report_journal_qweb_move'
+    _inherit = 'report_qweb_abstract'
 
     report_id = fields.Many2one(
         comodel_name='report_journal_qweb',
@@ -695,6 +698,7 @@ class ReportJournalQwebMove(models.TransientModel):
 class ReportJournalQwebMoveLine(models.TransientModel):
 
     _name = 'report_journal_qweb_move_line'
+    _inherit = 'report_qweb_abstract'
     _order = 'partner_id desc, account_id desc'
 
     report_id = fields.Many2one(
@@ -760,6 +764,7 @@ class ReportJournalQwebMoveLine(models.TransientModel):
 class ReportJournalQwebReportTaxLine(models.TransientModel):
 
     _name = 'report_journal_qweb_report_tax_line'
+    _inherit = 'report_qweb_abstract'
     _order = 'tax_code'
 
     report_id = fields.Many2one(

--- a/account_financial_report_qweb/report/open_items.py
+++ b/account_financial_report_qweb/report/open_items.py
@@ -17,6 +17,7 @@ class OpenItemsReport(models.TransientModel):
     """
 
     _name = 'report_open_items_qweb'
+    _inherit = 'report_qweb_abstract'
 
     # Filters fields, used for data computation
     date_at = fields.Date()
@@ -37,6 +38,7 @@ class OpenItemsReport(models.TransientModel):
 class OpenItemsReportAccount(models.TransientModel):
 
     _name = 'report_open_items_qweb_account'
+    _inherit = 'report_qweb_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -70,6 +72,7 @@ class OpenItemsReportAccount(models.TransientModel):
 class OpenItemsReportPartner(models.TransientModel):
 
     _name = 'report_open_items_qweb_partner'
+    _inherit = 'report_qweb_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_open_items_qweb_account',
@@ -114,6 +117,7 @@ ORDER BY
 class OpenItemsReportMoveLine(models.TransientModel):
 
     _name = 'report_open_items_qweb_move_line'
+    _inherit = 'report_qweb_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_open_items_qweb_partner',

--- a/account_financial_report_qweb/report/trial_balance.py
+++ b/account_financial_report_qweb/report/trial_balance.py
@@ -17,6 +17,7 @@ class TrialBalanceReport(models.TransientModel):
     """
 
     _name = 'report_trial_balance_qweb'
+    _inherit = 'report_qweb_abstract'
 
     # Filters fields, used for data computation
     date_from = fields.Date()
@@ -47,6 +48,7 @@ class TrialBalanceReport(models.TransientModel):
 class TrialBalanceReportAccount(models.TransientModel):
 
     _name = 'report_trial_balance_qweb_account'
+    _inherit = 'report_qweb_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -87,6 +89,7 @@ class TrialBalanceReportAccount(models.TransientModel):
 class TrialBalanceReportPartner(models.TransientModel):
 
     _name = 'report_trial_balance_qweb_partner'
+    _inherit = 'report_qweb_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_trial_balance_qweb_account',


### PR DESCRIPTION
When there are a lot of account.move.line (several millions) and print any of
the Qweb reports, that will generate also a lot of transient objects.
As these objects are created with an "insert" query, the cleaning normally
triggered by the count of the records in transient tables is not done, so only
the cleaning based on the age of the records is processed (by default, records
older than 1 hours are deleted), but the cron task is only ran one time per
day. For large setups this can lead to memory errors at that point. This change
prevents the memory error by executing the transient record cleanup for the
report models in this module in SQL.

Backport of https://github.com/OCA/account-financial-reporting/pull/441