### PR TITLE
[10.0][ADD] account_financial_report_web: add index on account_move_line to speed up report rendering

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.2.0.0',
+    'version': '10.0.2.0.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/models/__init__.py
+++ b/account_financial_report_qweb/models/__init__.py
@@ -4,3 +4,4 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from . import account
+from . import account_move_line

--- a/account_financial_report_qweb/models/account_move_line.py
+++ b/account_financial_report_qweb/models/account_move_line.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
+from odoo import api, models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = 'account.move.line'
+
+    @api.model_cr
+    def init(self):
+        """
+            The join between accounts_partners subquery and account_move_line
+            can be heavy to compute on big databases.
+            Join sample:
+                JOIN
+                    account_move_line ml
+                        ON ap.account_id = ml.account_id
+                        AND ml.date < '2018-12-30'
+                        AND ap.partner_id = ml.partner_id
+                        AND ap.include_initial_balance = TRUE
+            By adding the following index, performances are strongly increased.
+        :return:
+        """
+        self._cr.execute('SELECT indexname FROM pg_indexes WHERE indexname = '
+                         '%s',
+                         ('account_move_line_account_id_partner_id_index',))
+        if not self._cr.fetchone():
+            self._cr.execute("""
+            CREATE INDEX account_move_line_account_id_partner_id_index
+            ON account_move_line (account_id, partner_id)""")


### PR DESCRIPTION
ON a big database, requesting the Trial balance with details for all partners nerver ends, same for Aged Balance.

By index a combined index on account_move_line to speed up joins, the results are much better.

On my database with more than 2.000.000 records on move lines the time fails from 9 minutes to few seconds....
