### PR TITLE
[12.0][FIX] account_tax_balance: at_install/post_install test decorators

### DIFF
--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -6,13 +6,13 @@ from datetime import datetime
 
 from dateutil.rrule import MONTHLY
 
+import odoo
 from odoo.fields import Date
 from odoo.tests.common import HttpCase
 
 
+@odoo.tests.tagged('post_install', '-at_install')
 class TestAccountTaxBalance(HttpCase):
-    at_install = False
-    post_install = False
 
     def setUp(self):
         super(TestAccountTaxBalance, self).setUp()


### PR DESCRIPTION
Following odoo/odoo#27471, here is the patch for the `at_install`/`post_install` test decorators, the V12.0 way.