### PR TITLE
[12.0] account_financial_report: Increase columns width in general ledger

### DIFF
--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -130,7 +130,7 @@
                     <div class="act_as_cell" style="width: 12.01%;">Partner
                     </div>
                     <!--## ref - label-->
-                    <div class="act_as_cell" style="width: 22.9%;">Ref -
+                    <div class="act_as_cell" style="width: 16.9%;">Ref -
                         Label</div>
                     <t t-if="show_cost_center">
                         <!--## cost_center-->
@@ -144,11 +144,11 @@
                     <!--## matching_number-->
                     <div class="act_as_cell" style="width: 2.41%;">Rec.</div>
                     <!--## debit-->
-                    <div class="act_as_cell amount" style="width: 6.02%;">Debit</div>
+                    <div class="act_as_cell amount" style="width: 8.02%;">Debit</div>
                     <!--## credit-->
-                    <div class="act_as_cell amount" style="width: 6.02%;">Credit</div>
+                    <div class="act_as_cell amount" style="width: 8.02%;">Credit</div>
                     <!--## balance cumulated-->
-                    <div class="act_as_cell amount" style="width: 6.02%;">Cumul. Bal.</div>
+                    <div class="act_as_cell amount" style="width: 8.02%;">Cumul. Bal.</div>
                     <t t-if="foreign_currency">
                         <!--## currency_name-->
                         <div class="act_as_cell" style="width: 2.08%;">Cur.</div>
@@ -484,11 +484,11 @@
                          style="width: 41.32%;"><span
                             t-field="account_or_partner_object.code"/> - <span t-field="account_or_partner_object.name"/></div>
                     <div class="act_as_cell right"
-                         style="width: 22.9%;">Ending balance</div>
+                         style="width: 16.9%;">Ending balance</div>
                 </t>
                 <t t-if='type == "partner_type"'>
                     <div class="act_as_cell first_column" style="width: 41.32%;"/>
-                    <div class="act_as_cell right" style="width: 22.9%;">Partner ending balance</div>
+                    <div class="act_as_cell right" style="width: 16.9%;">Partner ending balance</div>
                 </t>
                 <t t-if="show_cost_center">
                     <!--## cost_center-->
@@ -501,15 +501,15 @@
                 <!--## matching_number-->
                 <div class="act_as_cell" style="width: 2.41%;"/>
                 <!--## debit-->
-                <div class="act_as_cell amount" style="width: 6.02%;">
+                <div class="act_as_cell amount" style="width: 8.02%;">
                     <span t-field="account_or_partner_object.final_debit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/>
                 </div>
                 <!--## credit-->
-                <div class="act_as_cell amount" style="width: 6.02%;">
+                <div class="act_as_cell amount" style="width: 8.02%;">
                     <span t-field="account_or_partner_object.final_credit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/>
                 </div>
                 <!--## balance cumulated-->
-                <div class="act_as_cell amount" style="width: 6.02%;">
+                <div class="act_as_cell amount" style="width: 8.02%;">
                     <span t-field="account_or_partner_object.final_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/>
                 </div>
                 <!--## currency_name + amount_currency-->


### PR DESCRIPTION
Before this commit, amounts such as "10'000.00 CHF" were exceeding their
columns width. Label column could be reduced as it's printed correctly
over two different lines.