### PR TITLE
[12.0][account_financial_report] Improve General Ledger wizard

### DIFF
--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -19,6 +19,9 @@
 
   * Pedro M. Baeza
   * Sergio Teruel
+* `Druidoo <https://www.druidoo.io>`__:
+
+  * Iván Todorovich
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -4,6 +4,7 @@
 # Copyright 2016 Camptocamp SA
 # Copyright 2017 Akretion - Alexis de Lattre
 # Copyright 2017 Eficent Business and IT Consulting Services, S.L.
+# Copyright 2020 Druidoo
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
@@ -57,8 +58,10 @@ class GeneralLedgerReportWizard(models.TransientModel):
     show_analytic_tags = fields.Boolean(
         string='Show analytic tags',
     )
-    receivable_accounts_only = fields.Boolean()
-    payable_accounts_only = fields.Boolean()
+    account_type_ids = fields.Many2many(
+        'account.account.type',
+        string='Account Types',
+    )
     partner_ids = fields.Many2many(
         comodel_name='res.partner',
         string='Filter partners',
@@ -133,8 +136,8 @@ class GeneralLedgerReportWizard(models.TransientModel):
                 lambda p: p.company_id == self.company_id or
                 not p.company_id)
         if self.company_id and self.account_ids:
-            if self.receivable_accounts_only or self.payable_accounts_only:
-                self.onchange_type_accounts_only()
+            if self.account_type_ids:
+                self._onchange_account_type_ids()
             else:
                 self.account_ids = self.account_ids.filtered(
                     lambda a: a.company_id == self.company_id)
@@ -180,18 +183,11 @@ class GeneralLedgerReportWizard(models.TransientModel):
                     _('The Company in the General Ledger Report Wizard and in '
                       'Date Range must be the same.'))
 
-    @api.onchange('receivable_accounts_only', 'payable_accounts_only')
-    def onchange_type_accounts_only(self):
-        """Handle receivable/payable accounts only change."""
-        if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = [('company_id', '=', self.company_id.id)]
-            if self.receivable_accounts_only and self.payable_accounts_only:
-                domain += [('internal_type', 'in', ('receivable', 'payable'))]
-            elif self.receivable_accounts_only:
-                domain += [('internal_type', '=', 'receivable')]
-            elif self.payable_accounts_only:
-                domain += [('internal_type', '=', 'payable')]
-            self.account_ids = self.env['account.account'].search(domain)
+    @api.onchange('account_type_ids')
+    def _onchange_account_type_ids(self):
+        if self.account_type_ids:
+            self.account_ids = self.env['account.account'].search([
+                ('user_type_id', 'in', self.account_type_ids.ids)])
         else:
             self.account_ids = None
 
@@ -199,9 +195,12 @@ class GeneralLedgerReportWizard(models.TransientModel):
     def onchange_partner_ids(self):
         """Handle partners change."""
         if self.partner_ids:
-            self.receivable_accounts_only = self.payable_accounts_only = True
+            self.account_type_ids = self.env['account.account.type'].search([
+                ('type', 'in', ['receivable', 'payable'])])
         else:
-            self.receivable_accounts_only = self.payable_accounts_only = False
+            self.account_type_ids = None
+        # Somehow this is required to force onchange on _default_partners()
+        self._onchange_account_type_ids()
 
     @api.multi
     def button_export_html(self):

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -187,6 +187,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
     def _onchange_account_type_ids(self):
         if self.account_type_ids:
             self.account_ids = self.env['account.account'].search([
+                ('company_id', '=', self.company_id.id),
                 ('user_type_id', 'in', self.account_type_ids.ids)])
         else:
             self.account_ids = None

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -20,10 +20,26 @@
                         </group>
                         <group name="other_filters">
                             <field name="target_move" widget="radio"/>
-                            <field name="centralize"/>
-                            <field name="hide_account_at_0"/>
-                            <field name="foreign_currency"/>
-                            <field name="show_analytic_tags"/>
+                            <label string="Other options" for="centralize"/>
+                            <div>
+                                <field name="centralize" nolabel="1" class="oe_inline"/>
+                                <label for="centralize" class="oe_inline"/>
+                            </div>
+                            <label string=" " for="hide_account_at_0"/>
+                            <div>
+                                <field name="hide_account_at_0" nolabel="1" class="oe_inline"/>
+                                <label for="hide_account_at_0" class="oe_inline"/>
+                            </div>
+                            <label string=" " for="foreign_currency"/>
+                            <div>
+                                <field name="foreign_currency" nolabel="1" class="oe_inline"/>
+                                <label for="foreign_currency" class="oe_inline"/>
+                            </div>
+                            <label string=" " for="show_analytic_tags"/>
+                            <div>
+                                <field name="show_analytic_tags" nolabel="1" class="oe_inline"/>
+                                <label for="show_analytic_tags" class="oe_inline"/>
+                            </div>
                         </group>
                     </group>
                     <notebook>

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -28,14 +28,14 @@
                     </group>
                     <notebook>
                         <page string="Filter accounts">
-                            <group col="4">
-                                <field name="receivable_accounts_only"/>
-                                <field name="payable_accounts_only"/>
+                            <group>
+                                <group>
+                                    <field name="account_type_ids" widget="many2many_checkboxes" nolabel="1"/>
+                                </group>
+                                <group>
+                                    <field name="account_ids" widget="many2many_tags" options="{'no_create': True}" nolabel="1"/>
+                                </group>
                             </group>
-                            <field name="account_ids"
-                                   nolabel="1"
-                                   widget="many2many_tags"
-                                   options="{'no_create': True}"/>
                         </page>
                         <page string="Filter partners">
                             <field name="partner_ids" nolabel="1"
@@ -91,10 +91,6 @@
                 res_model="general.ledger.report.wizard"
                 src_model="res.partner"
                 view_mode="form"
-                context="{
-                    'default_receivable_accounts_only':1,
-                    'default_payable_accounts_only':1,
-                    }"
                 groups="account.group_account_manager"
                 key2="client_action_multi"
                 target="new" />


### PR DESCRIPTION
This PR improves usability a bit in the General Ledger report wizard.

Instead of using a hardcoded `receivable/payable_accounts_only`, we're using `account.account.types` to offer a wider selection.

Also I took the oportunity to improve a bit the "settings" part of the view.

**Before:**
![image](https://user-images.githubusercontent.com/1914185/73550993-dd08e000-4445-11ea-811f-d482185ca146.png)

**After:**
![image](https://user-images.githubusercontent.com/1914185/73550891-b77bd680-4445-11ea-87d2-eec5e0d57fd1.png)
