### PR TITLE
[10.0][IMP] account_financial_repot_qweb: General Ledger optimization

### DIFF
--- a/account_financial_report_qweb/report/trial_balance.py
+++ b/account_financial_report_qweb/report/trial_balance.py
@@ -248,7 +248,8 @@ class TrialBalanceReportCompute(models.TransientModel):
             self._prepare_report_general_ledger(account_ids)
         )
         self.general_ledger_id.compute_data_for_report(
-            with_line_details=False, with_partners=self.show_partner_details
+            with_line_details=False, with_partners=self.show_partner_details,
+            trial_balance=True,
         )
 
         # Compute report data


### PR DESCRIPTION
Before this change, General Ledger report was fetching a lot of data that was not used in rendered report. Filtering partners and account used only in the selected date range make this report usable in large databases.

General Ledger report still showing correctly Journal Items related transactions in the selected date range.

In case we run Trial Balance these optimizations is not applied because all history is required to display correctly initial period balances headers for account/partners.

cc ~ @Eficent 