### PR TITLE
[FIX] cash_flow: forecast accumulate next columns

### DIFF
--- a/mis_builder_cash_flow/__manifest__.py
+++ b/mis_builder_cash_flow/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     'name': 'MIS Builder Cash Flow',
-    'version': '12.0.1.1.0',
+    'version': '12.0.1.2.0',
     'license': 'LGPL-3',
     'author': 'ADHOC SA, '
               'Odoo Community Association (OCA)',

--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -66,6 +66,8 @@ class MisCashFlow(models.Model):
 
     @api.model_cr
     def init(self):
+        account_type_receivable = self.env.ref(
+            'account.data_account_type_receivable')
         query = """
             SELECT
                 -- we use negative id to avoid duplicates and we don't use
@@ -110,12 +112,11 @@ class MisCashFlow(models.Model):
                 Null as reconciled,
                 Null as full_reconcile_id,
                 fl.company_id as company_id,
-                -- we dont need this field on forecast lines
-                Null as user_type_id,
+                %i as user_type_id,
                 fl.name as name,
                 fl.date as date
             FROM mis_cash_flow_forecast_line as fl
-        """
+        """ % account_type_receivable.id
         tools.drop_view_if_exists(self.env.cr, self._table)
         self._cr.execute(
             'CREATE OR REPLACE VIEW %s AS %s',


### PR DESCRIPTION
For mis_builder to compute correctly bale we need accounts with user type include_initial_balance. We use receivable type which is the more accurate for this purpose
