### PR TITLE
12.0 FIX account_export_csv: test the number of lines of the file

### DIFF
--- a/account_export_csv/tests/test_account_export_csv.py
+++ b/account_export_csv/tests/test_account_export_csv.py
@@ -3,6 +3,7 @@
 
 from datetime import date
 from dateutil import relativedelta
+import base64
 
 from odoo.tests.common import TransactionCase
 from odoo import fields
@@ -38,3 +39,14 @@ class TestAccountExportCsv(TransactionCase):
             'date_end': self.report_date_end
         })
         report_wizard.action_manual_export_journal_entries()
+
+    def test_file_content(self):
+        report_wizard = self.report_wizard.create({
+            "date_start": "2000-01-01",
+            "date_end": "2200-01-01",
+        })
+        report_wizard.action_manual_export_journal_entries()
+        res = base64.decodestring(report_wizard.data)
+        line_number = self.env["account.move.line"].search_count([])
+        # check the number of lines in file: include header + EOF line
+        self.assertEqual(len(res.decode().split("\r\n")), line_number + 2)

--- a/account_export_csv/wizard/account_export_csv.py
+++ b/account_export_csv/wizard/account_export_csv.py
@@ -38,9 +38,11 @@ class AccountingWriter(object):
         data = self.encoder.encode(data)
         # write to the target stream
         self.stream.write(data)
-        # seek() or truncate() have side effect then we reinitialize StringIO
+        # seek() or truncate() have side effect if not used combinated
+        self.queue.truncate(0)
+        self.queue.seek(0)
         # https://stackoverflow.com/questions/4330812/how-do-i-clear-a-stringio-object
-        self.queue = StringIO()
+        # It fails when you use `self.queue = StringIO()` only add one line
 
     def writerows(self, rows):
         for row in rows:


### PR DESCRIPTION
Without this fix, report has only 1 line