### PR TITLE
[13.0][FIX] account_financial_report: open_items

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -2,6 +2,7 @@
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+import operator
 from datetime import date, datetime
 
 from odoo import api, models


### PR DESCRIPTION
* Missing import causes failure when running Open Items with Date At in the past

**Previous Behavior:**

- Go to **Accounting > Reports > OCA accounting reports > Open Items**
- Change **Date At** to a date in the past
- An error is shown:

```
500: Internal Server Error
Traceback

Traceback (most recent call last):
  File "/opt/odoo/core/odoo/addons/base/models/ir_http.py", line 229, in _dispatch
    result = request.dispatch()
  File "/opt/odoo/core/odoo/http.py", line 809, in dispatch
    r = self._call_function(**self.params)
  File "/opt/odoo/core/odoo/http.py", line 350, in _call_function
    return checked_call(self.db, *args, **kwargs)
  File "/opt/odoo/core/odoo/service/model.py", line 94, in wrapper
    return f(dbname, *args, **kwargs)
  File "/opt/odoo/core/odoo/http.py", line 339, in checked_call
    result = self.endpoint(*a, **kw)
  File "/opt/odoo/core/odoo/http.py", line 915, in __call__
    return self.method(*args, **kw)
  File "/opt/odoo/core/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/vendor/_lib/report_xlsx/controllers/main.py", line 49, in report_routes
    reportname, docids, converter, **data
  File "/opt/odoo/core/odoo/http.py", line 515, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/core/addons/web/controllers/main.py", line 1958, in report_routes
    html = report.with_context(context).render_qweb_html(docids, data=data)[0]
  File "/opt/odoo/core/odoo/addons/base/models/ir_actions_report.py", line 766, in render_qweb_html
    data = self._get_rendering_context(docids, data)
  File "/opt/odoo/core/odoo/addons/base/models/ir_actions_report.py", line 783, in _get_rendering_context
    data.update(report_model._get_report_values(docids, data=data))
  File "/opt/odoo/vendor/_lib_static/account_financial_report/report/open_items.py", line 344, in _get_report_values
    account_ids, partner_ids, date_at_object, target_move, company_id, date_from
  File "/opt/odoo/vendor/_lib_static/account_financial_report/report/open_items.py", line 218, in _get_data
    operator.itemgetter("debit_move_id"), accounts_partial_reconcile
NameError: name 'operator' is not defined
```