### PR TITLE
account_financial_report: Switch to (Python 3.4 & below)-compatible syntax

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -63,7 +63,7 @@ class GeneralLedgerXslx(models.AbstractModel):
                      'type': 'amount_currency',
                      'width': 14},
             }
-            res = {**res, **foreign_currency}
+            res.update(foreign_currency)
         return res
 
     def _get_report_filters(self, report):

--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -49,7 +49,7 @@ class OpenItemsXslx(models.AbstractModel):
                      'type': 'amount_currency',
                      'width': 14},
             }
-            res = {**res, **foreign_currency}
+            res.update(foreign_currency)
         return res
 
     def _get_report_filters(self, report):

--- a/account_financial_report/report/trial_balance_xlsx.py
+++ b/account_financial_report/report/trial_balance_xlsx.py
@@ -50,7 +50,7 @@ class TrialBalanceXslx(models.AbstractModel):
                         'type': 'amount_currency',
                         'width': 14},
                 }
-                res = {**res, **foreign_currency}
+                res.update(foreign_currency)
             return res
         else:
             res = {
@@ -87,7 +87,7 @@ class TrialBalanceXslx(models.AbstractModel):
                         'type': 'amount_currency',
                         'width': 14},
                 }
-                res = {**res, **foreign_currency}
+                res.update(foreign_currency)
             return res
 
     def _get_report_filters(self, report):


### PR DESCRIPTION
This commit makes the module compatible with Python 3.4 & below, fixing #462.
Even if Odoo 11 is supposed to be run using Python 3.5+, compatibility with previous Python 3 versions is good to have.

```dict3 = {**dict1, **dict2}```
is syntactic sugar available in Python 3.5+ to merge dictionaries (see [PEP 448](https://www.python.org/dev/peps/pep-0448/)) and functionally equivalent to:
```
dict3 = {}
dict3.update(dict1)
dict3.update(dict2)
```