### PR TITLE
[10.0][IMP] account_financial_report_qweb : filter for partner

### DIFF
--- a/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/aged_partner_balance_wizard.py
@@ -60,8 +60,11 @@ class AgedPartnerBalance(models.TransientModel):
             res['domain']['account_ids'] += [
                 ('company_id', '=', self.company_id.id)]
             res['domain']['partner_ids'] += [
+                '&',
                 '|', ('company_id', '=', self.company_id.id),
-                ('company_id', '=', False)]
+                ('company_id', '=', False),
+                ('parent_id', '=', False)
+            ]
         return res
 
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')

--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -132,8 +132,11 @@ class GeneralLedgerReportWizard(models.TransientModel):
             res['domain']['journal_ids'] += [
                 ('company_id', '=', self.company_id.id)]
             res['domain']['partner_ids'] += [
+                '&',
                 '|', ('company_id', '=', self.company_id.id),
-                ('company_id', '=', False)]
+                ('company_id', '=', False),
+                ('parent_id', '=', False)
+            ]
             res['domain']['cost_center_ids'] += [
                 ('company_id', '=', self.company_id.id)]
             res['domain']['date_range_id'] += [

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -73,8 +73,10 @@ class OpenItemsReportWizard(models.TransientModel):
             res['domain']['account_ids'] += [
                 ('company_id', '=', self.company_id.id)]
             res['domain']['partner_ids'] += [
+                '&',
                 '|', ('company_id', '=', self.company_id.id),
-                ('company_id', '=', False)]
+                ('company_id', '=', False),
+                ('parent_id', '=', False)]
         return res
 
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -137,8 +137,10 @@ class TrialBalanceReportWizard(models.TransientModel):
             res['domain']['account_ids'] += [
                 ('company_id', '=', self.company_id.id)]
             res['domain']['partner_ids'] += [
+                '&',
                 '|', ('company_id', '=', self.company_id.id),
-                ('company_id', '=', False)]
+                ('company_id', '=', False),
+                ('parent_id', '=', False)]
             res['domain']['date_range_id'] += [
                 '|', ('company_id', '=', self.company_id.id),
                 ('company_id', '=', False)]


### PR DESCRIPTION
On wizards (for all reports) where a partner selection is possible, we should not be able to see contacts -> we only work on legal entity