### PR TITLE
[11.0][FIX] account_financial_report: WHERE clause

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '11.0.2.2.1',
+    'version': '11.0.2.2.2',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -15,7 +15,7 @@ class AbstractReport(models.AbstractModel):
         query = """
 DELETE FROM """ + self._table + """
 WHERE COALESCE(
-    write_date, self.create_date, (now() at time zone 'UTC'))::timestamp
+    write_date, create_date, (now() at time zone 'UTC'))::timestamp
     < ((now() at time zone 'UTC') - interval %s)
 """
         self.env.cr.execute(query, ("%s seconds" % seconds,))


### PR DESCRIPTION
Method `_transient_clean_rows_older_than()` was introduced with https://github.com/OCA/account-financial-reporting/commit/69809608b08ed6d62e7858673336ce2b1fbe78ea#diff-19027c9de5150658e37a97a7b6f65bdc. In some cases the SQL execution fails because of an error in the WHERE clause.