### PR TITLE
Bug fix

### DIFF
--- a/customer_activity_statement/views/statement.xml
+++ b/customer_activity_statement/views/statement.xml
@@ -53,7 +53,7 @@
                                     </td>
                                     <td />
                                     <td class="amount" >
-                                        <span t-esc="Balance_forward[o.id].get(currency, 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                        <span t-esc="Balance_forward[o.id].get(currency, 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </td>
 
                                 </tr>
@@ -76,10 +76,10 @@
                                         <t t-if="line['name'] == '/'"><span t-esc="line['ref']"/></t>
                                     </td>
                                     <td class="amount" >
-                                        <span t-esc="line['amount']" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                        <span t-esc="line['amount']" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </td>
                                     <td class="amount" >
-                                        <span t-esc="line['balance']" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                        <span t-esc="line['balance']" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </td>
 
                                 </tr>
@@ -93,7 +93,7 @@
                                     </td>
                                     <td />
                                     <td class="amount" >
-                                        <span t-esc="Amount_Due[o.id][currency]" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                        <span t-esc="Amount_Due[o.id][currency]" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </td>
                                 </tr>
                                 </tbody>
@@ -117,25 +117,25 @@
                                 <tbody >
                                     <tr >
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('current', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('current', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('b_1_30', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('b_1_30', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('b_30_60', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('b_30_60', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('b_60_90', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('b_60_90', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('b_90_120', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('b_90_120', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('b_over_120', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('b_over_120', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                         <td class="amount" >
-                                            <span t-esc="buckets.get('balance', 0.0)" t-options="{'widget': 'monetary', 'display_currency': 'currency'}"/>
+                                            <span t-esc="buckets.get('balance', 0.0)" t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                         </td>
                                     </tr>
                                 </tbody>


### PR DESCRIPTION
@mreficent @pedrobaeza @StefanRijnhart Your urgent attention please.

I somehow didn't test the conversion of the options dict from JSON to Python.  I was using --dev=reload etc but it seems it didn't take so there is an error as currency is an object not a string in the widget. 