### PR TITLE
[13.0][IMP] partner_statement: partner reference isn't displayed sometimes.

### DIFF
--- a/partner_statement/readme/CONTRIBUTORS.rst
+++ b/partner_statement/readme/CONTRIBUTORS.rst
@@ -1,2 +1,3 @@
 * Miquel Raïch <miquel.raich@forgeflow.com>
 * Graeme Gellatly <graeme@o4sb.com>
+* Lois Rilo <lois.rilo@forgeflow.com>

--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -79,29 +79,32 @@ class ActivityStatement(models.AbstractModel):
             self._cr.mogrify(
                 """
             SELECT m.name AS move_id, l.partner_id, l.date,
-       CASE WHEN (aj.type IN ('sale', 'purchase'))
-                THEN l.name
-                ELSE '/'
-            END as name,
-       CASE WHEN (aj.type IN ('sale', 'purchase'))
-                THEN l.ref
-           WHEN (aj.type in ('bank', 'cash'))
-                THEN 'Payment'
-                ELSE ''
-            END as ref,
-            l.blocked, l.currency_id, l.company_id,
-            CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
-                THEN sum(l.amount_currency)
-                ELSE sum(l.debit)
-            END as debit,
-            CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
-                THEN sum(l.amount_currency * (-1))
-                ELSE sum(l.credit)
-            END as credit,
-            CASE WHEN l.date_maturity is null
-                THEN l.date
-                ELSE l.date_maturity
-            END as date_maturity
+                CASE WHEN (aj.type IN ('sale', 'purchase'))
+                    THEN l.name
+                    ELSE '/'
+                END as name,
+                CASE
+                    WHEN (aj.type IN ('sale', 'purchase')) AND l.name IS NOT NULL
+                        THEN l.ref
+                    WHEN aj.type IN ('sale', 'purchase') AND l.name IS NULL
+                        THEN m.ref
+                    WHEN (aj.type in ('bank', 'cash'))
+                        THEN 'Payment'
+                    ELSE ''
+                END as ref,
+                l.blocked, l.currency_id, l.company_id,
+                CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
+                    THEN sum(l.amount_currency)
+                    ELSE sum(l.debit)
+                END as debit,
+                CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
+                    THEN sum(l.amount_currency * (-1))
+                    ELSE sum(l.credit)
+                END as credit,
+                CASE WHEN l.date_maturity is null
+                    THEN l.date
+                    ELSE l.date_maturity
+                END as date_maturity
             FROM account_move_line l
             JOIN account_move m ON (l.move_id = m.id)
             JOIN account_journal aj ON (l.journal_id = aj.id)
@@ -115,10 +118,13 @@ class ActivityStatement(models.AbstractModel):
                     THEN l.name
                     ELSE '/'
                 END,
-                CASE WHEN (aj.type IN ('sale', 'purchase'))
-                    THEN l.ref
-                WHEN (aj.type in ('bank', 'cash'))
-                    THEN 'Payment'
+                CASE
+                    WHEN (aj.type IN ('sale', 'purchase')) AND l.name IS NOT NULL
+                        THEN l.ref
+                    WHEN aj.type IN ('sale', 'purchase') AND l.name IS NULL
+                        THEN m.ref
+                    WHEN (aj.type in ('bank', 'cash'))
+                        THEN 'Payment'
                     ELSE ''
                 END,
                 l.blocked, l.currency_id, l.amount_currency, l.company_id

--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -17,7 +17,11 @@ class OutstandingStatement(models.AbstractModel):
             self._cr.mogrify(
                 """
             SELECT m.name AS move_id, l.partner_id, l.date, l.name,
-                            l.ref, l.blocked, l.currency_id, l.company_id,
+                            l.blocked, l.currency_id, l.company_id,
+            CASE WHEN l.ref IS NOT NULL
+                THEN l.ref
+                ELSE m.ref
+            END as ref,
             CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
                 THEN avg(l.amount_currency)
                 ELSE avg(l.debit)
@@ -62,8 +66,11 @@ class OutstandingStatement(models.AbstractModel):
                                   (pd.id IS NULL AND pc.id IS NULL)
                                 ) AND l.date <= %(date_end)s AND m.state IN ('posted')
             GROUP BY l.partner_id, m.name, l.date, l.date_maturity, l.name,
