### PR TITLE
[13.0][FIX] account_financial_report: filter cancelled journal items

### DIFF
--- a/account_financial_report/report/__init__.py
+++ b/account_financial_report/report/__init__.py
@@ -3,6 +3,7 @@
 # © 2016 Julien Coux (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
 
+from . import abstract_report
 from . import abstract_report_xlsx
 from . import aged_partner_balance
 from . import aged_partner_balance_xlsx

--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -1,0 +1,126 @@
+# Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class AgedPartnerBalanceReport(models.AbstractModel):
+    _name = "report.account_financial_report.abstract_report"
+    _description = "Abstract Report"
+
+    @api.model
+    def _get_move_lines_domain_not_reconciled(
+        self, company_id, account_ids, partner_ids, only_posted_moves, date_from
+    ):
+        domain = [
+            ("account_id", "in", account_ids),
+            ("company_id", "=", company_id),
+            ("reconciled", "=", False),
+        ]
+        if partner_ids:
+            domain += [("partner_id", "in", partner_ids)]
+        if only_posted_moves:
+            domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
+        if date_from:
+            domain += [("date", ">", date_from)]
+        return domain
+
+    @api.model
+    def _get_new_move_lines_domain(
+        self, new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
+    ):
+        domain = [
+            ("account_id", "in", account_ids),
+            ("company_id", "=", company_id),
+            ("id", "in", new_ml_ids),
+        ]
+        if partner_ids:
+            domain += [("partner_id", "in", partner_ids)]
+        if only_posted_moves:
+            domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
+        return domain
+
+    def _recalculate_move_lines(
+        self,
+        move_lines,
+        debit_ids,
+        credit_ids,
+        debit_amount,
+        credit_amount,
+        ml_ids,
+        account_ids,
+        company_id,
+        partner_ids,
+        only_posted_moves,
+    ):
+        debit_ids = set(debit_ids)
+        credit_ids = set(credit_ids)
+        in_credit_but_not_in_debit = credit_ids - debit_ids
+        reconciled_ids = list(debit_ids) + list(in_credit_but_not_in_debit)
+        reconciled_ids = set(reconciled_ids)
+        ml_ids = set(ml_ids)
+        new_ml_ids = reconciled_ids - ml_ids
+        new_ml_ids = list(new_ml_ids)
+        new_domain = self._get_new_move_lines_domain(
+            new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
+        )
+        ml_fields = [
+            "id",
+            "name",
+            "date",
+            "move_id",
+            "journal_id",
+            "account_id",
+            "partner_id",
+            "amount_residual",
+            "date_maturity",
+            "ref",
+            "debit",
+            "credit",
+            "reconciled",
+            "currency_id",
+            "amount_currency",
+            "amount_residual_currency",
+        ]
+        new_move_lines = self.env["account.move.line"].search_read(
+            domain=new_domain, fields=ml_fields
+        )
+        move_lines = move_lines + new_move_lines
+        for move_line in move_lines:
+            ml_id = move_line["id"]
+            if ml_id in debit_ids:
+                move_line["amount_residual"] += debit_amount[ml_id]
+            if ml_id in credit_ids:
+                move_line["amount_residual"] -= credit_amount[ml_id]
+        return move_lines
+
+    def _get_accounts_data(self, accounts_ids):
+        accounts = self.env["account.account"].browse(accounts_ids)
+        accounts_data = {}
+        for account in accounts:
+            accounts_data.update(
+                {
+                    account.id: {
+                        "id": account.id,
+                        "code": account.code,
+                        "name": account.name,
+                        "hide_account": False,
+                        "group_id": account.group_id.id,
+                        "currency_id": account.currency_id or False,
+                        "currency_name": account.currency_id.name,
+                        "centralized": account.centralized,
+                    }
+                }
+            )
+        return accounts_data
+
+    def _get_journals_data(self, journals_ids):
+        journals = self.env["account.journal"].browse(journals_ids)
+        journals_data = {}
+        for journal in journals:
+            journals_data.update({journal.id: {"id": journal.id, "code": journal.code}})
+        return journals_data

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -12,6 +12,7 @@ from odoo.tools import float_is_zero
 class AgedPartnerBalanceReport(models.AbstractModel):
     _name = "report.account_financial_report.aged_partner_balance"
     _description = "Aged Partner Balance Report"
