### PR TITLE
account_financial_report: set backgroud-color to table

### DIFF
--- a/account_financial_report/static/src/css/report.css
+++ b/account_financial_report/static/src/css/report.css
@@ -1,5 +1,6 @@
 .act_as_table {
     display: table !important;
+    background-color: white;
 }
 .act_as_row  {
     display: table-row !important;


### PR DESCRIPTION
If not defined, in odoo enterprise, the table in accounting financial reports will be the same as the base backgroud-color of odoo. Which makes it unreadable.

This is a forward-port from https://github.com/OCA/account-financial-reporting/pull/473 . It hasn't been tested, but has been asked by @jbeficent