### PR TITLE
[10.0][IMP] account_financial_repot_qweb: Open Items optimization

### DIFF
--- a/account_financial_report_qweb/static/src/js/account_financial_report_qweb_backend.js
+++ b/account_financial_report_qweb/static/src/js/account_financial_report_qweb_backend.js
@@ -5,7 +5,7 @@ odoo.define('account_financial_report_qweb.account_financial_report_backend', fu
     var Widget = require('web.Widget');
     var ControlPanelMixin = require('web.ControlPanelMixin');
     var ReportWidget = require(
-    'account_financial_report_qweb.account_financial_report_widget');
+        'account_financial_report_qweb.account_financial_report_widget');
     var Model = require('web.Model');
 
 

--- a/account_financial_report_qweb/tests/test_general_ledger.py
+++ b/account_financial_report_qweb/tests/test_general_ledger.py
@@ -534,7 +534,7 @@ class TestGeneralLedgerReport(common.TransactionCase):
                          time.strftime('%Y') + '-01-01')
 
     def test_validate_date_range(self):
-        type = self.env['date.range.type'].create({
+        date_range_type = self.env['date.range.type'].create({
             'name': 'Fiscal year',
             'company_id': False,
             'allow_overlap': False
@@ -544,7 +544,7 @@ class TestGeneralLedgerReport(common.TransactionCase):
             'name': 'FS2015',
             'date_start': '2018-01-01',
             'date_end': '2018-12-31',
-            'type_id': type.id,
+            'type_id': date_range_type.id,
         })
 
         wizard = self.env["general.ledger.report.wizard"].create({

--- a/account_financial_report_qweb/tests/test_open_items.py
+++ b/account_financial_report_qweb/tests/test_open_items.py
@@ -58,3 +58,7 @@ class TestOpenItems(a_t_f_c.AbstractTestForeignCurrency):
 
         wizard = self.env["open.items.report.wizard"].with_context(context)
         self.assertEqual(wizard._default_partners(), expected_list)
+
+    def test_filter_is_today(self):
+        wizard = self.env["open.items.report.wizard"].create({})
+        self.assertTrue(wizard._prepare_report_open_items()['is_today'])

--- a/account_financial_report_qweb/wizard/open_items_wizard.py
+++ b/account_financial_report_qweb/wizard/open_items_wizard.py
@@ -153,6 +153,7 @@ class OpenItemsReportWizard(models.TransientModel):
             'company_id': self.company_id.id,
             'filter_account_ids': [(6, 0, self.account_ids.ids)],
             'filter_partner_ids': [(6, 0, self.partner_ids.ids)],
+            'is_today': self.date_at == fields.Date.context_today(self),
         }
 
     def _export(self, report_type):


### PR DESCRIPTION
CC ~ @Eficent @jbeficent 

This PR aims to speed up Open items renderization when is launched at current date.

When Open Items is created at current date it is not required to look into all account moves lines, we just focus on not reconciled items, limiting number of account move lines to be computed, for the same result.