-                                l.ref, l.blocked, l.currency_id,
-                                l.balance, l.amount_currency, l.company_id
+                CASE WHEN l.ref IS NOT NULL
+                    THEN l.ref
+                    ELSE m.ref
+                END,
+                l.blocked, l.currency_id, l.balance, l.amount_currency, l.company_id
             """,
                 locals(),
             ),

--- a/partner_statement/views/activity_statement.xml
+++ b/partner_statement/views/activity_statement.xml
@@ -21,6 +21,10 @@
                         <strong>Date:</strong>
                         <p t-esc="d['today']" class="m-0" />
                     </div>
+                    <div class="col-3 bm-2">
+                        <strong>Partner Name:</strong>
+                        <p t-field="o.name" class="m-0" />
+                    </div>
                     <div t-if="o.ref" class="col-3 bm-2">
                         <strong>Partner Code:</strong>
                         <p t-field="o.ref" class="m-0" />
@@ -80,12 +84,15 @@
                                     </td>
                                     <td>
                                         <t t-if="line['name'] != '/'">
-                                            <t t-if="not line['ref']">
+                                            <t t-if="not line['ref'] and line['name']">
                                                 <span t-esc="line['name']" />
+                                            </t>
+                                            <t t-if="line['ref'] and not line['name']">
+                                                <span t-esc="line['ref']" />
                                             </t>
                                             <t t-if="line['ref'] and line['name']">
                                                 <t
-                                                    t-if="line['name'] not in line['ref']"
+                                                    t-if="line['name'] not in line['ref'] or line['name'] == line['ref']"
                                                 >
                                                     <span t-esc="line['name']" />
                                                 </t>
@@ -94,16 +101,10 @@
                                                 >
                                                     <span t-esc="line['ref']" />
                                                 </t>
-                                                <t t-if="line['name'] == line['ref']">
-                                                    <span t-esc="line['name']" />
-                                                </t>
                                             </t>
                                         </t>
                                         <t t-if="line['name'] == '/'">
-                                            <span
-                                                t-if="line['ref'] == 'Payment'"
-                                            >Payment</span>
-                                            <span t-else="" t-esc="line['ref']" />
+                                            <span t-esc="line['ref']" />
                                         </t>
                                     </td>
                                     <td class="amount">

--- a/partner_statement/views/outstanding_statement.xml
+++ b/partner_statement/views/outstanding_statement.xml
@@ -22,6 +22,10 @@
                         <strong>Date:</strong>
                         <p t-esc="d['today']" class="m-0" />
                     </div>
+                    <div class="col-3 bm-2">
+                        <strong>Partner Name:</strong>
+                        <p t-field="o.name" class="m-0" />
+                    </div>
                     <div t-if="o.ref" class="col-3 bm-2">
                         <strong>Partner Code:</strong>
                         <p t-field="o.ref" class="m-0" />
@@ -71,9 +75,12 @@
                                             <t t-if="not line['ref']">
                                                 <span t-esc="line['name']" />
                                             </t>
+                                            <t t-if="line['ref'] and not line['name']">
+                                                <span t-esc="line['ref']" />
+                                            </t>
                                             <t t-if="line['ref'] and line['name']">
                                                 <t
-                                                    t-if="line['name'] not in line['ref']"
+                                                    t-if="line['name'] not in line['ref'] or line['name'] == line['ref']"
                                                 >
                                                     <span t-esc="line['name']" />
                                                 </t>
@@ -81,9 +88,6 @@
                                                     t-if="line['ref'] not in line['name']"
                                                 >
                                                     <span t-esc="line['ref']" />
-                                                </t>
-                                                <t t-if="line['ref'] == line['name']">
-                                                    <span t-esc="line['name']" />
                                                 </t>
                                             </t>
                                         </t>


### PR DESCRIPTION
* show partner name at the top.
* simplify view logic for `name` and `ref` printing.
* fallback to journal entry `ref` when the journal item has no `ref` set.
* little query formatting changes to enhance readability.

@ForgeFlow