### PR TITLE
[12.0][FIX] partner_statement: Covers the case where name and ref are strictly the same in account_move_line

### DIFF
--- a/partner_statement/__manifest__.py
+++ b/partner_statement/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Partner Statement',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.0.1',
     'category': 'Accounting & Finance',
     'summary': 'OCA Financial Reports',
     'author': "Eficent, Odoo Community Association (OCA)",

--- a/partner_statement/views/activity_statement.xml
+++ b/partner_statement/views/activity_statement.xml
@@ -76,6 +76,9 @@
                                                     <t t-if="line['ref'] not in line['name']">
                                                         <span t-esc="line['ref']"/>
                                                     </t>
+                                                    <t t-else="">
+                                                        <span t-esc="line['name']"/>
+                                                    </t>
                                                 </t>
                                             </t>
                                             <t t-if="line['name'] == '/'">

--- a/partner_statement/views/outstanding_statement.xml
+++ b/partner_statement/views/outstanding_statement.xml
@@ -68,6 +68,9 @@
                                                     <t t-if="line['ref'] not in line['name']">
                                                         <span t-esc="line['ref']"/>
                                                     </t>
+                                                    <t t-else="">
+                                                        <span t-esc="line['name']"/>
+                                                    </t>
                                                 </t>
                                             </t>
                                             <t t-if="line['name'] == '/'">


### PR DESCRIPTION
Fixes the following use case : 
If the fields name and ref are the same in account_move_line, nothing appears in the description column of the reports