### PR TITLE
[11.0][account_financial_report] Fix wizards for proper multicompany behaviour

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '11.0.2.4.0',
+    'version': '11.0.2.4.1',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/readme/HISTORY.rst
+++ b/account_financial_report/readme/HISTORY.rst
@@ -1,3 +1,10 @@
+11.0.2.4.1 (2019-01-08)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* Handle better multicompany behaviour
+* Improve how title appears in the reports
+
+
 11.0.2.3.1 (2018-11-29)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -254,7 +254,6 @@ class GeneralLedgerReportCompute(models.TransientModel):
             self._inject_partner_values()
             if not self.filter_partner_ids:
                 self._inject_partner_values(only_empty_partner=True)
-
         # Add unaffected earnings account
         if (not self.filter_account_ids or
                 self.unaffected_earnings_account.id in

--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -17,9 +17,9 @@
         <!-- Defines global variables used by internal layout -->
         <t t-set="title">Aged Partner Balance - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <!-- Display filters -->
             <t t-call="account_financial_report.report_aged_partner_balance_filters"/>

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -19,9 +19,9 @@
         <!-- Defines global variables used by internal layout -->
         <t t-set="title">General Ledger - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <!-- Display filters -->
             <t t-call="account_financial_report.report_general_ledger_filters"/>

--- a/account_financial_report/report/templates/journal_ledger.xml
+++ b/account_financial_report/report/templates/journal_ledger.xml
@@ -16,9 +16,9 @@
         <t t-set="display_account_name" t-value="o.with_account_name"/>
         <t t-set="title">Journal Ledger - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <t t-if="o.group_option == 'none'">
                 <div class="page_break">

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -17,9 +17,9 @@
         <!-- Defines global variables used by internal layout -->
         <t t-set="title">Open Items - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <!-- Display filters -->
             <t t-call="account_financial_report.report_open_items_filters"/>

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -19,9 +19,9 @@
         <t t-set="title">Trial Balance - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
         <t t-set="res_company" t-value="o.company_id"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <!-- Display filters -->
             <t t-call="account_financial_report.report_trial_balance_filters"/>

--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -14,9 +14,9 @@
     <template id="account_financial_report.report_vat_report_base">
         <t t-set="title">VAT Report - <t t-raw="o.company_id.name"/> - <t t-raw="o.company_id.currency_id.name"/></t>
         <t t-set="company_name" t-value="o.company_id.name"/>
-        <div class="page data_table">
+        <div class="page">
             <div class="row">
-                <h4 class="mt0" t-esc="title or 'Odoo Report'"/>
+                <h4 class="mt0" t-esc="title or 'Odoo Report'" style="text-align: center;"/>
             </div>
             <!-- Display filters -->
             <t t-call="account_financial_report.report_vat_report_filters"/>

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -17,7 +17,7 @@ class AgedPartnerBalanceWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
-        required=True,
+        required=False,
         string='Company'
     )
     date_at = fields.Date(required=True,
@@ -47,8 +47,22 @@ class AgedPartnerBalanceWizard(models.TransientModel):
                 lambda p: p.company_id == self.company_id or
                 not p.company_id)
         if self.company_id and self.account_ids:
-            self.account_ids = self.account_ids.filtered(
-                lambda a: a.company_id == self.company_id)
+            if self.receivable_accounts_only or self.payable_accounts_only:
+                self.onchange_type_accounts_only()
+            else:
+                self.account_ids = self.account_ids.filtered(
+                    lambda a: a.company_id == self.company_id)
+        res = {'domain': {'account_ids': [],
+                          'partner_ids': []}}
+        if not self.company_id:
+            return res
+        else:
+            res['domain']['account_ids'] += [
+                ('company_id', '=', self.company_id.id)]
+            res['domain']['partner_ids'] += [
+                '|', ('company_id', '=', self.company_id.id),
+                ('company_id', '=', False)]
+        return res
 
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):

