### PR TITLE
[13.0][FIX] account_financial_report: missing date in invoice

### DIFF
--- a/account_financial_report/tests/test_vat_report.py
+++ b/account_financial_report/tests/test_vat_report.py
@@ -166,6 +166,7 @@ class TestVATReport(common.TransactionCase):
             self.env["account.move"].with_context(default_type="out_invoice")
         )
         move_form.partner_id = self.env.ref("base.res_partner_2")
+        move_form.invoice_date = time.strftime("%Y-%m-04")
         with move_form.invoice_line_ids.new() as line_form:
             line_form.product_id = self.env.ref("product.product_product_4")
             line_form.quantity = 1.0


### PR DESCRIPTION
The second invoice created has no explicit date so taking the current date could lead to failing tests because the invoice is out of search as the the setup sets date_from as time.strftime("%Y-%m-01") and date_to as time.strftime("%Y-%m-28"). So i choose the easy way by setting an explicit date for the invoice.