### PR TITLE
Fix display of captions in pdf

### DIFF
--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -27,8 +27,8 @@
             <t t-foreach="o.account_ids" t-as="account">
                 <div class="page_break">
                     <!-- Display account header -->
-                    <div class="act_as_table list_table" style="margin-top: 10px;"/>
-                    <div class="act_as_caption account_title"
+                    <div class="act_as_table list_table" style="margin-top: 10px;" />
+                    <div class="account_title"
                          style="width: 100%;">
                         <span t-field="account.code"/>
                         -
@@ -39,7 +39,7 @@
                     <t t-foreach="account.partner_ids" t-as="partner">
                         <div class="page_break">
                             <!-- Display partner header -->
-                            <div class="act_as_caption account_title">
+                            <div class="account_title">
                                 <span t-field="partner.name"/>
                             </div>
 
@@ -93,7 +93,7 @@
             <div class="act_as_thead">
                 <div class="act_as_row labels">
                     <!--## date-->
-                    <div class="act_as_cell first_column" style="width: 4.51%;">
+                    <div class="act_as_cell first_column" style="width: 5.51%;">
                         Date</div>
                     <!--## move-->
                     <div class="act_as_cell" style="width: 9.76%;">Entry</div>
@@ -105,7 +105,7 @@
                     <div class="act_as_cell" style="width: 15.07%;">Partner
                     </div>
                     <!--## ref - label-->
-                    <div class="act_as_cell" style="width: 25.5%;">Ref -
+                    <div class="act_as_cell" style="width: 24.5%;">Ref -
                         Label</div>
                     <!--## date_due-->
                     <div class="act_as_cell" style="width: 6.47%;">Due


### PR DESCRIPTION
display: table-caption without a surrounding display: table makes the container to small and introduces unnecessary  line breaks.
Adding a element with display: table broke the pdf version even though html was fine.

The date did not fit properly so i increased the width.
**Date**
before:
![date before](https://user-images.githubusercontent.com/358342/65223450-849dfb00-dac1-11e9-8a06-987b93aa2788.png)
after:
![date after](https://user-images.githubusercontent.com/358342/65223448-849dfb00-dac1-11e9-9ba8-92b9abf7ad87.png)

**Captions**
before
![captions before](https://user-images.githubusercontent.com/358342/65223451-849dfb00-dac1-11e9-84e6-71aee0af5a5c.png)
after
![captions after](https://user-images.githubusercontent.com/358342/65223449-849dfb00-dac1-11e9-9f1f-41cb3cc55522.png)

