### PR TITLE
[IMP] account_financial_report: adjust columns

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '11.0.2.4.2',
+    'version': '11.0.2.4.3',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/static/src/css/report.css
+++ b/account_financial_report/static/src/css/report.css
@@ -18,7 +18,6 @@
 }
 .list_table, .data_table, .totals_table{
     width: 100% !important;
-    table-layout: fixed !important;
 }
 .act_as_row.labels {
     background-color:#F0F0F0 !important;


### PR DESCRIPTION
When values are large in report, as layout is fixed, total values are overlapped as you can see in captures.

Before this patch:
![report_before](https://user-images.githubusercontent.com/4386443/54741280-4b420c80-4bbe-11e9-9e01-e5367634bccb.png)

After this patch:
![report_after](https://user-images.githubusercontent.com/4386443/54741294-539a4780-4bbe-11e9-8706-3014d52b8a73.png)


cc @Tecnativa
