### PR TITLE
[11.0][IMP] Improve transient models cleaning

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '11.0.2.2.0',
+    'version': '11.0.2.2.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/report/__init__.py
+++ b/account_financial_report/report/__init__.py
@@ -3,6 +3,7 @@
 # © 2016 Julien Coux (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
 
+from . import abstract_report
 from . import abstract_report_xlsx
 from . import aged_partner_balance
 from . import aged_partner_balance_xlsx

--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models
+
+
+class AbstractReport(models.AbstractModel):
+    _name = 'account_financial_report_abstract'
+
+    def _transient_clean_rows_older_than(self, seconds):
+        assert self._transient, \
+            "Model %s is not transient, it cannot be vacuumed!" % self._name
+        # Never delete rows used in last 5 minutes
+        seconds = max(seconds, 300)
+        query = """
+DELETE FROM """ + self._table + """
+WHERE COALESCE(
+    write_date, self.create_date, (now() at time zone 'UTC'))::timestamp
+    < ((now() at time zone 'UTC') - interval %s)
+"""
+        self.env.cr.execute(query, ("%s seconds" % seconds,))

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -18,6 +18,7 @@ class AgedPartnerBalanceReport(models.TransientModel):
     """
 
     _name = 'report_aged_partner_balance'
+    _inherit = 'account_financial_report_abstract'
 
     # Filters fields, used for data computation
     date_at = fields.Date()
@@ -39,6 +40,7 @@ class AgedPartnerBalanceReport(models.TransientModel):
 
 class AgedPartnerBalanceReportAccount(models.TransientModel):
     _name = 'report_aged_partner_balance_account'
+    _inherit = 'account_financial_report_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -81,6 +83,7 @@ class AgedPartnerBalanceReportAccount(models.TransientModel):
 
 class AgedPartnerBalanceReportPartner(models.TransientModel):
     _name = 'report_aged_partner_balance_partner'
+    _inherit = 'account_financial_report_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_account',
@@ -124,6 +127,7 @@ ORDER BY
 
 class AgedPartnerBalanceReportLine(models.TransientModel):
     _name = 'report_aged_partner_balance_line'
+    _inherit = 'account_financial_report_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_partner',
@@ -144,6 +148,7 @@ class AgedPartnerBalanceReportLine(models.TransientModel):
 
 class AgedPartnerBalanceReportMoveLine(models.TransientModel):
     _name = 'report_aged_partner_balance_move_line'
+    _inherit = 'account_financial_report_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_aged_partner_balance_partner',

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -22,6 +22,7 @@ class GeneralLedgerReport(models.TransientModel):
     """
 
     _name = 'report_general_ledger'
+    _inherit = 'account_financial_report_abstract'
 
     # Filters fields, used for data computation
     date_from = fields.Date()
@@ -74,6 +75,7 @@ class GeneralLedgerReport(models.TransientModel):
 class GeneralLedgerReportAccount(models.TransientModel):
 
     _name = 'report_general_ledger_account'
+    _inherit = 'account_financial_report_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -118,6 +120,7 @@ class GeneralLedgerReportAccount(models.TransientModel):
 class GeneralLedgerReportPartner(models.TransientModel):
 
     _name = 'report_general_ledger_partner'
+    _inherit = 'account_financial_report_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_general_ledger_account',
@@ -166,6 +169,7 @@ ORDER BY
 class GeneralLedgerReportMoveLine(models.TransientModel):
 
     _name = 'report_general_ledger_move_line'
+    _inherit = 'account_financial_report_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_general_ledger_account',

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -9,6 +9,7 @@ DIGITS = (16, 2)
 class ReportJournalLedger(models.TransientModel):
 
     _name = 'report_journal_ledger'
