### PR TITLE
[10.0][ADD] add account_bank_statement_line_reconciliation module

### DIFF
--- a/account_bank_statement_line_reconciliation/README.rst
+++ b/account_bank_statement_line_reconciliation/README.rst
@@ -1,0 +1,95 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+   :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
+   :alt: License: AGPL-3
+
+==========================================
+Account Bank Statement Line Reconciliation
+==========================================
+
+The wizard provides the ability to specify bank statement line when it needed.
+The only users from security group "Settings" can use it.
+
+Usage
+=====
+
+This module is for you if you work with Odoo enterprise and you messed up the bank reconcile report.
+
+The bank reconciliation report is accessible from the hyperlink 'Difference' which appears on bank journals cards when the GL balance differs from the bank statement balance.
+
+There are only 2 situation handled from field filter (from bank reconcile view) but there are more in real life:
+
+1 - Blue lines appear if account_move_lines have these values:
+
+.. code-block:: python
+
+   statement_id = false
+   AND payment_id = true
+   AND account_id = current bank
+
+-> This means that if you post a payment journal entry manually (meaning that you do not use the register payment button) the payment_id will not be populated then the payment_id will not be populated. When this happens, your entry won't match: you are stuck and you need this module to prevent this situation.
+
+Same issue in case of migration of payment entries with no payment_id
+
+
+2 - If 1st request is not applicable then Odoo will look up for account_move_lines with:
+
+.. code-block:: python
+
+   reconcile_id = false
+   account_id = flagged as 'Allow reconciliation" = true
+   excluding the line in the move with the bank account.
+
+-> This means that if you have created entries on a reconciliable account but you never reconcile it (ie: a cut-off entry or a correction) this line will appear forever in the list of possible matches -> so you may need this module to clean it up.
+
+
+To use this module, you need to:
+
+#. Go to Accounting > Adviser > Journal Entries
+#. Select one or more Journal Entry items
+#. Press 'Action > Bank reconcile report change'
+#. Select required value in 'New value' field. Leave empty if you want to set empty value.
+#. Press 'Set value'
+
+By doing this, you will create/delete the link between Journal entry and bank statement lines hence you will make corrections on the bank reconcile report which would be impossible to do through the Odoo interface.
+
+
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/91/10.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/account-financial-reporting/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted it
+first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Camptocamp SA
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/account_bank_statement_line_reconciliation/__init__.py
+++ b/account_bank_statement_line_reconciliation/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import wizard

--- a/account_bank_statement_line_reconciliation/__manifest__.py
+++ b/account_bank_statement_line_reconciliation/__manifest__.py
@@ -11,9 +11,13 @@
     'website': 'https://github.com/OCA/account-financial-reporting',
     'license': 'AGPL-3',
     'depends': [
+        'account',
         'account_accountant',
     ],
     'data': [
+        # Views
+        'views/res_config_settings_views.xml',
+        # Wizard
         'wizard/account_bank_statement_line_reconciliation_wizard.xml',
     ],
     'installable': True,

