### PR TITLE
[12.0][FIX] - remove many2many_tags on account_ids field in general ledger wizard view

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -34,7 +34,6 @@
                             </group>
                             <field name="account_ids"
                                    nolabel="1"
-                                   widget="many2many_tags"
                                    options="{'no_create': True}"/>
                         </page>
                         <page string="Filter partners">


### PR DESCRIPTION
many2many_tags don't support the selection of multiple records at the same time in "search more" wizard.
This make users sets accounts one by one. A huge waste of time

Before:
![1](https://user-images.githubusercontent.com/12665409/61122057-16c1cb80-a4a1-11e9-8fcb-c92969f9de06.png)

After:
![2](https://user-images.githubusercontent.com/12665409/61122209-7324eb00-a4a1-11e9-955a-f6862b8d916c.png)
