### PR TITLE
[11.0]remove lines with balance 0 on trial balance.

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -232,6 +232,11 @@ class TrialBalanceReportCompute(models.TransientModel):
         else:
             for line in self.account_ids:
                 line.write({'level': 0})
+        if self.hide_account_balance_at_0:
+            self.env.cr.execute("""
+DELETE FROM report_trial_balance_account
+WHERE report_id=%s AND final_balance IS NULL OR final_balance = 0""",
+                                [self.id])
 
     def _inject_account_values(self, account_ids):
         """Inject report values for report_trial_balance_account"""


### PR DESCRIPTION
When hide_account_balance_at_0 is checked remove the lines of groups with final_balance = 0.

I decided to make the delete instead of not create the records because the insert just takes the data from account_group table.
Another possibility is maybe make the insert and the _update_account_group_child_values/_update_account_group_computed_values at the same query and don't create the records. But i don't know if make the insert and after the update has some purpose.
cc: @pedrobaeza 
https://github.com/OCA/account-financial-reporting/issues/419