### PR TITLE
[FIX] account_export_csv: incorrect queue treatment

### DIFF
--- a/account_export_csv/wizard/account_export_csv.py
+++ b/account_export_csv/wizard/account_export_csv.py
@@ -40,7 +40,8 @@ class AccountingWriter(object):
         self.stream.write(data)
         # seek() or truncate() have side effect then we reinitialize StringIO
         # https://stackoverflow.com/questions/4330812/how-do-i-clear-a-stringio-object
-        self.queue = StringIO()
+        self.queue.seek(0)
+        self.queue.truncate(0)
 
     def writerows(self, rows):
         for row in rows:


### PR DESCRIPTION
As stated here: https://github.com/OCA/account-financial-reporting/issues/646#issuecomment-616096846

this pr solve this: https://github.com/OCA/account-financial-reporting/issues/646