### PR TITLE
account_financial_report: fix Trial Balance account.group ordering issue

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -75,8 +75,8 @@ class TrialBalanceReportAccount(models.TransientModel):
     )
     hide_line = fields.Boolean(compute='_compute_hide_line')
     # Data fields, used to keep link with real object.
-    # Sequence is a Char later built with 'parent_path' for groups
-    # and parent_path + account code for accounts
+    # Sequence is a Char later built with 'code_prefix' for groups
+    # and code_prefix + account code for accounts
     sequence = fields.Char(index=True, default='1')
     level = fields.Integer(index=True, default=1)
 
@@ -413,7 +413,7 @@ SELECT
     accgroup.parent_id,
     coalesce(accgroup.code_prefix, accgroup.name),
     accgroup.name,
-    accgroup.parent_path,
+    accgroup.code_prefix,
     accgroup.level
 FROM
     account_group accgroup"""


### PR DESCRIPTION
Fixes #609 and probably related issues mentioned there.

This simply changes how `sequence` field for Trial Balance lines is generated.
Before this PR, `parent_path` is used, which is not always correct for this use, as it is a `Char` field made out of integer IDs. That makes this a valid ordering statement: `'11' < '2'`.
After this PR, `code_prefix` is used, which is also a `Char` field, but represents actual Account Group codes that should be sequential by idea.
Also, `code_prefix` is used as the default for `_order` field in `account.group` model:
https://github.com/odoo/odoo/blob/12.0/addons/account/models/account.py#L367

More details and a way to reproduce the problem can be found on the referenced issue thread: #609