+    _inherit = "report.account_financial_report.abstract_report"
 
     @api.model
     def _initialize_account(self, ag_pb_data, acc_id):
@@ -39,47 +40,6 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         ag_pb_data[acc_id][prt_id]["older"] = 0.0
         ag_pb_data[acc_id][prt_id]["move_lines"] = []
         return ag_pb_data
-
-    def _get_journals_data(self, journals_ids):
-        journals = self.env["account.journal"].browse(journals_ids)
-        journals_data = {}
-        for journal in journals:
-            journals_data.update({journal.id: {"id": journal.id, "code": journal.code}})
-        return journals_data
-
-    def _get_accounts_data(self, accounts_ids):
-        accounts = self.env["account.account"].browse(accounts_ids)
-        accounts_data = {}
-        for account in accounts:
-            accounts_data.update(
-                {
-                    account.id: {
-                        "id": account.id,
-                        "code": account.code,
-                        "name": account.name,
-                    }
-                }
-            )
-        return accounts_data
-
-    @api.model
-    def _get_move_lines_domain(
-        self, company_id, account_ids, partner_ids, only_posted_moves, date_from
-    ):
-        domain = [
-            ("account_id", "in", account_ids),
-            ("company_id", "=", company_id),
-            ("reconciled", "=", False),
-        ]
-        if partner_ids:
-            domain += [("partner_id", "in", partner_ids)]
-        if only_posted_moves:
-            domain += [("move_id.state", "=", "posted")]
-        else:
-            domain += [("move_id.state", "in", ["posted", "draft"])]
-        if date_from:
-            domain += [("date", ">", date_from)]
-        return domain
 
     @api.model
     def _calculate_amounts(
@@ -130,72 +90,6 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             )
         return accounts_partial_reconcile, debit_amount, credit_amount
 
-    @api.model
-    def _get_new_move_lines_domain(
-        self, new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
-    ):
-        domain = [
-            ("account_id", "in", account_ids),
-            ("company_id", "=", company_id),
-            ("id", "in", new_ml_ids),
-        ]
-        if partner_ids:
-            domain += [("partner_id", "in", partner_ids)]
-        if only_posted_moves:
-            domain += [("move_id.state", "=", "posted")]
-        else:
-            domain += [("move_id.state", "in", ["posted", "draft"])]
-        return domain
-
-    def _recalculate_move_lines(
-        self,
-        move_lines,
-        debit_ids,
-        credit_ids,
-        debit_amount,
-        credit_amount,
-        ml_ids,
-        account_ids,
-        company_id,
-        partner_ids,
-        only_posted_moves,
-    ):
-        debit_ids = set(debit_ids)
-        credit_ids = set(credit_ids)
-        in_credit_but_not_in_debit = credit_ids - debit_ids
-        reconciled_ids = list(debit_ids) + list(in_credit_but_not_in_debit)
-        reconciled_ids = set(reconciled_ids)
-        ml_ids = set(ml_ids)
-        new_ml_ids = reconciled_ids - ml_ids
-        new_ml_ids = list(new_ml_ids)
-        new_domain = self._get_new_move_lines_domain(
-            new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
-        )
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "amount_residual",
-            "date_maturity",
-            "ref",
-            "reconciled",
-        ]
-        new_move_lines = self.env["account.move.line"].search_read(
-            domain=new_domain, fields=ml_fields
-        )
-        move_lines = move_lines + new_move_lines
-        for move_line in move_lines:
-            ml_id = move_line["id"]
-            if ml_id in debit_ids:
-                move_line["amount_residual"] += debit_amount[ml_id]
-            if ml_id in credit_ids:
-                move_line["amount_residual"] -= credit_amount[ml_id]
-        return move_lines
-
     def _get_move_lines_data(
         self,
         company_id,
@@ -206,7 +100,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         only_posted_moves,
         show_move_line_details,
     ):
