### PR TITLE
[FIX] account_chart_report: Add ondelete=cascade to wizard

### DIFF
--- a/account_chart_report/wizard/account_report_chart_of_account.py
+++ b/account_chart_report/wizard/account_report_chart_of_account.py
@@ -32,6 +32,7 @@ class ChartOfAccountsReport(models.TransientModel):
         'Chart of Accounts',
         help='Select Charts of Accounts',
         required=True,
+        ondelete="cascade",
         domain=([('parent_id', '=', False)]))
 
     @api.multi


### PR DESCRIPTION
Wizards should never have `required=True` without `ondelete="cascade"`, or they forbid deletion of the referenced model.

@Tecnativa TT18838