### PR TITLE
[12.0][IMP] account_tax_balance: multicompany fiscal unit

### DIFF
--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -34,10 +34,11 @@ class AccountTax(models.Model):
 
     def get_context_values(self):
         context = self.env.context
+        actual_company_id = context.get("company_id", self.env.user.company_id.id)
         return (
             context.get('from_date', fields.Date.context_today(self)),
             context.get('to_date', fields.Date.context_today(self)),
-            context.get('company_id', self.env.user.company_id.id),
+            context.get('company_ids', [actual_company_id]),
             context.get('target_move', 'posted'),
         )
 
@@ -49,17 +50,19 @@ class AccountTax(models.Model):
         Caveat: this ignores record rules and ACL but it is good
         enough for filtering taxes with activity during the period.
         """
+        from_date, to_date, company_ids, _ = self.get_context_values()
+        company_ids = tuple(company_ids)
         req = """
             SELECT id
             FROM account_tax at
             WHERE
-            company_id = %s AND
+            company_id in %s AND
             EXISTS (
               SELECT 1 FROM account_move_Line aml
               WHERE
                 date >= %s AND
                 date <= %s AND
-                company_id = %s AND (
+                company_id in %s AND (
                   tax_line_id = at.id OR
                   EXISTS (
                     SELECT 1 FROM account_move_line_account_tax_rel
@@ -69,9 +72,8 @@ class AccountTax(models.Model):
                 )
             )
         """
-        from_date, to_date, company_id, target_move = self.get_context_values()
         self.env.cr.execute(
-            req, (company_id, from_date, to_date, company_id))
+            req, (company_ids, from_date, to_date, company_ids))
         return [r[0] for r in self.env.cr.fetchall()]
 
     @api.multi
@@ -121,11 +123,11 @@ class AccountTax(models.Model):
             state = []
         return state
 
-    def get_move_line_partial_domain(self, from_date, to_date, company_id):
+    def get_move_line_partial_domain(self, from_date, to_date, company_ids):
         return [
             ('date', '<=', to_date),
             ('date', '>=', from_date),
-            ('company_id', '=', company_id),
+            ('company_id', 'in', company_ids),
         ]
 
     def compute_balance(self, tax_or_base='tax', move_type=None):
@@ -161,11 +163,12 @@ class AccountTax(models.Model):
         return domain
 
     def get_move_lines_domain(self, tax_or_base='tax', move_type=None):
-        from_date, to_date, company_id, target_move = self.get_context_values()
+        from_date, to_date, company_ids, target_move = \
+            self.get_context_values()
         state_list = self.get_target_state_list(target_move)
         type_list = self.get_target_type_list(move_type)
         domain = self.get_move_line_partial_domain(
-            from_date, to_date, company_id)
+            from_date, to_date, company_ids)
         balance_domain = []
         if tax_or_base == 'tax':
             balance_domain = self.get_balance_domain(state_list, type_list)

--- a/account_tax_balance/wizard/open_tax_balances.py
+++ b/account_tax_balance/wizard/open_tax_balances.py
@@ -54,6 +54,6 @@ class WizardOpenTaxBalances(models.TransientModel):
             'from_date': self.from_date,
             'to_date': self.to_date,
             'target_move': self.target_move,
-            'company_id': self.company_id.id,
+            'company_ids': [self.company_id.id],
         }
         return vals


### PR DESCRIPTION
In some countries it is allowed to declare to the tax authorities one single tax report that contains data of multiple companies. For example, in The Netherlands a group of companies (one parent company and N children companies) can form a fiscal unit; in this case, the parent company declares one single tax statement for all companies of the fiscal unit (see https://github.com/OCA/l10n-netherlands/issues/237).

In the current `account_tax_balance` module, you can only see the data regarding move lines of the company you're logged in. This is fine when using the module itself but it could be a bit uncomfortable when extending the module to generate tax statements for multiple companies.

This PR make the extension of this module easier in case of generating reports for multiple companies.
Without this PR, it is still possible to do it, but that requires overriding the methods `get_move_line_partial_domain()` and `_account_tax_ids_with_moves()`.

Not sure if this patch should set the version of the module to `12.0.2.0.0`, since the type of one returned value of `get_context_values()` method is changed. In any case, I think it's a good idea to include this patch when migrating `account_tax_balance` module to V13.