### PR TITLE
 [8.0][account_financial_report_webkit] Fix ``Type Error`` when printing aged open invoice report on Windows

### DIFF
--- a/account_financial_report_webkit/report/webkit_parser_header_fix.py
+++ b/account_financial_report_webkit/report/webkit_parser_header_fix.py
@@ -208,7 +208,7 @@ class HeaderFooterTextWebKitParser(webkit_report.WebKitParser):
 
         if report_xml.report_file:
             path = get_module_resource(
-                *report_xml.report_file.split(os.path.sep))
+                *report_xml.report_file.split('/'))
             if os.path.exists(path):
                 template = file(path).read()
         if not template and report_xml.report_webkit_data:


### PR DESCRIPTION
The separator in the [report_file](https://github.com/OCA/account-financial-reporting/blob/8.0/account_financial_report_webkit/report/report.xml#L122) path is hard-coded and the [create_single_pdf](https://github.com/OCA/account-financial-reporting/blob/8.0/account_financial_report_webkit/report/webkit_parser_header_fix.py#L211) will try to split the report file path using the system path separator which will lead to a type error when using a windows platform.

The fix will replace the system path separator with the hard-coded separator.