### PR TITLE
Format Improvements for customer outstanding statement

### DIFF
--- a/customer_outstanding_statement/__manifest__.py
+++ b/customer_outstanding_statement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Partner Outstanding Statement',
-    'version': '11.0.2.0.0',
+    'version': '11.0.2.1.0',
     'category': 'Accounting & Finance',
     'summary': 'OCA Financial Reports',
     'author': "Eficent, Odoo Community Association (OCA)",

--- a/customer_outstanding_statement/static/src/less/layout_statement.less
+++ b/customer_outstanding_statement/static/src/less/layout_statement.less
@@ -1,0 +1,22 @@
+.table-statement {
+    .amount {
+        text-align: right !important;
+        width: 14%  //spread 7 columns evenly
+    }
+    thead {
+        border-bottom: solid; // required for clean layout
+        tr th:first-child {
+            width: auto !important; // required for clean layout
+            }
+        tr th:last-child {
+            width: 16% !important; // required for boxed layout
+            }
+    }
+}
+
+.statement-blocked {
+    background-color: @gray-lighter-darker !important;
+    td:last-child {
+        background-color: @gray-lighter-darker !important;
+    }
+}

--- a/customer_outstanding_statement/views/statement.xml
+++ b/customer_outstanding_statement/views/statement.xml
@@ -2,184 +2,162 @@
 <!-- Copyright 2018 Eficent Business and IT Consulting Services S.L.
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
+    <template id="report_assets_common" name="oca_statements report assets" inherit_id="web.report_assets_common">
+        <xpath expr="." position="inside">
+            <link href="/customer_outstanding_statement/static/src/less/layout_statement.less" rel="stylesheet"/>
+        </xpath>
+    </template>
+
     <template id="customer_outstanding_statement.statement_document">
         <t t-call="web.external_layout">
             <div class="page">
                 <div class="row">
-                    <div class="col-xs-5 col-xs-offset-7">
-                        <span t-field="o.name"/><br/>
-                        <span t-raw="o.contact_address.replace('\n\n', '\n').replace('\n', '&lt;br&gt;')"/>
-                        <span t-field="o.vat"/>
+                    <div name="statement_address" class="col-xs-5 col-xs-offset-7">
+                        <address t-esc="o"
+                                 t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+                        <div t-if="o.vat" class="mt16"><t t-esc="o.country_id.vat_label or 'TIN'"/>:
+                            <span t-field="o.vat"/>
+                        </div>
                     </div>
                     <h4 style="padding-left:15em;padding-top:2em">
                         Outstanding Statement
                     </h4>
                     <p>
-                        Date: <span t-esc="Date[o.id]" /><br/><!--Today-->
-                        <t t-if="o.ref">Partner ref: <span t-field="o.ref"/></t>
+                        Date: <span t-esc="Date[o.id]"/><br/><!--Today-->
+                        <t t-if="o.ref">Partner ref:<span t-field="o.ref"/></t>
                     </p>
 
                     <t t-if="Lines[o.id]">
                         <br/>
                         <t t-foreach="Lines[o.id]" t-as="currency">
-                            <br t-if="not currency_first" />
-                            <p t-if="account_type == 'receivable'">
-+                                Customer Outstanding Statement at <span t-esc="Date_end[o.id]" /> in <span t-esc="Currencies[o.id][currency].name"/>:
-+                           </p>
-                            <p t-if="account_type == 'payable'">
-+                                Supplier Outstanding Statement at <span t-esc="Date_end[o.id]" /> in <span t-esc="Currencies[o.id][currency].name"/>:
+                            <br t-if="not currency_first"/>
+                            <p>
+                                <span t-esc="'Customer' if  account_type == 'receivable' else 'Supplier'"/>
+                                Outstanding Statement at
+                                <span t-esc="Date_end[o.id]"/>
+                                in <span t-esc="Currencies[o.id][currency].name"/>:
+
                             </p>
-                            <table class="table table-condensed" style="border: 1px solid black; border-collapse: collapse;">
+                            <table class="table table-condensed table-statement">
                                 <thead>
                                     <tr>
