### PR TITLE
[11.0] [FIX] Not hide line of accounts in trial balance

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -59,7 +59,7 @@
             <!-- Display partner lines -->
             <t t-if="show_partner_details">
                 <t t-set="padding" t-value="0"/>
-                <t t-foreach="o.account_ids" t-as="account">
+                <t t-foreach="o.account_ids.filtered(lambda a: not a.hide_line)" t-as="account">
                     <div class="page_break">
                         <t t-set="style" t-value="'font-size:8px;'"/>
                         <t t-set="padding" t-value="account.level * 4"/>


### PR DESCRIPTION
In Trial Balance the option Hide Account At 0 not working if you check the option Show Partner Details in Export PDF.

- without fix:
![Selección_047](https://user-images.githubusercontent.com/6359121/81153916-ab8f3b80-8f83-11ea-8538-abf15d215bac.png)

- with fix:
![Selección_048](https://user-images.githubusercontent.com/6359121/81153942-b053ef80-8f83-11ea-91b9-aa30cfd8c54b.png)

Regards