### PR TITLE
[10.0][UPT]customer_outstanding_statement standard name is Aging Statement

### DIFF
--- a/customer_outstanding_statement/README.rst
+++ b/customer_outstanding_statement/README.rst
@@ -2,11 +2,11 @@
    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
    :alt: License: AGPL-3
 
-====================================
-Print Customer Outstanding Statement
-====================================
+=====================
+Print Aging Statement
+=====================
 
-The outstanding statement provides details of all outstanding customer receivables
+The aging statement provides details of all outstanding customer receivables
 up to a particular date. This includes all unpaid invoices, unclaimed refunds and
 outstanding payments. The list is displayed in chronological order and is split by currencies.
 
@@ -27,7 +27,7 @@ Usage
 To use this module, you need to:
 
 #. Go to Customers and select one or more
-#. Press 'Action > Customer Outstanding Statement'
+#. Press 'Action > Aging Statement'
 #. Indicate if you want to display aging buckets
 
 

--- a/customer_outstanding_statement/__manifest__.py
+++ b/customer_outstanding_statement/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 {
-    'name': 'Customer Outstanding Statement',
+    'name': 'Aging Statement',
     'version': '10.0.1.1.0',
     'category': 'Accounting & Finance',
     'summary': 'OCA Financial Reports',

--- a/customer_outstanding_statement/report/customer_outstanding_statement.py
+++ b/customer_outstanding_statement/report/customer_outstanding_statement.py
@@ -9,7 +9,7 @@ from odoo import api, fields, models
 
 
 class CustomerOutstandingStatement(models.AbstractModel):
-    """Model of Customer Outstanding Statement"""
+    """Model of Aging Statement"""
 
     _name = 'report.customer_outstanding_statement.statement'
 

--- a/customer_outstanding_statement/static/description/index.html
+++ b/customer_outstanding_statement/static/description/index.html
@@ -1,7 +1,7 @@
 <section class="oe_container">
     <div class="oe_row oe_spaced">
         <div class="oe_span12">
-            <h2 class="oe_slogan">Customer Outstanding Statement</h2>
+            <h2 class="oe_slogan">Aging Statement</h2>
         </div>
         <div class="oe_span6">
             <div class="oe_demo oe_picture oe_screenshot">
@@ -43,7 +43,7 @@ due, ...), so the customer can review how much is open, due or overdue.</div></p
             <p class="oe_mt32">To use this module, you need to:
                 <ul>
                     <li>Go to <code>Customers</code> and select one or more</li>
-                    <li>Press '<code>Action > Customer Outstanding Statement</code>'</li>
+                    <li>Press '<code>Action > Aging Statement</code>'</li>
                     <li>Indicate if you want to display aging buckets</li>
                 </ul>
             </p>

--- a/customer_outstanding_statement/tests/test_customer_outstanding_statement.py
+++ b/customer_outstanding_statement/tests/test_customer_outstanding_statement.py
@@ -8,7 +8,7 @@ from odoo.tests.common import TransactionCase
 
 class TestCustomerOutstandingStatement(TransactionCase):
     """
-        Tests for Customer Outstanding Statement.
+        Tests for Aging Statement.
     """
     def setUp(self):
         super(TestCustomerOutstandingStatement, self).setUp()
@@ -26,7 +26,7 @@ class TestCustomerOutstandingStatement(TransactionCase):
             self.env['report.customer_outstanding_statement.statement']
         self.wiz = self.env['customer.outstanding.statement.wizard']
         self.report_name = 'customer_outstanding_statement.statement'
-        self.report_title = 'Customer Outstanding Statement'
+        self.report_title = 'Aging Statement'
 
     def _create_user(self, login, groups, company):
         group_ids = [group.id for group in groups]

--- a/customer_outstanding_statement/views/statement.xml
+++ b/customer_outstanding_statement/views/statement.xml
@@ -10,7 +10,7 @@
                         <span t-field="o.vat"/>
                     </div>
                     <h4 style="padding-left:15em;padding-top:2em">
-                        Outstanding Statement
+                        Aging Statement
                     </h4>
                     <p>
                         Date: <span t-esc="Date[o.id]" /><br/><!--Today-->
@@ -22,7 +22,7 @@
                         <t t-foreach="Lines[o.id]" t-as="currency">
                             <br t-if="not currency_first" />
                             <p>
-                                Outstanding Statement at <span t-esc="Date_end[o.id]" /> in <span t-esc="Currencies[o.id][currency].name"/>:
+                                Aging Statement at <span t-esc="Date_end[o.id]" /> in <span t-esc="Currencies[o.id][currency].name"/>:
                             </p>
                             <table class="table table-condensed" style="border: 1px solid black; border-collapse: collapse;">
                                 <thead>

--- a/customer_outstanding_statement/wizard/customer_outstanding_statement_wizard.py
+++ b/customer_outstanding_statement/wizard/customer_outstanding_statement_wizard.py
@@ -8,10 +8,10 @@ from odoo import api, fields, models
 
 
 class CustomerOutstandingStatementWizard(models.TransientModel):
-    """Customer Outstanding Statement wizard."""
+    """Aging Statement wizard."""
 
     _name = 'customer.outstanding.statement.wizard'
-    _description = 'Customer Outstanding Statement Wizard'
+    _description = 'Aging Statement Wizard'
 
     company_id = fields.Many2one(
         comodel_name='res.company',

--- a/customer_outstanding_statement/wizard/customer_outstanding_statement_wizard.xml
+++ b/customer_outstanding_statement/wizard/customer_outstanding_statement_wizard.xml
@@ -2,7 +2,7 @@
 <odoo>
     <!-- wizard action on res.partner -->
     <act_window id="customer_outstanding_statement_wizard_action"
-        name="Customer Outstanding Statement"
+        name="Aging Statement"
         src_model="res.partner"
         res_model="customer.outstanding.statement.wizard"
         view_type="form" view_mode="form"
@@ -11,7 +11,7 @@
 
     <!-- wizard view -->
     <record id="customer_outstanding_statement_wizard_view" model="ir.ui.view">
-        <field name="name">Customer Outstanding Statement Wizard</field>
+        <field name="name">Aging Statement Wizard</field>
         <field name="model">customer.outstanding.statement.wizard</field>
         <field name="arch" type="xml">
             <form name="Report Options">


### PR DESCRIPTION
All English speaking companies I have seen call this report Aging Statement. They find current name confusing. Just searching on the web by Aging Statement retrieves much more results than searching by Customer Outstanding Statement or Partner Statement. As long as we try to be the most standardized as possible I think this change is necessary. I am not changing anything in the data model, just strings, in order to avoid breaking current instances.

If community agrees I will forward port this change also to newer versions (partner_statement module).
