### PR TITLE
[12.0][FIX] account_financial_report: Correctly inject selected journals in accounts query

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     'name': 'Account Financial Reports',
-    'version': '12.0.1.4.1',
+    'version': '12.0.1.4.2',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
     'author': 'Camptocamp SA,'

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -338,8 +338,8 @@ class GeneralLedgerReportCompute(models.TransientModel):
         if self.filter_journal_ids:
             sub_subquery_sum_amounts += """
             AND
-                ml.journal_id IN %s
-            """ % (tuple(self.filter_journal_ids.ids,),)
+                ml.journal_id IN (%s)
+            """ % ', '.join(map(str, self.filter_journal_ids.ids))
 
         if self.only_posted_moves:
             sub_subquery_sum_amounts += """


### PR DESCRIPTION
**Steps to reproduce**
1. Open Invoicing > Reporting > OCA accounting reports > Trial balance
2. Input any date in mandatory date fields
3. Select a journal
4. Export PDF

**Before this PR**
Error
```
[...]
  File "/home/odoo/build/OCA/account-financial-reporting/account_financial_report/report/general_ledger.py", line 639, in _inject_account_values
    self.env.cr.execute(query_inject_account, query_inject_account_params)
  File "/.repo_requirements/odoo/odoo/sql_db.py", line 148, in wrapper
    return f(self, *args, **kwargs)
  File "/.repo_requirements/odoo/odoo/sql_db.py", line 225, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: syntax error at or near ")"
LINE 62:                 ml.journal_id IN (1,)
                                             ^
```
**After this PR**
Get trial balance with only accounts from the selected journal