-        domain = self._get_move_lines_domain(
+        domain = self._get_move_lines_domain_not_reconciled(
             company_id, account_ids, partner_ids, only_posted_moves, date_from
         )
         ml_fields = [

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -75,6 +75,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if date_from:
             domain += [("date", ">", date_from)]
         return domain
@@ -141,6 +143,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         return domain
 
     def _recalculate_move_lines(

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -13,32 +13,7 @@ from odoo.tools import float_is_zero
 class GeneralLedgerReport(models.AbstractModel):
     _name = "report.account_financial_report.general_ledger"
     _description = "General Ledger Report"
-
-    def _get_accounts_data(self, account_ids):
-        accounts = self.env["account.account"].browse(account_ids)
-        accounts_data = {}
-        for account in accounts:
-            accounts_data.update(
-                {
-                    account.id: {
-                        "id": account.id,
-                        "code": account.code,
-                        "name": account.name,
-                        "group_id": account.group_id.id,
-                        "currency_id": account.currency_id or False,
-                        "currency_name": account.currency_id.name,
-                        "centralized": account.centralized,
-                    }
-                }
-            )
-        return accounts_data
-
-    def _get_journals_data(self, journals_ids):
-        journals = self.env["account.journal"].browse(journals_ids)
-        journals_data = {}
-        for journal in journals:
-            journals_data.update({journal.id: {"id": journal.id, "code": journal.code}})
-        return journals_data
+    _inherit = "report.account_financial_report.abstract_report"
 
     def _get_tags_data(self, tags_ids):
         tags = self.env["account.analytic.tag"].browse(tags_ids)

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -191,6 +191,8 @@ class GeneralLedgerReport(models.AbstractModel):
             base_domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             base_domain += [("move_id.state", "=", "posted")]
+        else:
+            base_domain += [("move_id.state", "in", ["posted", "draft"])]
         if analytic_tag_ids:
             base_domain += [("analytic_tag_ids", "in", analytic_tag_ids)]
         if cost_center_ids:
@@ -371,6 +373,8 @@ class GeneralLedgerReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if analytic_tag_ids:
             domain += [("analytic_tag_ids", "in", analytic_tag_ids)]
         if cost_center_ids:

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -49,6 +49,8 @@ class JournalLedgerReport(models.AbstractModel):
         ]
         if wizard.move_target != "all":
             domain += [("state", "=", wizard.move_target)]
+        else:
+            domain += [("state", "in", ["posted", "draft"])]
         return domain
 
     def _get_moves_order(self, wizard, journal_ids):

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -12,23 +12,7 @@ from odoo.tools import float_is_zero
 class OpenItemsReport(models.AbstractModel):
     _name = "report.account_financial_report.open_items"
     _description = "Open Items Report"
-
-    @api.model
-    def get_html(self, given_context=None):
-        return self._get_html()
-
-    def _get_html(self):
-        result = {}
-        rcontext = {}
-        context = dict(self.env.context)
-        rcontext.update(context.get("data"))
-        active_id = context.get("active_id")
-        wiz = self.env["open.items.report.wizard"].browse(active_id)
-        rcontext["o"] = wiz
-        result["html"] = self.env.ref(
-            "account_financial_report.report_open_items"
-        ).render(rcontext)
-        return result
+    _inherit = "report.account_financial_report.abstract_report"
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
@@ -52,121 +36,6 @@ class OpenItemsReport(models.AbstractModel):
             )
         return accounts_partial_reconcile, debit_amount, credit_amount
 
-    @api.model
-    def _get_new_move_lines_domain(
-        self, new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
-    ):
-        domain = [
-            ("account_id", "in", account_ids),
-            ("company_id", "=", company_id),
-            ("id", "in", new_ml_ids),
-        ]
-        if partner_ids:
-            domain += [("partner_id", "in", partner_ids)]
-        if only_posted_moves:
-            domain += [("move_id.state", "=", "posted")]
-        else:
-            domain += [("move_id.state", "in", ["posted", "draft"])]
-        return domain
-
-    def _recalculate_move_lines(
-        self,
-        move_lines,
-        debit_ids,
-        credit_ids,
-        debit_amount,
-        credit_amount,
-        ml_ids,
-        account_ids,
-        company_id,
-        partner_ids,
-        only_posted_moves,
-    ):
-        debit_ids = set(debit_ids)
-        credit_ids = set(credit_ids)
-        in_credit_but_not_in_debit = credit_ids - debit_ids
-        reconciled_ids = list(debit_ids) + list(in_credit_but_not_in_debit)
-        reconciled_ids = set(reconciled_ids)
-        ml_ids = set(ml_ids)
-        new_ml_ids = reconciled_ids - ml_ids
-        new_ml_ids = list(new_ml_ids)
-        new_domain = self._get_new_move_lines_domain(
-            new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
-        )
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "amount_residual",
-            "date_maturity",
-            "ref",
-            "debit",
-            "credit",
-            "reconciled",
-            "currency_id",
-            "amount_currency",
-            "amount_residual_currency",
-        ]
-        new_move_lines = self.env["account.move.line"].search_read(
-            domain=new_domain, fields=ml_fields
-        )
-        move_lines = move_lines + new_move_lines
-        for move_line in move_lines:
-            ml_id = move_line["id"]
-            if ml_id in debit_ids:
-                move_line["amount_residual"] += debit_amount[ml_id]
-            if ml_id in credit_ids:
-                move_line["amount_residual"] -= credit_amount[ml_id]
-        return move_lines
-
-    @api.model
-    def _get_move_lines_domain(
-        self, company_id, account_ids, partner_ids, only_posted_moves, date_from
-    ):
-        domain = [
-            ("account_id", "in", account_ids),
-            ("company_id", "=", company_id),
-            ("reconciled", "=", False),
-        ]
-        if partner_ids:
-            domain += [("partner_id", "in", partner_ids)]
-        if only_posted_moves:
-            domain += [("move_id.state", "=", "posted")]
-        else:
-            domain += [("move_id.state", "in", ["posted", "draft"])]
-        if date_from:
-            domain += [("date", ">", date_from)]
-        return domain
-
-    def _get_accounts_data(self, accounts_ids):
-        accounts = self.env["account.account"].browse(accounts_ids)
-        accounts_data = {}
-        for account in accounts:
-            accounts_data.update(
-                {
-                    account.id: {
-                        "id": account.id,
-                        "code": account.code,
-                        "name": account.name,
-                        "hide_account": False,
-                        "currency_id": account.currency_id or False,
-                        "currency_name": account.currency_id.name,
-                    }
-                }
-            )
-        return accounts_data
-
-    def _get_journals_data(self, journals_ids):
-        journals = self.env["account.journal"].browse(journals_ids)
-        journals_data = {}
-        for journal in journals:
-            journals_data.update({journal.id: {"id": journal.id, "code": journal.code}})
-        return journals_data
-
     def _get_data(
         self,
         account_ids,
@@ -176,7 +45,7 @@ class OpenItemsReport(models.AbstractModel):
         company_id,
         date_from,
     ):
