### PR TITLE
[10.0][account_financial_report_qweb] Fix to Trial Balance with parameter 'Hide account at 0'

### DIFF
--- a/account_financial_report_qweb/report/trial_balance.py
+++ b/account_financial_report_qweb/report/trial_balance.py
@@ -215,7 +215,6 @@ class TrialBalanceReportCompute(models.TransientModel):
             'date_from': self.date_from,
             'date_to': self.date_to,
             'only_posted_moves': self.only_posted_moves,
-            'hide_account_at_0': self.hide_account_at_0,
             'foreign_currency': self.foreign_currency,
             'company_id': self.company_id.id,
             'filter_account_ids': [(6, 0, account_ids.ids)],


### PR DESCRIPTION
when computing the trial balance, do not pass the parameter 'hide_account_at_0' to the computation
of the general ledger.

cc @alexis-via 