-                                        <th style="border-right: 1px solid black;">Reference number</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">Date</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">Due Date</th>
-                                        <th style="border-right: 1px solid black;">Description</th>
-                                        <th class="text-right" style="border-right: 1px solid black;">Original Amount</th>
-                                        <th class="text-right" style="border-right: 1px solid black;">Open Amount</th>
-                                        <th class="text-right" style="border-right: 1px solid black;">Balance</th>
+                                        <th>Reference number</th>
+                                        <th>Date</th>
+                                        <th>Due Date</th>
+                                        <th>Description</th>
+                                        <th class="amount">Original Amount</th>
+                                        <th class="amount">Open Amount</th>
+                                        <th class="amount">Balance</th>
                                     </tr>
                                 </thead>
-                                <tr t-foreach="Lines[o.id][currency]" t-as="line">
-                                    <t t-if="not line['blocked']">
-                                        <td style="border-right: 1px solid black;">
-                                            <span t-esc="line['move_id']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black;">
-                                            <span t-esc="line['date']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black;">
-                                            <span t-esc="line['date_maturity']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black;">
-                                            <t t-if="line['name'] != '/'">
-                                                <t t-if="not line['ref']"><span t-esc="line['name']"/></t>
-                                                <t t-if="line['ref'] and line['name']">
-                                                    <t t-if="line['name'] not in line['ref']"><span t-esc="line['name']"/></t>
-                                                    <t t-if="line['ref'] not in line['name']"><span t-esc="line['ref']"/></t>
+                                <tr t-foreach="Lines[o.id][currency]" t-as="line"
+                                    t-att-class="'statement-blocked' if line['blocked'] else ''">
+
+                                    <td>
+                                        <span t-esc="line['move_id']"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="line['date']"/>
+                                    </td>
+                                    <td>
+                                        <span t-esc="line['date_maturity']"/>
+                                    </td>
+                                    <td>
+                                        <t t-if="line['name'] != '/'">
+                                            <t t-if="not line['ref']">
+                                                <span t-esc="line['name']"/>
+                                            </t>
+                                            <t t-if="line['ref'] and line['name']">
+                                                <t t-if="line['name'] not in line['ref']">
+                                                    <span t-esc="line['name']"/>
+                                                </t>
+                                                <t t-if="line['ref'] not in line['name']">
+                                                    <span t-esc="line['ref']"/>
                                                 </t>
                                             </t>
-                                            <t t-if="line['name'] == '/'"><span t-esc="line['ref']"/></t>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black;">
-                                            <span t-esc="line['amount']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black;">
-                                            <span t-esc="line['open_amount']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black;">
-                                            <span t-esc="line['balance']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                    </t>
-                                    <t t-if="line['blocked']">
-                                        <td style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['move_id']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['date']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['date_maturity']"/>
-                                        </td>
-                                        <td style="border-right: 1px solid black; background-color: grey;">
-                                            <t t-if="line['name'] != '/'">
-                                                <t t-if="not line['ref']"><span t-esc="line['name']"/></t>
-                                                <t t-if="line['ref'] and line['name']">
-                                                    <t t-if="line['name'] not in line['ref']"><span t-esc="line['name']"/></t>
-                                                    <t t-if="line['ref'] not in line['name']"><span t-esc="line['ref']"/></t>
-                                                </t>
-                                            </t>
-                                            <t t-if="line['name'] == '/'"><span t-esc="line['ref']"/></t>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['amount']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['open_amount']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                        <td class="text-right" style="border-right: 1px solid black; background-color: grey;">
-                                            <span t-esc="line['balance']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                        </td>
-                                    </t>
+                                        </t>
+                                        <t t-if="line['name'] == '/'">
+                                            <span t-esc="line['ref']"/>
+                                        </t>
+                                    </td>
+                                    <td class="amount">
+                                        <span t-esc="line['amount']"
+                                              t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                    </td>
+                                    <td class="amount">
+                                        <span t-esc="line['open_amount']"
+                                              t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                    </td>
+                                    <td class="amount">
+                                        <span t-esc="line['balance']"
+                                              t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                    </td>
                                 </tr>
                                 <tr>
-                                    <td style="border-right: 1px solid black;"/>
-                                    <td style="border-right: 1px solid black;">
+                                    <td/>
+                                    <td>
                                         <span t-esc="Date_end[o.id]"/>
                                     </td>
