### PR TITLE
[12.0][FIX] account_financial_report; Add format to date fields

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -2,8 +2,10 @@
 # Author: Julien Coux
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import models, fields
+from odoo import models
 import datetime
+
+from odoo.tools import format_date
 
 
 class AbstractReportXslx(models.AbstractModel):
@@ -190,7 +192,7 @@ class AbstractReportXslx(models.AbstractModel):
         for col_pos, column in self.columns.items():
             value = getattr(line_object, column['field'])
             if isinstance(value, datetime.date):
-                value = fields.Date.to_string(value)
+                value = format_date(self.env, value)
             cell_type = column.get('type', 'string')
             if cell_type == 'many2one':
                 self.sheet.write_string(


### PR DESCRIPTION
**Steps to reproduce issue**

* In runbot, go to Invoicing > Reporting > OCA accounting reports > Open items
* Print the XLSX report

**Behavior before this PR**
The date format is not the user's date format

**Behavior after this PR**
The date format is the user's date format