### PR TITLE
[14.0][FIX] account_financial_report fix default company

### DIFF
--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -15,7 +15,7 @@ class AgedPartnerBalanceWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         required=False,
         string="Company",
     )

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -24,7 +24,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         required=False,
         string="Company",
     )

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -12,7 +12,7 @@ class JournalLedgerReportWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         string="Company",
         required=False,
         ondelete="cascade",

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -15,7 +15,7 @@ class OpenItemsReportWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         required=False,
         string="Company",
     )

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -18,7 +18,7 @@ class TrialBalanceReportWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         required=False,
         string="Company",
     )

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -11,7 +11,7 @@ class VATReportWizard(models.TransientModel):
 
     company_id = fields.Many2one(
         comodel_name="res.company",
-        default=lambda self: self.env.user.company_id,
+        default=lambda self: self.env.company,
         required=False,
         string="Company",
     )


### PR DESCRIPTION
Company_id on res.users is used as a default company. When opening the wizard in company A it should not use company B since this is the default company of a user. It should use the current user.

@pedrobaeza 