### PR TITLE
[12.0][FIX] Add missing date formatting to the VAT report

### DIFF
--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -66,8 +66,8 @@
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t t-set="domain"
                                t-value="[('tax_ids', 'in', [tax.tax_id.id for tax in tag.tax_ids]),
-                                         ('date', '&gt;=', o.date_from),
-                                         ('date', '&lt;=', o.date_to)]"/>
+                                         ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                         ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d'))]"/>
                             <span>
                                 <a t-att-data-domain="domain"
                                     t-att-data-res-model="'account.move.line'"
@@ -80,8 +80,8 @@
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t t-set="domain"
                                t-value="[('tax_line_id', 'in', [tax.tax_id.id for tax in tag.tax_ids]),
-                                         ('date', '&gt;=', o.date_from),
-                                         ('date', '&lt;=', o.date_to),
+                                         ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                         ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d')),
                                          ('tax_exigible', '=', True)]"/>
                             <span>
                                 <a t-att-data-domain="domain"
@@ -109,8 +109,8 @@
                                 <div class="act_as_cell amount" style="width: 15%;">
                                     <t t-set="domain"
                                        t-value="[('tax_ids', 'in', tax.tax_id.ids),
-                                                 ('date', '&gt;=', o.date_from),
-                                                 ('date', '&lt;=', o.date_to),
+                                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d')),
                                                  ('tax_exigible', '=', True)]"/>
                                     <span>
                                         <a t-att-data-domain="domain"
@@ -124,8 +124,8 @@
                                 <div class="act_as_cell amount" style="width: 15%;">
                                     <t t-set="domain"
                                        t-value="[('tax_line_id', '=', tax.tax_id.id),
-                                                 ('date', '&gt;=', o.date_from),
-                                                 ('date', '&lt;=', o.date_to),
+                                                 ('date', '&gt;=', o.date_from.strftime('%Y-%m-%d')),
+                                                 ('date', '&lt;=', o.date_to.strftime('%Y-%m-%d')),
                                                  ('tax_exigible', '=', True)]"/>
                                     <span>
                                         <a t-att-data-domain="domain"


### PR DESCRIPTION
Add missing strftime in the vat report domain filters.

Before this PR, when clicking on amounts in the tax report, a javascript traceback appears.