-        domain = self._get_move_lines_domain(
+        domain = self._get_move_lines_domain_not_reconciled(
             company_id, account_ids, partner_ids, only_posted_moves, date_from
         )
         ml_fields = [

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -54,7 +54,7 @@ class OpenItemsReport(models.AbstractModel):
 
     @api.model
     def _get_new_move_lines_domain(
-        self, new_ml_ids, account_ids, company_id, partner_ids, target_moves
+        self, new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
     ):
         domain = [
             ("account_id", "in", account_ids),
@@ -63,8 +63,10 @@ class OpenItemsReport(models.AbstractModel):
         ]
         if partner_ids:
             domain += [("partner_id", "in", partner_ids)]
-        if target_moves == "posted":
+        if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         return domain
 
     def _recalculate_move_lines(
@@ -78,7 +80,7 @@ class OpenItemsReport(models.AbstractModel):
         account_ids,
         company_id,
         partner_ids,
-        target_moves,
+        only_posted_moves,
     ):
         debit_ids = set(debit_ids)
         credit_ids = set(credit_ids)
@@ -89,7 +91,7 @@ class OpenItemsReport(models.AbstractModel):
         new_ml_ids = reconciled_ids - ml_ids
         new_ml_ids = list(new_ml_ids)
         new_domain = self._get_new_move_lines_domain(
-            new_ml_ids, account_ids, company_id, partner_ids, target_moves
+            new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
         )
         ml_fields = [
             "id",
@@ -123,7 +125,7 @@ class OpenItemsReport(models.AbstractModel):
 
     @api.model
     def _get_move_lines_domain(
-        self, company_id, account_ids, partner_ids, target_move, date_from
+        self, company_id, account_ids, partner_ids, only_posted_moves, date_from
     ):
         domain = [
             ("account_id", "in", account_ids),
@@ -132,8 +134,10 @@ class OpenItemsReport(models.AbstractModel):
         ]
         if partner_ids:
             domain += [("partner_id", "in", partner_ids)]
-        if target_move == "posted":
+        if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if date_from:
             domain += [("date", ">", date_from)]
         return domain
@@ -168,12 +172,12 @@ class OpenItemsReport(models.AbstractModel):
         account_ids,
         partner_ids,
         date_at_object,
-        target_move,
+        only_posted_moves,
         company_id,
         date_from,
     ):
         domain = self._get_move_lines_domain(
-            company_id, account_ids, partner_ids, target_move, date_from
+            company_id, account_ids, partner_ids, only_posted_moves, date_from
         )
         ml_fields = [
             "id",
@@ -223,7 +227,7 @@ class OpenItemsReport(models.AbstractModel):
                     account_ids,
                     company_id,
                     partner_ids,
-                    target_move,
+                    only_posted_moves,
                 )
         move_lines = [
             move_line
@@ -356,7 +360,7 @@ class OpenItemsReport(models.AbstractModel):
         date_at = data["date_at"]
         date_at_object = datetime.strptime(date_at, "%Y-%m-%d").date()
         date_from = data["date_from"]
-        target_move = data["target_move"]
+        only_posted_moves = data["only_posted_moves"]
         show_partner_details = data["show_partner_details"]
 
         (
@@ -366,7 +370,12 @@ class OpenItemsReport(models.AbstractModel):
             accounts_data,
             open_items_move_lines_data,
         ) = self._get_data(
-            account_ids, partner_ids, date_at_object, target_move, company_id, date_from
+            account_ids,
+            partner_ids,
+            date_at_object,
+            only_posted_moves,
+            company_id,
+            date_from,
         )
 
         total_amount = self._calculate_amounts(open_items_move_lines_data)

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -74,6 +74,8 @@ class TrialBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if show_partner_details:
             domain += [("account_id.internal_type", "in", ["receivable", "payable"])]
         return domain
@@ -106,6 +108,8 @@ class TrialBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if show_partner_details:
             domain += [("account_id.internal_type", "in", ["receivable", "payable"])]
         return domain
@@ -137,6 +141,8 @@ class TrialBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if show_partner_details:
             domain += [("account_id.internal_type", "in", ["receivable", "payable"])]
         return domain
@@ -168,6 +174,8 @@ class TrialBalanceReport(models.AbstractModel):
             domain += [("partner_id", "in", partner_ids)]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         if show_partner_details:
             domain += [("account_id.internal_type", "in", ["receivable", "payable"])]
         return domain

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -10,42 +10,7 @@ from odoo import api, models
 class TrialBalanceReport(models.AbstractModel):
     _name = "report.account_financial_report.trial_balance"
     _description = "Trial Balance Report"
-
-    @api.model
-    def get_html(self, given_context=None):
-        return self._get_html()
-
-    def _get_html(self):
-        result = {}
-        rcontext = {}
-        context = dict(self.env.context)
-        rcontext.update(context.get("data"))
-        active_id = context.get("active_id")
-        wiz = self.env["open.items.report.wizard"].browse(active_id)
-        rcontext["o"] = wiz
-        result["html"] = self.env.ref(
-            "account_financial_report.report_trial_balance"
-        ).render(rcontext)
-        return result
-
-    def _get_accounts_data(self, account_ids):
-        accounts = self.env["account.account"].browse(account_ids)
-        accounts_data = {}
-        for account in accounts:
-            accounts_data.update(
-                {
-                    account.id: {
-                        "id": account.id,
-                        "code": account.code,
-                        "name": account.name,
-                        "group_id": account.group_id.id,
-                        "hide_account": False,
-                        "currency_id": account.currency_id or False,
-                        "currency_name": account.currency_id.name,
-                    }
-                }
-            )
-        return accounts_data
+    _inherit = "report.account_financial_report.abstract_report"
 
     def _get_initial_balances_bs_ml_domain(
         self,
@@ -261,6 +226,25 @@ class TrialBalanceReport(models.AbstractModel):
         return total_amount
 
     @api.model
+    def _compute_acc_prt_amount(
+        self, total_amount, tb, acc_id, prt_id, foreign_currency
+    ):
+        total_amount[acc_id][prt_id] = {}
+        total_amount[acc_id][prt_id]["credit"] = 0.0
+        total_amount[acc_id][prt_id]["debit"] = 0.0
+        total_amount[acc_id][prt_id]["balance"] = 0.0
+        total_amount[acc_id][prt_id]["initial_balance"] = tb["balance"]
+        total_amount[acc_id][prt_id]["ending_balance"] = tb["balance"]
+        if foreign_currency:
+            total_amount[acc_id][prt_id]["initial_currency_balance"] = round(
+                tb["amount_currency"], 2
+            )
+            total_amount[acc_id][prt_id]["ending_currency_balance"] = round(
+                tb["amount_currency"], 2
+            )
+        return total_amount
+
+    @api.model
     def _compute_partner_amount(
         self, total_amount, tb_initial_prt, tb_period_prt, foreign_currency
     ):
@@ -295,34 +279,14 @@ class TrialBalanceReport(models.AbstractModel):
                         {prt_id: {"id": prt_id, "name": tb["partner_id"][1]}}
                     )
                 if acc_id not in total_amount.keys():
-                    total_amount[acc_id][prt_id] = {}
-                    total_amount[acc_id][prt_id]["credit"] = 0.0
-                    total_amount[acc_id][prt_id]["debit"] = 0.0
-                    total_amount[acc_id][prt_id]["balance"] = 0.0
-                    total_amount[acc_id][prt_id]["initial_balance"] = tb["balance"]
-                    total_amount[acc_id][prt_id]["ending_balance"] = tb["balance"]
-                    if foreign_currency:
-                        total_amount[acc_id][prt_id][
-                            "initial_currency_balance"
-                        ] = round(tb["amount_currency"], 2)
-                        total_amount[acc_id][prt_id]["ending_currency_balance"] = round(
-                            tb["amount_currency"], 2
-                        )
+                    total_amount = self._compute_acc_prt_amount(
+                        total_amount, tb, acc_id, prt_id, foreign_currency
+                    )
                     partners_ids.add(tb["partner_id"])
                 elif prt_id not in total_amount[acc_id].keys():
-                    total_amount[acc_id][prt_id] = {}
-                    total_amount[acc_id][prt_id]["credit"] = 0.0
-                    total_amount[acc_id][prt_id]["debit"] = 0.0
-                    total_amount[acc_id][prt_id]["balance"] = 0.0
-                    total_amount[acc_id][prt_id]["initial_balance"] = tb["balance"]
-                    total_amount[acc_id][prt_id]["ending_balance"] = tb["balance"]
-                    if foreign_currency:
-                        total_amount[acc_id][prt_id][
-                            "initial_currency_balance"
-                        ] = round(tb["amount_currency"], 2)
-                        total_amount[acc_id][prt_id]["ending_currency_balance"] = round(
-                            tb["amount_currency"], 2
-                        )
+                    total_amount = self._compute_acc_prt_amount(
+                        total_amount, tb, acc_id, prt_id, foreign_currency
+                    )
                     partners_ids.add(tb["partner_id"])
                 else:
                     total_amount[acc_id][prt_id]["initial_balance"] += tb["balance"]

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -40,6 +40,8 @@ class VATReport(models.AbstractModel):
         ]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         return domain
 
     @api.model
@@ -52,6 +54,8 @@ class VATReport(models.AbstractModel):
         ]
         if only_posted_moves:
             domain += [("move_id.state", "=", "posted")]
+        else:
+            domain += [("move_id.state", "in", ["posted", "draft"])]
         return domain
 
     def _get_vat_report_data(self, company_id, date_from, date_to, only_posted_moves):

--- a/account_financial_report/wizard/abstract_wizard.py
+++ b/account_financial_report/wizard/abstract_wizard.py
@@ -34,3 +34,18 @@ class AbstractWizard(models.AbstractModel):
         required=False,
         string="Company",
     )