--- a/account_bank_statement_line_reconciliation/__manifest__.py
+++ b/account_bank_statement_line_reconciliation/__manifest__.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Account Bank Statement Line Reconciliation',
+    'version': '10.0.1.0.0',
+    'category': 'Accounting & Finance',
+    'summary': 'OCA Financial Reports',
+    'author': "Camptocamp, Odoo Community Association (OCA)",
+    'website': 'https://github.com/OCA/account-financial-reporting',
+    'license': 'AGPL-3',
+    'depends': [
+        'account_accountant',
+    ],
+    'data': [
+        'wizard/account_bank_statement_line_reconciliation_wizard.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/account_bank_statement_line_reconciliation/models/__init__.py
+++ b/account_bank_statement_line_reconciliation/models/__init__.py
@@ -2,5 +2,6 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from . import models
-from . import wizard
+from . import res_config_settings
+from . import account_bank_statement
+from . import company

--- a/account_bank_statement_line_reconciliation/models/account_bank_statement.py
+++ b/account_bank_statement_line_reconciliation/models/account_bank_statement.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-from odoo import models, fields, api
-from odoo.osv import expression
+from odoo import models, api
+
 
 class AccountBankStatementLine(models.Model):
     _inherit = "account.bank.statement.line"
-
 
     def get_move_lines_for_reconciliation(
         self, excluded_ids=None, str=False, offset=0, limit=None,

--- a/account_bank_statement_line_reconciliation/models/account_bank_statement.py
+++ b/account_bank_statement_line_reconciliation/models/account_bank_statement.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+from odoo import models, fields, api
+from odoo.osv import expression
+
+class AccountBankStatementLine(models.Model):
+    _inherit = "account.bank.statement.line"
+
+
+    def get_move_lines_for_reconciliation(
+        self, excluded_ids=None, str=False, offset=0, limit=None,
+        additional_domain=None, overlook_partner=False
+    ):
+        """
+        Change the additional_domain to just see account statement line
+        with date after 'Bank Reconciliation Threshold' date
+        """
+
+        additional_domain = additional_domain or []
+        rec_start = self.env.user.company_id.account_bank_reconciliation_start
+        if rec_start:
+            additional_domain.append(('date', '>', rec_start))
+
+        return super(
+            AccountBankStatementLine, self
+        ).get_move_lines_for_reconciliation(
+            excluded_ids=excluded_ids,
+            str=str,
+            offset=offset,
+            limit=limit,
+            additional_domain=additional_domain,
+            overlook_partner=overlook_partner
+        )
+
+    @api.multi
+    def get_data_for_reconciliation_widget(self, excluded_ids=None):
+        """
+        Keep account bank statement line only if date line is after
+        'Bank Reconciliation Threshold' date
+        """
+
+        excluded_ids = excluded_ids or []
+        rec_start = self.env.user.company_id.account_bank_reconciliation_start
+        ret = []
+        acc_bank_st_lines = super(
+            AccountBankStatementLine, self
+        ).get_data_for_reconciliation_widget(excluded_ids)
+
+        if rec_start:
+            for acc_bank_st_line in acc_bank_st_lines:
+                st_line_date = acc_bank_st_line['st_line']['date']
+                if st_line_date > rec_start:
+                    ret.append(acc_bank_st_line)
+        else:
+            ret = acc_bank_st_lines
+
+        return ret

--- a/account_bank_statement_line_reconciliation/models/company.py
+++ b/account_bank_statement_line_reconciliation/models/company.py
@@ -2,6 +2,7 @@
 
 from odoo import fields, models
 
+
 class ResCompany(models.Model):
     _inherit = "res.company"
 

--- a/account_bank_statement_line_reconciliation/models/company.py
+++ b/account_bank_statement_line_reconciliation/models/company.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    account_bank_reconciliation_start = fields.Date(
+        string="Bank Reconciliation Threshold",
+        help="""The bank reconciliation widget won't ask to reconcile\
+         payments older than this date.\
+        This is useful if you install accounting after having used invoicing\
+         for some time and don't want to reconcile all\
+         the past payments with bank statements."""
+    )

--- a/account_bank_statement_line_reconciliation/models/res_config_settings.py
+++ b/account_bank_statement_line_reconciliation/models/res_config_settings.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models
+
+
+class AccountConfigSettings(models.TransientModel):
+    _inherit = 'account.config.settings'
+
+    account_bank_reconciliation_start = fields.Date(
+        string="Bank Reconciliation Threshold",
+        related='company_id.account_bank_reconciliation_start',
+        readonly=False,
+        help="""The bank reconciliation widget won't ask to reconcile\
+         payments older than this date.\
+        This is useful if you install accounting after having used invoicing\
+         for some time and don't want to reconcile all the past payments\
+         with bank statements."""
+    )

--- a/account_bank_statement_line_reconciliation/views/res_config_settings_views.xml
+++ b/account_bank_statement_line_reconciliation/views/res_config_settings_views.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
-    <record id="extra_account_mass_reconcile_view_account_config" model="ir.ui.view">
-        <field name="name">extra.account.mass.reconcile.view.account.config</field>
+    <record id="extra_view_account_config_settings" model="ir.ui.view">
+        <field name="name">extra.view.account.config.settings</field>
         <field name="model">account.config.settings</field>
-        <field name="inherit_id" ref="account_mass_reconcile.view_account_config"/>
+        <field name="inherit_id" ref="account.view_account_config_settings"/>
         <field name="arch" type="xml">
 
-            <xpath expr="//div[@name='reconciliation_config']" position="inside">
+            <xpath expr="//group[@groups='account.group_account_user']" position="inside">
+            <label for="id" string="Bank Reconciliation Threshold"/>
               <div>
-                <label for="account_bank_reconciliation_start"/>
-                <field name="account_bank_reconciliation_start" class="oe_inline"/>
+                  <div>
+                      <label for="account_bank_reconciliation_start"/>
+                      <field name="account_bank_reconciliation_start" class="oe_inline"/>
+                  </div>
               </div>
             </xpath>
 

--- a/account_bank_statement_line_reconciliation/views/res_config_settings_views.xml
+++ b/account_bank_statement_line_reconciliation/views/res_config_settings_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="extra_account_mass_reconcile_view_account_config" model="ir.ui.view">
+        <field name="name">extra.account.mass.reconcile.view.account.config</field>
+        <field name="model">account.config.settings</field>
+        <field name="inherit_id" ref="account_mass_reconcile.view_account_config"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//div[@name='reconciliation_config']" position="inside">
+              <div>
+                <label for="account_bank_reconciliation_start"/>
+                <field name="account_bank_reconciliation_start" class="oe_inline"/>
+              </div>
+            </xpath>
+
+        </field>
+     </record>
+</odoo>

--- a/account_bank_statement_line_reconciliation/wizard/__init__.py
+++ b/account_bank_statement_line_reconciliation/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import account_bank_statement_line_reconciliation_wizard

--- a/account_bank_statement_line_reconciliation/wizard/account_bank_statement_line_reconciliation_wizard.py
+++ b/account_bank_statement_line_reconciliation/wizard/account_bank_statement_line_reconciliation_wizard.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields, api, _
+from odoo.exceptions import ValidationError
+
+
+class AccountBankStatementLineReconciliationWizard(models.TransientModel):
+    _name = "account.bank.statement.line.reconciliation.wizard"
+
+    statement_line_ids = fields.Many2many(
+        string='Current values',
+        comodel_name='account.bank.statement.line',
+        compute='_compute_statement_line_ids',
+    )
+    new_statement_line_id = fields.Many2one(
+        string='New value',
+        comodel_name='account.bank.statement.line',
+    )
+
+    def _account_move_ids(self):
+        ids = self._context.get('active_ids')
+        account_move_ids = self.env['account.move']
+        if ids:
+            account_move_ids = account_move_ids.browse(ids)
+
+            journal_ids = account_move_ids.mapped('journal_id')
+
+            if len(account_move_ids) > 1 and len(journal_ids) > 1:
+                msg = _("Please only select Journal entries "
+                        "that belongs to the same bank journal")
+                raise ValidationError(msg)
+
+        return account_move_ids
+
+    def _compute_statement_line_ids(self):
+        for record in self:
+            account_move_ids = record._account_move_ids()
+            record.statement_line_ids = [
+                (6, 0, account_move_ids.mapped('statement_line_id').ids),
+            ]
+
+    @api.multi
+    def set_new_statement_line_value(self):
+        account_move_ids = self._account_move_ids()
+        account_move_ids.write({
+            'statement_line_id': self.new_statement_line_id.id,
+        })
+        account_move_ids.mapped("line_ids").write({
+            'statement_id': self.new_statement_line_id.statement_id.id,
+        })
+        return {}

--- a/account_bank_statement_line_reconciliation/wizard/account_bank_statement_line_reconciliation_wizard.xml
+++ b/account_bank_statement_line_reconciliation/wizard/account_bank_statement_line_reconciliation_wizard.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+
+    <act_window id="action_account_bank_statement_line_reconciliation_wizard"
+                name="Bank reconcile report change"
+                src_model="account.move"
+                res_model="account.bank.statement.line.reconciliation.wizard"
+                view_mode="form"
+                target="new"
+                key2="client_action_multi"
+                groups="base.group_system"/>
+
+    <record id="account_bank_statement_line_reconciliation_wizard" model="ir.ui.view">
+        <field name="name">Bank reconcile report change</field>
+        <field name="model">account.bank.statement.line.reconciliation.wizard</field>
+        <field name="arch" type="xml">
+            <form string="Bank reconcile report change">
+                <sheet>
+                    <group>
+                        <field name="statement_line_ids">
+                            <tree>
+                                <field name="name" string="Entry"/>
+                            </tree>
+                        </field>
+                        <field name="new_statement_line_id" options="{'no_create': True, 'no_create_edit': True}"/>
+                    </group>
+                </sheet>
+                <footer>
+                    <button string="Set value" name="set_new_statement_line_value" type="object" class="btn-primary"/>
+                    <button string="Cancel" class="btn-default" special="cancel" />
+                </footer>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION

Account Bank Statement Line Reconciliation The wizard provides the ability to specify bank statement line when it needed. The only user from security group "Settings" can use it.
--


Modification for the delete repos : https://github.com/OCA/account-financial-reporting/pull/423