### PR TITLE
[10.0] report_qweb: usability improvements

### DIFF
--- a/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
@@ -54,6 +54,27 @@ class AgedPartnerBalance(models.TransientModel):
         else:
             self.account_ids = None
 
+    @api.model
+    def create(self, vals):
+        """
+        This is a workaround for bug https://github.com/odoo/odoo/issues/14761
+        This bug impacts M2M fields in wizards filled-up via onchange
+        It replaces the workaround widget="many2many_tags" on
+        field name="account_ids" which prevented from selecting several
+        accounts at the same time (quite useful when you want to select
+        an interval of accounts for example)
+        """
+        if 'account_ids' in vals and isinstance(vals['account_ids'], list):
+            account_ids = []
+            for account in vals['account_ids']:
+                if account[0] in (1, 4):
+                    account_ids.append(account[1])
+                elif account[0] == 6 and isinstance(account[2], list):
+                    account_ids += account[2]
+            vals['account_ids'] = [(6, 0, account_ids)]
+        res = super(AgedPartnerBalance, self).create(vals)
+        return res
+
     @api.multi
     def button_export_html(self):
         self.ensure_one()

--- a/account_financial_report_qweb/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/aged_partner_balance_wizard_view.xml
@@ -27,7 +27,7 @@
                     <field name="receivable_accounts_only"/>
                     <field name="payable_accounts_only"/>
                 </group>
-                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                <field name="account_ids" nolabel="1" options="{'no_create': True}"/>
                 <footer>
                     <button name="button_export_html" string="View"
                             type="object" default_focus="1" class="oe_highlight"/>

--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -110,6 +110,27 @@ class GeneralLedgerReportWizard(models.TransientModel):
         else:
             self.account_ids = None
 
+    @api.model
+    def create(self, vals):
+        """
+        This is a workaround for bug https://github.com/odoo/odoo/issues/14761
+        This bug impacts M2M fields in wizards filled-up via onchange
+        It replaces the workaround widget="many2many_tags" on
+        field name="account_ids" which prevented from selecting several
+        accounts at the same time (quite useful when you want to select
+        an interval of accounts for example)
+        """
+        if 'account_ids' in vals and isinstance(vals['account_ids'], list):
+            account_ids = []
+            for account in vals['account_ids']:
+                if account[0] in (1, 4):
+                    account_ids.append(account[1])
+                elif account[0] == 6 and isinstance(account[2], list):
+                    account_ids += account[2]
+            vals['account_ids'] = [(6, 0, account_ids)]
+        res = super(GeneralLedgerReportWizard, self).create(vals)
+        return res
+
     @api.onchange('partner_ids')
     def onchange_partner_ids(self):
         """Handle partners change."""

--- a/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
@@ -17,6 +17,7 @@
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>
+                            <field name="journal_ids" widget="many2many_tags" options="{'no_create': True}"/>
                         </group>
                         <group name="other_filters">
                             <field name="target_move" widget="radio"/>
@@ -25,15 +26,14 @@
                             <field name="foreign_currency"/>
                         </group>
                     </group>
-                    <label for="cost_center_ids" groups="analytic.group_analytic_accounting"/>
-                    <field name="cost_center_ids" nolabel="1" options="{'no_create': True}" groups="analytic.group_analytic_accounting"/>
-                    <group/>
-                    <label for="partner_ids"/>
-                    <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
-                    <group/>
-                    <label for="journal_ids"/>
-                    <field name="journal_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
-                    <group/>
+                    <group groups="analytic.group_analytic_accounting" name="cost_center_filter" col="1">
+                        <label for="cost_center_ids"/>
+                        <field name="cost_center_ids" nolabel="1" options="{'no_create': True}" groups="analytic.group_analytic_accounting"/>
+                    </group>
+                    <group name="partner_filter" col="1">
+                        <label for="partner_ids"/>
+                        <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
+                    </group>
                     <label for="account_ids"/>
                     <group col="4">
                         <field name="receivable_accounts_only"/>

--- a/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
@@ -39,7 +39,7 @@
                         <field name="receivable_accounts_only"/>
                         <field name="payable_accounts_only"/>
                     </group>
-                    <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                    <field name="account_ids" nolabel="1" options="{'no_create': True}"/>
                 </div>
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}">
                     <field name="not_only_one_unaffected_earnings_account" invisible="1"/>

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -67,6 +67,27 @@ class OpenItemsReportWizard(models.TransientModel):
         else:
             self.account_ids = None
 