+
+    def button_export_html(self):
+        self.ensure_one()
+        report_type = "qweb-html"
+        return self._export(report_type)
+
+    def button_export_pdf(self):
+        self.ensure_one()
+        report_type = "qweb-pdf"
+        return self._export(report_type)
+
+    def button_export_xlsx(self):
+        self.ensure_one()
+        report_type = "xlsx"
+        return self._export(report_type)

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -127,21 +127,6 @@ class AgedPartnerBalanceWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        self.ensure_one()
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
-
     def _prepare_report_aged_partner_balance(self):
         self.ensure_one()
         return {

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -279,21 +279,6 @@ class GeneralLedgerReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        self.ensure_one()
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
-
     def _prepare_report_general_ledger(self):
         self.ensure_one()
         return {

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -152,8 +152,8 @@ class JournalLedgerReportWizard(models.TransientModel):
 
     @api.model
     def _get_partner_name(self, partner_id, partner_data):
-        if str(partner_id) in partner_data.keys():
-            return partner_data[str(partner_id)]["name"]
+        if partner_id in partner_data.keys():
+            return partner_data[partner_id]["name"]
         else:
             return ""
 

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -94,20 +94,6 @@ class JournalLedgerReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
-
     def _prepare_report_journal_ledger(self):
         self.ensure_one()
         journals = self.journal_ids

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -148,21 +148,6 @@ class OpenItemsReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        self.ensure_one()
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
-
     def _prepare_report_open_items(self):
         self.ensure_one()
         return {

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -247,21 +247,6 @@ class TrialBalanceReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        self.ensure_one()
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
-
     def _prepare_report_trial_balance(self):
         self.ensure_one()
         return {

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -8,13 +8,8 @@ from odoo.exceptions import ValidationError
 class VATReportWizard(models.TransientModel):
     _name = "vat.report.wizard"
     _description = "VAT Report Wizard"
+    _inherit = "account_financial_report_abstract_wizard"
 
-    company_id = fields.Many2one(
-        comodel_name="res.company",
-        default=lambda self: self.env.company.id,
-        required=False,
-        string="Company",
-    )
     date_range_id = fields.Many2one(comodel_name="date.range", string="Date range")
     date_from = fields.Date("Start Date", required=True)
     date_to = fields.Date("End Date", required=True)
@@ -87,21 +82,6 @@ class VATReportWizard(models.TransientModel):
             )
             .report_action(self, data=data)
         )
-
-    def button_export_html(self):
-        self.ensure_one()
-        report_type = "qweb-html"
-        return self._export(report_type)
-
-    def button_export_pdf(self):
-        self.ensure_one()
-        report_type = "qweb-pdf"
-        return self._export(report_type)
-
-    def button_export_xlsx(self):
-        self.ensure_one()
-        report_type = "xlsx"
-        return self._export(report_type)
 
     def _prepare_vat_report(self):
         self.ensure_one()


### PR DESCRIPTION
Fixes for not showing Journal Items of canceled Journal Entries when looking for Posted and Unposted moves.
Also a little fix for showing partner name in Journal Ledger. (associated with migration to v12 to v13)

cc @ForgeFlow @LoisRForgeFlow 