### PR TITLE
[FIX] account_financial_report: Fix error when generating reports

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -327,7 +327,11 @@ class GeneralLedgerReport(models.AbstractModel):
         analytic_tag_ids,
         cost_center_ids,
     ):
-        domain = [("date", ">=", date_from), ("date", "<=", date_to)]
+        domain = [
+            ("display_type", "=", False),
+            ("date", ">=", date_from),
+            ("date", "<=", date_to),
+        ]
         if account_ids:
             domain += [("account_id", "in", account_ids)]
         if company_id:

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -79,8 +79,7 @@ class JournalLedgerReport(models.AbstractModel):
         return moves.ids, Moves, move_data
 
     def _get_move_lines_domain(self, move_ids, wizard, journal_ids):
-
-        return [("move_id", "in", move_ids)]
+        return [("display_type", "=", False), ("move_id", "in", move_ids)]
 
     def _get_move_lines_order(self, move_ids, wizard, journal_ids):
         return ""

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -123,7 +123,11 @@ class TrialBalanceReport(models.AbstractModel):
         only_posted_moves,
         show_partner_details,
     ):
-        domain = ["&", ("date", ">=", date_from), ("date", "<=", date_to)]
+        domain = [
+            ("display_type", "=", False),
+            ("date", ">=", date_from),
+            ("date", "<=", date_to),
+        ]
         if company_id:
             domain += [("company_id", "=", company_id)]
         if account_ids:


### PR DESCRIPTION
Some reports crash if account move line implicated are Sections lines or Notes lines in an invoice

Issue: https://github.com/OCA/account-financial-reporting/issues/669

Cc @Tecnativa TT19684