+    @api.model
+    def create(self, vals):
+        """
+        This is a workaround for bug https://github.com/odoo/odoo/issues/14761
+        This bug impacts M2M fields in wizards filled-up via onchange
+        It replaces the workaround widget="many2many_tags" on
+        field name="account_ids" which prevented from selecting several
+        accounts at the same time (quite useful when you want to select
+        an interval of accounts for example)
+        """
+        if 'account_ids' in vals and isinstance(vals['account_ids'], list):
+            account_ids = []
+            for account in vals['account_ids']:
+                if account[0] in (1, 4):
+                    account_ids.append(account[1])
+                elif account[0] == 6 and isinstance(account[2], list):
+                    account_ids += account[2]
+            vals['account_ids'] = [(6, 0, account_ids)]
+        res = super(OpenItemsReportWizard, self).create(vals)
+        return res
+
     @api.multi
     def button_export_html(self):
         self.ensure_one()

--- a/account_financial_report_qweb/wizard/open_items_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/open_items_wizard_view.xml
@@ -28,7 +28,7 @@
                     <field name="receivable_accounts_only"/>
                     <field name="payable_accounts_only"/>
                 </group>
-                <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                <field name="account_ids" nolabel="1" options="{'no_create': True}"/>
                 <footer>
                     <button name="button_export_html" string="View"
                             type="object" default_focus="1" class="oe_highlight"/>

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -51,6 +51,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     )
     journal_ids = fields.Many2many(
         comodel_name="account.journal",
+        string="Filter journals",
     )
 
     not_only_one_unaffected_earnings_account = fields.Boolean(

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -105,6 +105,27 @@ class TrialBalanceReportWizard(models.TransientModel):
         else:
             self.account_ids = None
 
+    @api.model
+    def create(self, vals):
+        """
+        This is a workaround for bug https://github.com/odoo/odoo/issues/14761
+        This bug impacts M2M fields in wizards filled-up via onchange
+        It replaces the workaround widget="many2many_tags" on
+        field name="account_ids" which prevented from selecting several
+        accounts at the same time (quite useful when you want to select
+        an interval of accounts for example)
+        """
+        if 'account_ids' in vals and isinstance(vals['account_ids'], list):
+            account_ids = []
+            for account in vals['account_ids']:
+                if account[0] in (1, 4):
+                    account_ids.append(account[1])
+                elif account[0] == 6 and isinstance(account[2], list):
+                    account_ids += account[2]
+            vals['account_ids'] = [(6, 0, account_ids)]
+        res = super(TrialBalanceReportWizard, self).create(vals)
+        return res
+
     @api.onchange('show_partner_details')
     def onchange_show_partner_details(self):
         """Handle partners change."""

--- a/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
@@ -35,7 +35,7 @@
                         <field name="receivable_accounts_only"/>
                         <field name="payable_accounts_only"/>
                     </group>
-                    <field name="account_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
+                    <field name="account_ids" nolabel="1" options="{'no_create': True}"/>
                 </div>
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', False)]}">
                     <field name="not_only_one_unaffected_earnings_account" invisible="1"/>

--- a/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
@@ -17,6 +17,7 @@
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>
+                            <field name="journal_ids" widget="many2many_tags" options="{'no_create': True}"/>
                         </group>
                         <group name="other_filters">
                             <field name="target_move" widget="radio"/>
@@ -25,11 +26,10 @@
                             <field name="foreign_currency"/>
                         </group>
                     </group>
-                    <label for="partner_ids" attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
-                    <field name="partner_ids" nolabel="1" options="{'no_create': True}" attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
-                    <label for="journal_ids"/>
-                    <field name="journal_ids" widget="many2many_tags" nolabel="1" options="{'no_create': True}"/>
-                    <group attrs="{'invisible':[('show_partner_details','!=',True)]}"/>
+                    <group name="partner_filter" attrs="{'invisible':[('show_partner_details','!=',True)]}" col="1">
+                        <label for="partner_ids"/>
+                        <field name="partner_ids" nolabel="1" options="{'no_create': True}"/>
+                    </group>
                     <label for="account_ids"/>
                     <group col="4">
                         <field name="receivable_accounts_only"/>


### PR DESCRIPTION
Fix view layout issue introduced recently by PR https://github.com/OCA/account-financial-reporting/pull/445

Improve workaround for bug https://github.com/odoo/odoo/issues/14761 (bug with M2M + onchange in wizards): it replaces the workaround widget="many2many_tags" on field name="account_ids" which prevented from selecting several accounts at the same time (quite useful when you want to select an interval of accounts for example). We now use the regular M2M widget and inherit create().