+    _inherit = 'account_financial_report_abstract'
 
     date_from = fields.Date(
         required=True
@@ -615,6 +616,7 @@ class ReportJournalLedger(models.TransientModel):
 class ReportJournalLedgerJournal(models.TransientModel):
 
     _name = 'report_journal_ledger_journal'
+    _inherit = 'account_financial_report_abstract'
 
     name = fields.Char(
         required=True,
@@ -657,6 +659,7 @@ class ReportJournalLedgerJournal(models.TransientModel):
 class ReportJournalLedgerMove(models.TransientModel):
 
     _name = 'report_journal_ledger_move'
+    _inherit = 'account_financial_report_abstract'
 
     report_id = fields.Many2one(
         comodel_name='report_journal_ledger',
@@ -688,6 +691,7 @@ class ReportJournalLedgerMove(models.TransientModel):
 class ReportJournalLedgerMoveLine(models.TransientModel):
 
     _name = 'report_journal_ledger_move_line'
+    _inherit = 'account_financial_report_abstract'
     _order = 'partner_id desc, account_id desc'
 
     report_id = fields.Many2one(
@@ -753,6 +757,7 @@ class ReportJournalLedgerMoveLine(models.TransientModel):
 class ReportJournalLedgerReportTaxLine(models.TransientModel):
 
     _name = 'report_journal_ledger_report_tax_line'
+    _inherit = 'account_financial_report_abstract'
     _order = 'tax_code'
 
     report_id = fields.Many2one(

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -17,6 +17,7 @@ class OpenItemsReport(models.TransientModel):
     """
 
     _name = 'report_open_items'
+    _inherit = 'account_financial_report_abstract'
 
     # Filters fields, used for data computation
     date_at = fields.Date()
@@ -37,6 +38,7 @@ class OpenItemsReport(models.TransientModel):
 class OpenItemsReportAccount(models.TransientModel):
 
     _name = 'report_open_items_account'
+    _inherit = 'account_financial_report_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -70,6 +72,7 @@ class OpenItemsReportAccount(models.TransientModel):
 class OpenItemsReportPartner(models.TransientModel):
 
     _name = 'report_open_items_partner'
+    _inherit = 'account_financial_report_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_open_items_account',
@@ -114,6 +117,7 @@ ORDER BY
 class OpenItemsReportMoveLine(models.TransientModel):
 
     _name = 'report_open_items_move_line'
+    _inherit = 'account_financial_report_abstract'
 
     report_partner_id = fields.Many2one(
         comodel_name='report_open_items_partner',

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -17,6 +17,7 @@ class TrialBalanceReport(models.TransientModel):
     """
 
     _name = 'report_trial_balance'
+    _inherit = 'account_financial_report_abstract'
 
     # Filters fields, used for data computation
     date_from = fields.Date()
@@ -51,6 +52,7 @@ class TrialBalanceReport(models.TransientModel):
 
 class TrialBalanceReportAccount(models.TransientModel):
     _name = 'report_trial_balance_account'
+    _inherit = 'account_financial_report_abstract'
     _order = 'sequence, code ASC, name'
 
     report_id = fields.Many2one(
@@ -104,6 +106,7 @@ class TrialBalanceReportAccount(models.TransientModel):
 
 class TrialBalanceReportPartner(models.TransientModel):
     _name = 'report_trial_balance_partner'
+    _inherit = 'account_financial_report_abstract'
 
     report_account_id = fields.Many2one(
         comodel_name='report_trial_balance_account',

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 
 class VATReport(models.TransientModel):
     _name = "report_vat_report"
+    _inherit = 'account_financial_report_abstract'
     """ Here, we just define class fields.
     For methods, go more bottom at this file.
 
@@ -35,6 +36,7 @@ class VATReport(models.TransientModel):
 
 class VATReportTaxTags(models.TransientModel):
     _name = 'report_vat_report_taxtag'
+    _inherit = 'account_financial_report_abstract'
     _order = 'code ASC'
 
     report_id = fields.Many2one(
@@ -68,6 +70,7 @@ class VATReportTaxTags(models.TransientModel):
 
 class VATReportTax(models.TransientModel):
     _name = 'report_vat_report_tax'
+    _inherit = 'account_financial_report_abstract'
     _order = 'name ASC'
 
     report_tax_id = fields.Many2one(


### PR DESCRIPTION
When there are a lot of account.move.line (several millions) and print any of
the Qweb reports, that will generate also a lot of transient objects.
As these objects are created with an "insert" query, the cleaning normally
triggered by the count of the records in transient tables is not done, so only
the cleaning based on the age of the records is processed (by default, records
older than 1 hours are deleted), but the cron task is only ran one time per
day. For large setups this can lead to memory errors at that point. This change
prevents the memory error by executing the transient record cleanup for the
report models in this module in SQL.

Backport of https://github.com/OCA/account-financial-reporting/pull/441