### PR TITLE
[10.0][IMP] Add report to res partner, default values

### DIFF
--- a/account_financial_report_qweb/static/src/js/account_financial_report_qweb_widgets.js
+++ b/account_financial_report_qweb/static/src/js/account_financial_report_qweb_widgets.js
@@ -47,7 +47,7 @@ odoo.define('account_financial_report_qweb.account_financial_report_widget', fun
         boundLinkMonetary: function (e) {
             var res_model = $(e.target).data('res-model');
             var res_id = $(e.target).data('active-id');
-            // check if we call on appropriate element, amount been wrapped in
+            // Check if we call on appropriate element, amount been wrapped in
             // a span by a monetary widget
             if (e.target.localName === 'span' ) {
                 res_model = $(e.target.parentElement).data('res-model');
@@ -64,7 +64,7 @@ odoo.define('account_financial_report_qweb.account_financial_report_widget', fun
         boundLinkMonetarymulti: function (e) {
             var res_model = $(e.target).data('res-model');
             var domain = $(e.target).data('domain');
-            // check if we call on appropriate element, amount been wrapped in
+            // Check if we call on appropriate element, amount been wrapped in
             // a span by a monetary widget
             if (e.target.localName === 'span' ) {
                 res_model = $(e.target.parentElement).data('res-model');

--- a/account_financial_report_qweb/tests/test_general_ledger.py
+++ b/account_financial_report_qweb/tests/test_general_ledger.py
@@ -499,3 +499,20 @@ class TestGeneralLedgerReport(common.TransactionCase):
         self.assertEqual(lines['unaffected'].final_debit, 500)
         self.assertEqual(lines['unaffected'].final_credit, 0)
         self.assertEqual(lines['unaffected'].final_balance, 500)
+
+    def test_partner_filter(self):
+        partner_1 = self.env.ref('base.res_partner_1')
+        partner_2 = self.env.ref('base.res_partner_2')
+        partner_3 = self.env.ref('base.res_partner_3')
+        partner_4 = self.env.ref('base.res_partner_4')
+        partner_1.write({'is_company': False,
+                         'parent_id': partner_2.id})
+        partner_3.write({'is_company': False})
+
+        expected_list = [partner_2.id, partner_3.id, partner_4.id]
+        context = {'active_ids':
+                       [partner_1.id, partner_2.id, partner_3.id, partner_4.id],
+                   'active_model': 'res.partner'}
+
+        wizard = self.env["general.ledger.report.wizard"].with_context(context)
+        self.assertEqual(wizard._default_partners(), expected_list)

--- a/account_financial_report_qweb/tests/test_open_items.py
+++ b/account_financial_report_qweb/tests/test_open_items.py
@@ -51,9 +51,10 @@ class TestOpenItems(a_t_f_c.AbstractTestForeignCurrency):
         partner_3.write({'is_company': False})
 
         expected_list = [partner_2.id, partner_3.id, partner_4.id]
-        context = {'active_ids':
-                       [partner_1.id, partner_2.id, partner_3.id, partner_4.id],
-                   'active_model': 'res.partner'}
+        context = {'active_ids': [
+            partner_1.id, partner_2.id, partner_3.id, partner_4.id
+        ],
+            'active_model': 'res.partner'}
 
         wizard = self.env["open.items.report.wizard"].with_context(context)
         self.assertEqual(wizard._default_partners(), expected_list)

--- a/account_financial_report_qweb/tests/test_open_items.py
+++ b/account_financial_report_qweb/tests/test_open_items.py
@@ -40,3 +40,20 @@ class TestOpenItems(a_t_f_c.AbstractTestForeignCurrency):
             {'hide_account_at_0': True},
             {'only_posted_moves': True, 'hide_account_at_0': True},
         ]
+
+    def test_partner_filter(self):
+        partner_1 = self.env.ref('base.res_partner_1')
+        partner_2 = self.env.ref('base.res_partner_2')
+        partner_3 = self.env.ref('base.res_partner_3')
+        partner_4 = self.env.ref('base.res_partner_4')
+        partner_1.write({'is_company': False,
+                         'parent_id': partner_2.id})
+        partner_3.write({'is_company': False})
+
+        expected_list = [partner_2.id, partner_3.id, partner_4.id]
+        context = {'active_ids':
+                       [partner_1.id, partner_2.id, partner_3.id, partner_4.id],
+                   'active_model': 'res.partner'}
+
+        wizard = self.env["open.items.report.wizard"].with_context(context)
+        self.assertEqual(wizard._default_partners(), expected_list)

--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -9,6 +9,8 @@ from odoo import api, fields, models, _
 from odoo.tools.safe_eval import safe_eval
 from odoo.exceptions import ValidationError
 
+import time
+
 
 class GeneralLedgerReportWizard(models.TransientModel):
     """General ledger report wizard."""
@@ -26,8 +28,10 @@ class GeneralLedgerReportWizard(models.TransientModel):
         comodel_name='date.range',
         string='Date range'
     )
-    date_from = fields.Date(required=True)
-    date_to = fields.Date(required=True)
+    date_from = fields.Date(required=True,
+                            default=lambda self: self._init_date_from())
+    date_to = fields.Date(required=True,
+                          default=fields.Date.context_today)
     fy_start_date = fields.Date(compute='_compute_fy_start_date')
     target_move = fields.Selection([('posted', 'All Posted Entries'),
                                     ('all', 'All Entries')],
@@ -100,6 +104,18 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
             return list(partner_ids)
 
+    def _init_date_from(self):
+        """set start date to begin of current year if fiscal year running"""
+        today = fields.Date.context_today(self)
+        cur_month = int(fields.Date.from_string(today).strftime('%m'))
+        cur_day = int(fields.Date.from_string(today).strftime('%d'))
+        last_fsc_month = self.env.user.company_id.fiscalyear_last_month
+        last_fsc_day = self.env.user.company_id.fiscalyear_last_day
+
+        if cur_month < last_fsc_month \
+                or cur_month == last_fsc_month and cur_day <= last_fsc_day:
+            return time.strftime('%Y-01-01')
+
     @api.depends('date_from')
     def _compute_fy_start_date(self):
         for wiz in self.filtered('date_from'):
@@ -164,8 +180,9 @@ class GeneralLedgerReportWizard(models.TransientModel):
     @api.onchange('date_range_id')
     def onchange_date_range_id(self):
         """Handle date range change."""
-        self.date_from = self.date_range_id.date_start
-        self.date_to = self.date_range_id.date_end
+        if self.date_range_id:
+            self.date_from = self.date_range_id.date_start
+            self.date_to = self.date_range_id.date_end
 
     @api.multi
     @api.constrains('company_id', 'date_range_id')

--- a/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard_view.xml
@@ -86,4 +86,16 @@
                 view_id="general_ledger_wizard"
                 target="new" />
 
+    <!--Add to res.partner action-->
+    <act_window id="act_action_general_ledger_wizard_partner_relation"
+                name="General Ledger"
+                res_model="general.ledger.report.wizard"
+                src_model="res.partner"
+                view_mode="form"
+                context="{
+                    'default_receivable_accounts_only':1,
+                    'default_payable_accounts_only':1,
+                    }"
+                key2="client_action_multi"
+                target="new" />
 </odoo>

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -44,9 +44,11 @@ class OpenItemsReportWizard(models.TransientModel):
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
+        default=lambda self: self._default_partners(),
     )
     foreign_currency = fields.Boolean(
         string='Show foreign currency',
+        default=lambda self: self._default_foreign_currency(),
         help='Display foreign currency for move lines, unless '
              'account currency is not setup through chart of accounts '
              'will display initial and final balance in that currency.'
@@ -76,6 +78,24 @@ class OpenItemsReportWizard(models.TransientModel):
                 '|', ('company_id', '=', self.company_id.id),
                 ('company_id', '=', False)]
         return res
+
+    def _default_foreign_currency(self):
+        if self.env.user.has_group('base.group_multi_currency'):
+            return True
+
+    def _default_partners(self):
+        context = self.env.context
+
+        if context.get('active_ids') and context.get('active_model')\
+                == 'res.partner':
+            partner_ids = context['active_ids']
+            corp_partners = self.env['res.partner'].browse(partner_ids).\
+                filtered(lambda p: p.parent_id)
+
+            partner_ids = set(partner_ids) - set(corp_partners.ids)
+            partner_ids |= set(corp_partners.mapped('parent_id.id'))
+
+            return list(partner_ids)
 
     @api.onchange('receivable_accounts_only', 'payable_accounts_only')
     def onchange_type_accounts_only(self):

--- a/account_financial_report_qweb/wizard/open_items_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/open_items_wizard_view.xml
@@ -58,4 +58,16 @@
                 view_id="open_items_wizard"
                 target="new" />
 
+    <!--Add to res.partner action-->
+    <act_window id="act_action_open_items_wizard_partner_relation"
+                name="Open Items Partner"
+                res_model="open.items.report.wizard"
+                src_model="res.partner"
+                view_mode="form"
+                context="{
+                    'default_receivable_accounts_only':1,
+                    'default_payable_accounts_only':1,
+                    }"
+                key2="client_action_multi"
+                target="new" />
 </odoo>


### PR DESCRIPTION
Add to partner action open item and general ledger report
Add method to filter only account applicable partner
Set currency checkbox due to user settings
Set start date to 01/01/2018 if today's date is 12 dec 2018 and that fiscal year end up on 31/12 as per accounting settings - see fiscalyear_last_month in the account_config_settings
Set end date to today 