### PR TITLE
[10.0] account_financial_report_qweb: usability improvement on onchange_partner_ids

### DIFF
--- a/account_financial_report_qweb/wizard/general_ledger_wizard.py
+++ b/account_financial_report_qweb/wizard/general_ledger_wizard.py
@@ -215,10 +215,11 @@ class GeneralLedgerReportWizard(models.TransientModel):
     @api.onchange('partner_ids')
     def onchange_partner_ids(self):
         """Handle partners change."""
-        if self.partner_ids:
+        if (
+                self.partner_ids and
+                not self.receivable_accounts_only and
+                not self.payable_accounts_only):
             self.receivable_accounts_only = self.payable_accounts_only = True
-        else:
-            self.receivable_accounts_only = self.payable_accounts_only = False
 
     @api.multi
     def button_export_html(self):


### PR DESCRIPTION
On the general ledger wizard, the following scenario is very annoying:
1) start the general ledger wizard
2) in the "Filter Accounts" tab, check "Receivable accounts only"
3) in the "Filter Partners" tab, select a partner
-> it automatically checks the option "Payable accounts only", which is not what I wanted !

This PR fixes this.