--- a/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
@@ -23,8 +23,7 @@
                     <label for="partner_ids"/>
                     <field name="partner_ids" nolabel="1"
                            widget="many2many_tags"
-                           options="{'no_create': True}"
-                           domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
+                           options="{'no_create': True}"/>
                 </group>
                 <group name="account_filter" col="4">
                     <label for="account_ids" colspan="4"/>
@@ -33,7 +32,6 @@
                     <field name="account_ids" nolabel="1"
                            widget="many2many_tags"
                            options="{'no_create': True}"
-                           domain="[('company_id','=',company_id)]"
                            colspan="4"/>
                 </group>
                 <footer>

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -13,8 +13,7 @@
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}">
                     <group name="filters">
                         <group name="date_range">
-                            <field name="date_range_id"
-                                   domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
+                            <field name="date_range_id"/>
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>
@@ -36,19 +35,16 @@
                             <field name="account_ids"
                                    nolabel="1"
                                    widget="many2many_tags"
-                                   options="{'no_create': True}"
-                                   domain="[('company_id','=',company_id)]"/>
+                                   options="{'no_create': True}"/>
                         </page>
                         <page string="Filter partners">
                             <field name="partner_ids" nolabel="1"
                                    widget="many2many_tags"
-                                   domain="['|',('company_id','=',company_id), ('company_id','=',False)]"
                                    options="{'no_create': True}"/>
                         </page>
                         <page string="Filter cost centers" groups="analytic.group_analytic_accounting">
                             <field name="cost_center_ids" nolabel="1"
                                    options="{'no_create': True}"
-                                   domain="[('company_id','=',company_id)]"
                                    groups="analytic.group_analytic_accounting"/>
                         </page>
                         <page string="Filter analytic tags">

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -17,7 +17,7 @@ class OpenItemsReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
-        required=True,
+        required=False,
         string='Company'
     )
     date_at = fields.Date(required=True,
@@ -60,8 +60,22 @@ class OpenItemsReportWizard(models.TransientModel):
                 lambda p: p.company_id == self.company_id or
                 not p.company_id)
         if self.company_id and self.account_ids:
-            self.account_ids = self.account_ids.filtered(
-                lambda a: a.company_id == self.company_id)
+            if self.receivable_accounts_only or self.payable_accounts_only:
+                self.onchange_type_accounts_only()
+            else:
+                self.account_ids = self.account_ids.filtered(
+                    lambda a: a.company_id == self.company_id)
+        res = {'domain': {'account_ids': [],
+                          'partner_ids': []}}
+        if not self.company_id:
+            return res
+        else:
+            res['domain']['account_ids'] += [
+                ('company_id', '=', self.company_id.id)]
+            res['domain']['partner_ids'] += [
+                '|', ('company_id', '=', self.company_id.id),
+                ('company_id', '=', False)]
+        return res
 
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -24,7 +24,6 @@
                     <label for="partner_ids"/>
                     <field name="partner_ids"
                            nolabel="1"
-                           domain="['|',('company_id','=',company_id), ('company_id','=',False)]"
                            widget="many2many_tags"
                            options="{'no_create': True}"/>
                 </group>
@@ -34,7 +33,6 @@
                     <field name="account_ids"
                            nolabel="1"
                            widget="many2many_tags"
