### PR TITLE
[9.0][FIX] account_tax_balance: init hook refund confusion

### DIFF
--- a/account_tax_balance/hooks.py
+++ b/account_tax_balance/hooks.py
@@ -20,8 +20,8 @@ def pre_init_hook(cr):
         ('liquidity', 'liquidity', False),
         ('payable', 'payable', 'AND aml.balance < 0'),
         ('payable_refund', 'payable', 'AND aml.balance >= 0'),
-        ('receivable', 'receivable', 'AND aml.balance < 0'),
-        ('receivable_refund', 'receivable', 'AND aml.balance >= 0'),
+        ('receivable', 'receivable', 'AND aml.balance > 0'),
+        ('receivable_refund', 'receivable', 'AND aml.balance <= 0'),
         ('other', False, False),
     ]
     for move_type, internal_type, extra_where in MAPPING:


### PR DESCRIPTION
Regression of https://github.com/OCA/account-financial-reporting/pull/647