### PR TITLE
[FIX] account_tax_balance: improve test resilience

### DIFF
--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -108,8 +108,7 @@ class TestAccountTaxBalance(HttpCase):
 
         # exercise search has_moves = True
         taxes = self.env['account.tax'].search([('has_moves', '=', True)])
-        self.assertEqual(len(taxes), 1)
-        self.assertEqual(taxes[0].name, "Tax 10.0%")
+        self.assertLessEqual(tax, taxes)
 
         # testing buttons
         tax_action = tax.view_tax_lines()


### PR DESCRIPTION
This test failed in an integration environment where the search returned more items than necessary.

I modified it to just check that the tax that's created some lines above appears in the search results.

@Tecnativa TT21419