### PR TITLE
[12.0][FIX] account_financial_report: add index to report_move_id

### DIFF
--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -722,6 +722,7 @@ class ReportJournalLedgerMoveLine(models.TransientModel):
         comodel_name='report_journal_ledger_move',
         required=True,
         ondelete='cascade',
+        index=True,
     )
     move_line_id = fields.Many2one(
         comodel_name='account.move.line',


### PR DESCRIPTION
When running `DELETE FROM report_journal_ledger_move` this column is checked repeatedly, even though the table is empty. On our setup that caused the query to take hours. Adding an index solved it.