### PR TITLE
[WIP] [10][IMP] imp account financial report qweb

### DIFF
--- a/account_financial_report_qweb/report/general_ledger.py
+++ b/account_financial_report_qweb/report/general_ledger.py
@@ -186,6 +186,7 @@ class GeneralLedgerReportMoveLine(models.TransientModel):
 
     # Data fields, used to keep link with real object
     move_line_id = fields.Many2one('account.move.line')
+    matched_ml = fields.Many2one("account.full.reconcile")
 
     # Data fields, used for report display
     date = fields.Date()
@@ -197,7 +198,6 @@ class GeneralLedgerReportMoveLine(models.TransientModel):
     label = fields.Char()
     cost_center = fields.Char()
     tags = fields.Char()
-    matching_number = fields.Char()
     debit = fields.Float(digits=(16, 2))
     credit = fields.Float(digits=(16, 2))
     cumul_balance = fields.Float(digits=(16, 2))
@@ -1067,6 +1067,7 @@ INSERT INTO
     create_uid,
     create_date,
     move_line_id,
+    matched_ml,
     date,
     entry,
     journal,
@@ -1075,7 +1076,6 @@ INSERT INTO
     partner,
     label,
     cost_center,
-    matching_number,
     debit,
     credit,
     cumul_balance,
@@ -1096,6 +1096,7 @@ SELECT
     %s AS create_uid,
     NOW() AS create_date,
     ml.id AS move_line_id,
+    fr.id AS matched_ml, 
     ml.date,
     m.name AS entry,
     j.code AS journal,
@@ -1139,7 +1140,6 @@ SELECT
         query_inject_move_line += """
     CONCAT_WS(' - ', NULLIF(ml.ref, ''), NULLIF(ml.name, '')) AS label,
     aa.name AS cost_center,
-    fr.name AS matching_number,
     ml.debit,
     ml.credit,
         """

--- a/account_financial_report_qweb/report/templates/general_ledger.xml
+++ b/account_financial_report_qweb/report/templates/general_ledger.xml
@@ -334,8 +334,8 @@
                             <a t-att-data-active-id="line.move_line_id.move_id.id"
                                t-att-data-res-model="res_model"
                                class="o_account_financial_reports_web_action underline-on-hover"
-                               style="color: black; cursor: pointer;">
-                                <t t-raw="line.entry"/></a>
+                               t-att-style="style">
+                                <t t-att-style="style" t-raw="line.entry"/></a>
                         </span>
                     </div>
                     <!--## journal-->

--- a/account_financial_report_qweb/report/templates/general_ledger.xml
+++ b/account_financial_report_qweb/report/templates/general_ledger.xml
@@ -401,12 +401,12 @@
                     </t>
                     <!--## matching_number-->
                     <div class="act_as_cell">
-                        <t t-set="res_model" t-value="'account_full_reconcile'"/>
-                        <span t-if="line.matching_number">
-                            <a t-att-data-active-id="line.move_line_id.full_reconcile_id.id"
+                        <t t-set="res_model" t-value="'account.full.reconcile'"/>
+                        <span t-if="line.matched_ml">
+                            <a t-att-data-active-id="line.matched_ml.id"
                                t-att-data-res-model="res_model"
                                class="o_account_financial_reports_web_action underline-on-hover"
-                               style="color: black; cursor: pointer;"><t t-raw="line.matching_number"/></a>
+                               style="color: black; cursor: pointer;"><t t-raw="line.matched_ml.name"/></a>
                         </span>
                     </div>
                     <!--## debit-->

--- a/account_financial_report_qweb/report/templates/open_items.xml
+++ b/account_financial_report_qweb/report/templates/open_items.xml
@@ -134,8 +134,8 @@
                             <a t-att-data-active-id="line.move_line_id.move_id.id"
                                t-att-data-res-model="res_model"
                                class="o_account_financial_reports_web_action"
-                               style="color: black;">
-                                <t t-raw="line.entry"/>
+                               t-att-style="style">
+                                <t t-att-style="style" t-raw="line.entry"/>
                             </a>
                         </span>
                     </div>

--- a/account_financial_report_qweb/static/src/css/report.css
+++ b/account_financial_report_qweb/static/src/css/report.css
@@ -96,7 +96,7 @@
 }
 
 .o_account_financial_reports_page {
-    background-color: @odoo-view-background-color;
+    background-color: white;
     color: @odoo-main-text-color;
     padding-top: 10px;
     width: 90%;

--- a/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
@@ -35,6 +35,7 @@ class AgedPartnerBalance(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
+        domain="[('parent_id','=', False)]",
     )
     show_move_line_details = fields.Boolean()
 

--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -53,6 +53,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
+        domain="[('parent_id','=', False)]",
     )
     journal_ids = fields.Many2many(
         comodel_name="account.journal",

--- a/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
@@ -79,4 +79,16 @@
                 view_id="general_ledger_wizard"
                 target="new" />
 
+    <!--Add to res.partner action-->
+    <act_window id="act_action_general_ledger_wizard_partner_relation"
+                name="General Ledger"
+                res_model="general.ledger.report.wizard"
+                src_model="res.partner"
+                view_mode="form"
+                context="{
+                    'default_receivable_accounts_only':1,
+                    'default_payable_accounts_only':1,
+                    }"
+                key2="client_action_multi"
+                target="new" />
 </odoo>

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -43,6 +43,7 @@ class OpenItemsReportWizard(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
+        domain="[('parent_id','=', False)]",
     )
     foreign_currency = fields.Boolean(
         string='Show foreign currency',

--- a/account_financial_report_qweb/wizard/open_items_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/open_items_wizard_view.xml
@@ -52,4 +52,16 @@
                 view_id="open_items_wizard"
                 target="new" />
 
+    <!--Add to res.partner action-->
+    <act_window id="act_action_open_items_wizard_partner_relation"
+                name="Open Items Partner"
+                res_model="open.items.report.wizard"
+                src_model="res.partner"
+                view_mode="form"
+                context="{
+                    'default_receivable_accounts_only':1,
+                    'default_payable_accounts_only':1,
+                    }"
+                key2="client_action_multi"
+                target="new" />
 </odoo>

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -65,6 +65,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
+        domain="[('parent_id','=', False)]",
     )
     journal_ids = fields.Many2many(
         comodel_name="account.journal",


### PR DESCRIPTION
Add 2 new report menus on the partner form (action menu)

- Open items report 
- General ledger report

The goal it that when you click on one of these report, the wizard is automatically be filled in this way:
set start date to 01/01/2018 if today's date is 12 dec 2018 and that fiscal year end up on 31/12 as per accounting settings - see fiscalyear_last_month in the account_config_settings
set end date to today 
For the open items report, just set today's date
select the current partner  only (warning: no contact - take the parent if it is the case - We do not bother about contact for accounting)
show multi-currency checkbox = true (if multi-currency access rights activated)
check 2 boxes: receivable_accounts_only and payable_accounts_only
Let the end user validating the wizard so he can change any values if necessary.