-                                    <td style="border-right: 1px solid black;"/>
-                                    <td style="border-right: 1px solid black;">
+                                    <td/>
+                                    <td>
                                         Ending Balance
                                     </td>
-                                    <td style="border-right: 1px solid black;"/>
-                                    <td style="border-right: 1px solid black;"/>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Amount_Due[o.id][currency]" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
+                                    <td/>
+                                    <td/>
+                                    <td class="amount">
+                                        <span t-esc="Amount_Due[o.id][currency]"
+                                              t-options="{'widget': 'monetary', 'display_currency': currency}"/>
                                     </td>
                                 </tr>
                             </table>
                             <p>
-                                Aging Report at  <span t-esc="Date_end[o.id]" /> in <span t-esc="Currencies[o.id][currency].name"/>:
+                                Aging Report at <span t-esc="Date_end[o.id]"/> in <span t-esc="Currencies[o.id][currency].name"/>:
                             </p>
-                            <table class="table table-condensed" t-if="Show_Buckets" style="border: 1px solid black; border-collapse: collapse;">
+                            <table class="table table-condensed table-statement" t-if="Show_Buckets">
                                 <thead>
                                     <tr>
-                                        <th class="text-center" style="border-right: 1px solid black;">Current Due</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">1-30 Days Due</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">30-60 Days Due</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">60-90 Days Due</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">90-120 Days Due</th>
-                                        <th class="text-center" style="border-right: 1px solid black;">+120 Days Due</th>
-                                        <th class="text-right" style="border-right: 1px solid black;">Balance Due</th>
+                                        <th class="amount">Current Due</th>
+                                        <th class="amount">1-30 Days</th>
+                                        <th class="amount">30-60 Days</th>
+                                        <th class="amount">60-90 Days</th>
+                                        <th class="amount">90-120 Days</th>
+                                        <th class="amount">+120 Days</th>
+                                        <th class="amount">Balance Due</th>
                                     </tr>
                                 </thead>
-                                <tr t-if="currency in Buckets[o.id]">
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['current']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['b_1_30']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['b_30_60']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['b_60_90']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['b_90_120']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['b_over_120']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="Buckets[o.id][currency]['balance']" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                </tr>
-                                <tr t-if="currency not in Buckets[o.id]">
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                    <td class="text-right" style="border-right: 1px solid black;">
-                                        <span t-esc="0.0" t-esc-options='{"widget": "monetary", "display_currency": "currency"}'/>
-                                    </td>
-                                </tr>
+                                <t t-set="buckets" t-value="Buckets[o.id].get(currency, {})"/>
+                                <tbody>
+                                    <tr>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('current', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('b_1_30', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('b_30_60', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('b_60_90', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('b_90_120', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('b_over_120', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                        <td class="amount">
+                                            <span t-esc="buckets.get('balance', 0.0)"
+                                                  t-options="{'widget': 'monetary', 'display_currency': currency}"/>
+                                        </td>
+                                    </tr>
+                                </tbody>
                             </table>
                         </t>
                     </t>
@@ -188,7 +166,7 @@
                     </p>
                 </div>
             </div>
-       </t>
+        </t>
     </template>
 
     <template id="statement">
@@ -202,11 +180,11 @@
     </template>
 
     <report id="action_print_customer_outstanding_statement"
-        model="res.partner"
-        report_type="qweb-pdf"
-        menu="False"
-        string="Statement Action to PDF"
-        name="customer_outstanding_statement.statement"
-        file="customer_outstanding_statement.statement"
+            model="res.partner"
+            report_type="qweb-pdf"
+            menu="False"
+            string="Outstanding Statement"
+            name="customer_outstanding_statement.statement"
+            file="customer_outstanding_statement.statement"
     />
 </odoo>


### PR DESCRIPTION
This is essentially the same as #453 except during testing I noticed:

* This report was based off report_overdue which hasn't had much new api love, so converted the manual address formatting to use the address tag same as invoice report.
* In testing #453 I was using a custom aging module, turns out the standard aging headers are too long, so removed Due from the `days` columns to stop wrapping.

Because this report has 2 extra columns in the top part, it will still wrap "Original Amount" on some formats - there is just no space unless we drop the word amount.