-                           domain="[('company_id','=',company_id)]"
                            options="{'no_create': True}"
                            colspan="4"/>
                 </group>

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -19,7 +19,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
-        required=True,
+        required=False,
         string='Company'
     )
     date_range_id = fields.Many2one(
@@ -115,9 +115,35 @@ class TrialBalanceReportWizard(models.TransientModel):
             self.partner_ids = self.partner_ids.filtered(
                 lambda p: p.company_id == self.company_id or
                 not p.company_id)
-        if self.company_id and self.account_ids:
-            self.account_ids = self.account_ids.filtered(
+        if self.company_id and self.journal_ids:
+            self.journal_ids = self.journal_ids.filtered(
                 lambda a: a.company_id == self.company_id)
+        if self.company_id and self.account_ids:
+            if self.receivable_accounts_only or self.payable_accounts_only:
+                self.onchange_type_accounts_only()
+            else:
+                self.account_ids = self.account_ids.filtered(
+                    lambda a: a.company_id == self.company_id)
+        res = {'domain': {'account_ids': [],
+                          'partner_ids': [],
+                          'date_range_id': [],
+                          'journal_ids': [],
+                          }
+               }
+        if not self.company_id:
+            return res
+        else:
+            res['domain']['account_ids'] += [
+                ('company_id', '=', self.company_id.id)]
+            res['domain']['partner_ids'] += [
+                '|', ('company_id', '=', self.company_id.id),
+                ('company_id', '=', False)]
+            res['domain']['date_range_id'] += [
+                '|', ('company_id', '=', self.company_id.id),
+                ('company_id', '=', False)]
+            res['domain']['journal_ids'] += [
+                ('company_id', '=', self.company_id.id)]
+        return res
 
     @api.onchange('date_range_id')
     def onchange_date_range_id(self):

--- a/account_financial_report/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report/wizard/trial_balance_wizard_view.xml
@@ -13,7 +13,7 @@
                 <div attrs="{'invisible': [('not_only_one_unaffected_earnings_account', '=', True)]}">
                     <group name="filters">
                         <group name="date_range">
-                            <field name="date_range_id" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
+                            <field name="date_range_id"/>
                             <field name="date_from"/>
                             <field name="date_to"/>
                             <field name="fy_start_date" invisible="1"/>
@@ -32,14 +32,12 @@
                         <label for="partner_ids"/>
                         <field name="partner_ids"
                                nolabel="1"
-                               domain="['|',('company_id','=',company_id), ('company_id','=',False)]"
                                widget="many2many_tags"
                                options="{'no_create': True}"/>
                     </group>
                     <label for="journal_ids"/>
                     <field name="journal_ids"
                            widget="many2many_tags"
-                           domain="[('company_id','=',company_id)]"
                            nolabel="1"
                            options="{'no_create': True}"
                     />
@@ -52,7 +50,6 @@
                         <field name="account_ids"
                                nolabel="1"
                                widget="many2many_tags"
-                               domain="[('company_id','=',company_id)]"
                                options="{'no_create': True}"
                                colspan="4"/>
                     </group>

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -13,7 +13,7 @@ class VATReportWizard(models.TransientModel):
     company_id = fields.Many2one(
         comodel_name='res.company',
         default=lambda self: self.env.user.company_id,
-        required=True,
+        required=False,
         string='Company'
     )
     date_range_id = fields.Many2one(
@@ -34,6 +34,16 @@ class VATReportWizard(models.TransientModel):
         if self.company_id and self.date_range_id.company_id and \
                 self.date_range_id.company_id != self.company_id:
             self.date_range_id = False
+        res = {'domain': {'date_range_id': [],
+                          }
+               }
+        if not self.company_id:
+            return res
+        else:
+            res['domain']['date_range_id'] += [
+                '|', ('company_id', '=', self.company_id.id),
+                ('company_id', '=', False)]
+        return res
 
     @api.onchange('date_range_id')
     def onchange_date_range_id(self):

--- a/account_financial_report/wizard/vat_report_wizard_view.xml
+++ b/account_financial_report/wizard/vat_report_wizard_view.xml
@@ -11,7 +11,7 @@
             </group>
             <group name="filters">
                 <group name="date_range">
-                    <field name="date_range_id" domain="['|',('company_id','=',company_id), ('company_id','=',False)]"/>
+                    <field name="date_range_id"/>
                     <field name="date_from"/>
                     <field name="date_to"/>
                 </group>


### PR DESCRIPTION
This PR:
* Allows the financial reports to be run with no company indicated in the wizards, whenever allowed, but if you indicate a company, it ensures that the other company-dependent fields in the wizard are consistent with the choice of company.
* Fixes a wrong layout that was introduced in #489
