### PR TITLE
[FIX] customer_activity_statement: reference table on the query

### DIFF
--- a/customer_activity_statement/__manifest__.py
+++ b/customer_activity_statement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Partner Activity Statement',
-    'version': '11.0.2.1.0',
+    'version': '11.0.2.1.1',
     'category': 'Accounting & Finance',
     'summary': 'OCA Financial Reports',
     'author': "Eficent, Odoo Community Association (OCA)",

--- a/customer_activity_statement/report/customer_activity_statement.py
+++ b/customer_activity_statement/report/customer_activity_statement.py
@@ -92,9 +92,10 @@ class CustomerActivityStatement(models.AbstractModel):
 
     def _display_lines_sql_q2(self, company_id):
         return """
-            SELECT Q1.partner_id, move_id, date, date_maturity, Q1.name, ref,
-                            debit, credit, debit-credit as amount, blocked,
-            COALESCE(Q1.currency_id, c.currency_id) AS currency_id
+            SELECT Q1.partner_id, Q1.move_id, Q1.date, Q1.date_maturity,
+                Q1.name, Q1.ref, Q1.debit, Q1.credit,
+                Q1.debit-Q1.credit as amount, Q1.blocked,
+                COALESCE(Q1.currency_id, c.currency_id) AS currency_id
             FROM Q1
             JOIN res_company c ON (c.id = Q1.company_id)
             WHERE c.id = %s


### PR DESCRIPTION
It limits how the fields can be named on res.company (also, ref is a standard field of partner_id)