### PR TITLE
Add background color

### DIFF
--- a/account_financial_report_qweb/static/src/css/report.css
+++ b/account_financial_report_qweb/static/src/css/report.css
@@ -1,5 +1,6 @@
 .act_as_table {
     display: table !important;
+    background-color: white;
 }
 .act_as_row  {
     display: table-row !important;


### PR DESCRIPTION
If not defined, in odoo enterprise, the table in accounting financial reports will be the same as the base backgroud-color of odoo. Which makes it unreadable.

@fclementic2c 

Sidenote: the variable  `@odoo-view-background-color;` is not defined by default. I could also update it in this view. https://github.com/OCA/account-financial-reporting/pull/473/files#diff-85d5b2cbc1bb086a85416f6e4dbca71fR99