### PR TITLE
[FIX] account_financial_report_webkit: Fix error if column exists

### DIFF
--- a/account_financial_report_webkit/README.rst
+++ b/account_financial_report_webkit/README.rst
@@ -166,6 +166,7 @@ Contributors
 * Guewen Baconnier
 * David Dufresne <david.dufresne@savoirfairelinux.com>
 * Luc De Meyer <luc.demeyer@noviat.com>
+* Jairo Llopis <jairo.llopis@tecnativa.com>
 
 Maintainer
 ----------

--- a/account_financial_report_webkit/hooks.py
+++ b/account_financial_report_webkit/hooks.py
@@ -1,23 +1,28 @@
 # -*- coding: utf-8 -*-
 # © 2017 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from psycopg2 import ProgrammingError
+
 from .models.account_move_line import AccountMoveLine
 
 
 def pre_init_hook(cr):
-    with cr.savepoint():
-        # don't break if column exists
-        cr.execute(
-            'alter table account_move_line add column last_rec_date date',
-        )
-        cr.execute(
-            'comment on column account_move_line.last_rec_date is %s',
-            (AccountMoveLine.last_rec_date.string,),
-        )
-        cr.execute(
-            'create index account_move_line_last_rec_date_index '
-            'on account_move_line (last_rec_date)',
-        )
+    # don't break if column exists
+    try:
+        with cr.savepoint():
+            cr.execute(
+                'alter table account_move_line add column last_rec_date date',
+            )
+            cr.execute(
+                'comment on column account_move_line.last_rec_date is %s',
+                (AccountMoveLine.last_rec_date.string,),
+            )
+            cr.execute(
+                'create index account_move_line_last_rec_date_index '
+                'on account_move_line (last_rec_date)',
+            )
+    except ProgrammingError:
+        pass
     # but still do the initialization
     cr.execute(
         """update account_move_line


### PR DESCRIPTION
The code comments say this should be happening before, but it was actually failing with:

    2018-12-03 11:31:49,074 48 ERROR test openerp.sql_db: Programming error: column "last_rec_date" of relation "account_move_line" already exists
    , in query alter table account_move_line add column last_rec_date date
    2018-12-03 11:31:49,074 48 CRITICAL test openerp.service.server: Failed to initialize database `test`.
    Traceback (most recent call last):
    File "/opt/odoo/custom/src/odoo/openerp/service/server.py", line 941, in preload_registries
        registry = RegistryManager.new(dbname, update_module=update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 370, in new
        openerp.modules.load_modules(registry._db, force_demo, status, update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 354, in load_modules
        loaded_modules, update_module)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 255, in load_marked_modules
        loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
    File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 150, in load_module_graph
        getattr(py_module, pre_init)(cr)
    File "/opt/odoo/auto/addons/account_financial_report_webkit/hooks.py", line 11, in pre_init_hook
        'alter table account_move_line add column last_rec_date date',
    File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 171, in wrapper
        return f(self, *args, **kwargs)
    File "/opt/odoo/custom/src/odoo/openerp/sql_db.py", line 247, in execute
        res = self._obj.execute(query, params)
    ProgrammingError: column "last_rec_date" of relation "account_move_line" already exists

@Tecnativa