### PR TITLE
[13.0] [IMP] account_financial_report - Add invoice date to aged partner balance & open items

### DIFF
--- a/account_financial_report/models/account_move_line.py
+++ b/account_financial_report/models/account_move_line.py
@@ -1,10 +1,16 @@
 # Copyright 2019 ACSONE SA/NV (<http://acsone.eu>)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
-from odoo import models
+from odoo import models, fields
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
+
+    invoice_date = fields.Date(related='move_id.invoice_date',
+                               string='Invoice/Bill Date',
+                               readonly=True,
+                               store=True,
+                               index=True)
 
     def init(self):
         """

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -202,6 +202,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             "id",
             "name",
             "date",
+            "invoice_date",
             "move_id",
             "journal_id",
             "account_id",
@@ -270,6 +271,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 move_line_data.update(
                     {
                         "date": move_line["date"],
+                        "invoice_date": move_line["invoice_date"],
                         "entry": move_line["move_id"][1],
                         "jnl_id": move_line["journal_id"][0],
                         "acc_id": acc_id,

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -116,6 +116,7 @@ class OpenItemsReport(models.AbstractModel):
         aml_fields = [
             "id",
             "date",
+            "invoice_date",
             "move_id",
             "journal_id",
             "account_id",
@@ -272,6 +273,7 @@ class OpenItemsReport(models.AbstractModel):
             move_line.update(
                 {
                     "date": move_line["date"].strftime("%d/%m/%Y"),
+                    "invoice_date": move_line["invoice_date"],
                     "date_maturity": move_line["date_maturity"]
                     and move_line["date_maturity"].strftime("%d/%m/%Y"),
                     "original": original,

--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -192,6 +192,9 @@
                     <!--## date-->
                     <div class="act_as_cell first_column" style="width: 6.00%;">
                         Date</div>
+                    <!--## invoice date-->
+                    <div class="act_as_cell first_column" style="width: 6.00%;">
+                        Invoice Date</div>
                     <!--## move-->
                     <div class="act_as_cell" style="width: 7.00%;">Entry</div>
                     <!--## journal-->
@@ -243,6 +246,10 @@
                         <t t-esc="line['date']" t-options="{'widget': 'date'}" />
                         <!--                            </a>-->
                         <!--                        </span>-->
+                    </div>
+                    <!--## invoice date-->
+                    <div class="act_as_cell left">
+                        <t t-esc="line['invoice_date']" t-options="{'widget': 'date'}" />
                     </div>
                     <!--## move-->
                     <div class="act_as_cell left">

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -109,6 +109,9 @@
                     <!--## date-->
                     <div class="act_as_cell first_column" style="width: 5.51%;">
                         Date</div>
+                    <!--## invoice date-->
+                    <div class="act_as_cell first_column" style="width: 5.51%;">
+                        Invoice Date</div>
                     <!--## move-->
                     <div class="act_as_cell" style="width: 9.76%;">Entry</div>
                     <!--## journal-->
@@ -152,6 +155,10 @@
                     <!--## date-->
                     <div class="act_as_cell left">
                         <span t-raw="line['date']" />
+                    </div>
+                    <!--## invoice date-->
+                    <div class="act_as_cell left">
+                        <span t-raw="line['invoice_date']" />
                     </div>
                     <!--## move-->
                     <div class="act_as_cell left">


### PR DESCRIPTION
Solves #672

Invoice date can be different as date on account.move. Companies invoicing in month B for month A use both fields. It's crucial to show the (correct) invoice date on the partner reports.