### PR TITLE
[10.0] account_financial_report_qweb: add option to hide parent hierarchy levels

### DIFF
--- a/account_financial_report_qweb/README.rst
+++ b/account_financial_report_qweb/README.rst
@@ -50,13 +50,10 @@ currency balances are not available.
 Changelog
 =========
 
-10.0.3.0.0 (2019-01-09)
+10.0.3.1.0 (2019-04-26)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-* Improve multicompany related usability.
-* Improve performance in the General Ledger.
-* The reports now display an improved title that includes report name,
-  company and currency.
+* In the Trial Balance you have an option to hide parent hierarchy levels
 
 
 10.0.2.0.0 (2018-11-29)

--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -5,7 +5,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'QWeb Financial Reports',
-    'version': '10.0.3.0.1',
+    'version': '10.0.3.1.0',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report_qweb/readme/HISTORY.rst
+++ b/account_financial_report_qweb/readme/HISTORY.rst
@@ -1,3 +1,9 @@
+10.0.3.1.0 (2019-04-26)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* In the Trial Balance you have an option to hide parent hierarchy levels
+
+
 10.0.3.0.0 (2019-01-09)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/account_financial_report_qweb/report/trial_balance.py
+++ b/account_financial_report_qweb/report/trial_balance.py
@@ -47,6 +47,8 @@ class TrialBalanceReport(models.TransientModel):
     limit_hierarchy_level = fields.Boolean('Limit hierarchy levels')
     show_hierarchy_level = fields.Integer('Hierarchy Levels to display',
                                           default=1)
+    hide_parent_hierarchy_level = fields.Boolean(
+        'Do not display parent levels', default=False)
     # General Ledger Report Data fields,
     # used as base for compute the data reports
     general_ledger_id = fields.Many2one(
@@ -126,9 +128,16 @@ class TrialBalanceReportAccount(models.TransientModel):
                     not rec.debit and
                     not rec.credit):
                 rec.hide_line = True
-            elif report.limit_hierarchy_level and \
-                    rec.level > report.show_hierarchy_level:
-                rec.hide_line = True
+            elif report.limit_hierarchy_level and report.show_hierarchy_level:
+                if report.hide_parent_hierarchy_level:
+                    distinct_level = rec.level != report.show_hierarchy_level
+                    if rec.account_group_id and distinct_level:
+                        rec.hide_line = True
+                    elif rec.level and distinct_level:
+                        rec.hide_line = True
+                elif not report.hide_parent_hierarchy_level and \
+                        rec.level > report.show_hierarchy_level:
+                    rec.hide_line = True
 
 
 class TrialBalanceReportPartner(models.TransientModel):

--- a/account_financial_report_qweb/wizard/trial_balance_wizard.py
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard.py
@@ -50,6 +50,8 @@ class TrialBalanceReportWizard(models.TransientModel):
     limit_hierarchy_level = fields.Boolean('Limit hierarchy levels')
     show_hierarchy_level = fields.Integer('Hierarchy Levels to display',
                                           default=1)
+    hide_parent_hierarchy_level = fields.Boolean(
+        'Do not display parent levels', default=False)
     account_ids = fields.Many2many(
         comodel_name='account.account',
         string='Filter accounts',
@@ -231,6 +233,7 @@ class TrialBalanceReportWizard(models.TransientModel):
             'fy_start_date': self.fy_start_date,
             'hierarchy_on': self.hierarchy_on,
             'limit_hierarchy_level': self.limit_hierarchy_level,
+            'hide_parent_hierarchy_level': self.hide_parent_hierarchy_level,
             'show_hierarchy_level': self.show_hierarchy_level,
             'show_partner_details': self.show_partner_details,
         }

--- a/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report_qweb/wizard/trial_balance_wizard_view.xml
@@ -26,6 +26,7 @@
                             <field name="hierarchy_on" widget="radio" attrs="{'invisible':[('show_partner_details','=',True)]}"/>
                             <field name="limit_hierarchy_level" attrs="{'invisible':['|', ('hierarchy_on','=','none'),('show_partner_details','=',True)]}"/>
                             <field name="show_hierarchy_level" attrs="{'invisible':[('limit_hierarchy_level','=', False)]}"/>
+                            <field name="hide_parent_hierarchy_level" attrs="{'invisible':[('limit_hierarchy_level','=', False)]}"/>
                             <field name="foreign_currency"/>
                         </group>
                     </group>


### PR DESCRIPTION
Adds this option to the Trial Balance:
![image](https://user-images.githubusercontent.com/7683926/56784556-53125380-67f1-11e9-8ea4-6a12e82d7190.png)

So instead of this:
![image](https://user-images.githubusercontent.com/7683926/56784570-67eee700-67f1-11e9-88c5-55227d37c83b.png)


You get this:
![image](https://user-images.githubusercontent.com/7683926/56784584-7806c680-67f1-11e9-81f5-e02d23b48012.png)

