### PR TITLE
[13.0][imp][account_tax_balance] Use direct SQL queries to improve performance

### DIFF
--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Antonio Espinosa <antonio.espinosa@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class AccountTax(models.Model):
@@ -18,11 +18,6 @@ class AccountTax(models.Model):
     base_balance_refund = fields.Float(
         string="Base Balance Refund", compute="_compute_balance"
     )
-    has_moves = fields.Boolean(
-        string="Has balance in period",
-        compute="_compute_has_moves",
-        search="_search_has_moves",
-    )
 
     def get_context_values(self):
         context = self.env.context
@@ -34,56 +29,9 @@ class AccountTax(models.Model):
             context.get("target_move", "posted"),
         )
 
-    def _account_tax_ids_with_moves(self):
-        """ Return all account.tax ids for which there is at least
-        one account.move.line in the context period
-        for the user company.
-
-        Caveat: this ignores record rules and ACL but it is good
-        enough for filtering taxes with activity during the period.
-        """
-        from_date, to_date, company_ids, _ = self.get_context_values()
-        company_ids = tuple(company_ids)
-        req = """
-            SELECT id
-            FROM account_tax at
-            WHERE
-            company_id in %s AND
-            EXISTS (
-              SELECT 1 FROM account_move_Line aml
-              WHERE
-                date >= %s AND
-                date <= %s AND
-                company_id in %s AND (
-                  tax_line_id = at.id OR
-                  EXISTS (
-                    SELECT 1 FROM account_move_line_account_tax_rel
-                    WHERE account_move_line_id = aml.id AND
-                      account_tax_id = at.id
-                  )
-                )
-            )
-        """
-        self.env.cr.execute(
-            req, (company_ids, from_date, to_date, company_ids)
-        )  # pylint: disable=E8103
-        return [r[0] for r in self.env.cr.fetchall()]
-
-    def _compute_has_moves(self):
-        ids_with_moves = set(self._account_tax_ids_with_moves())
-        for tax in self:
-            tax.has_moves = tax.id in ids_with_moves
-
     @api.model
     def _is_unsupported_search_operator(self, operator):
         return operator != "="
-
-    @api.model
-    def _search_has_moves(self, operator, value):
-        if self._is_unsupported_search_operator(operator) or not value:
-            raise ValueError(_("Unsupported search operator"))
-        ids_with_moves = self._account_tax_ids_with_moves()
-        return [("id", "in", ids_with_moves)]
 
     def _compute_balance(self):
         total_balance_regular = self.compute_balance(

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -33,20 +33,36 @@ class AccountTax(models.Model):
     def _is_unsupported_search_operator(self, operator):
         return operator != "="
 
+    def _compute_regular_and_refund(self, total):
+        tax_ids = total.keys()
+        total_refund = {}
+        total_regular = {}
+        for tax_id in tax_ids:
+            total_refund[tax_id] = 0.0
+            total_regular[tax_id] = 0.0
+            move_types = total[tax_id].keys()
+            for move_type in move_types:
+                if move_type in ["receivable_refund", "payable_refund"]:
+                    total_refund[tax_id] += total[tax_id][move_type]
+                else:
+                    total_regular[tax_id] += total[tax_id][move_type]
+        return total_regular, total_refund
+
     def _compute_balance(self):
-        total_balance_regular = self.compute_balance(
-            tax_or_base="tax", move_type="regular"
+        total_balance_tax = self.compute_balance(tax_or_base="tax")
+        total_balance_base = self.compute_balance(tax_or_base="base")
+        total_balance_regular, total_balance_refund = self._compute_regular_and_refund(
+            total_balance_tax
         )
-        total_base_balance_regular = self.compute_balance(
-            tax_or_base="base", move_type="regular"
+        (
+            total_base_balance_regular,
+            total_base_balance_refund,
+        ) = self._compute_regular_and_refund(total_balance_base)
+        founded_taxes_ids = set(list(total_balance_tax.keys())).union(
+            set(list(total_balance_base.keys()))
         )
-        total_balance_refund = self.compute_balance(
-            tax_or_base="tax", move_type="refund"
-        )
-        total_base_balance_refund = self.compute_balance(
-            tax_or_base="base", move_type="refund"
-        )
-        for tax in self:
+        for tax_id in list(founded_taxes_ids):
+            tax = self.browse(tax_id)
             tax.balance_regular = (
                 total_balance_regular[tax.id]
                 if tax.id in total_balance_regular.keys()
@@ -91,48 +107,47 @@ class AccountTax(models.Model):
         params = [to_date, from_date, tuple(company_ids)]
         return query, params
 
-    def compute_balance(self, tax_or_base="tax", move_type=None):
+    def compute_balance(self, tax_or_base="tax"):
         # There's really bad performace in m2m fields.
         # So we better do a direct query.
         # See https://github.com/odoo/odoo/issues/30350
         _select, _group_by, query, params = self.get_move_lines_query(
-            tax_or_base=tax_or_base, move_type=move_type
+            tax_or_base=tax_or_base
         )
         query = query.format(select_clause=_select, group_by_clause=_group_by)
         self.env.cr.execute(query, params)  # pylint: disable=E8103
         results = self.env.cr.fetchall()
         total_balance = {}
-        for balance, tax_id in results:
-            total_balance[tax_id] = balance
+        for balance, tax_id, move_type in results:
+            if tax_id not in total_balance.keys():
+                total_balance[tax_id] = {}
+            total_balance[tax_id][move_type] = balance
         return total_balance
 
-    def get_move_lines_query(self, tax_or_base="tax", move_type=None):
+    def get_move_lines_query(self, tax_or_base="tax"):
         from_date, to_date, company_ids, target_move = self.get_context_values()
         state_list = self.get_target_state_list(target_move)
-        type_list = self.get_target_type_list(move_type)
         base_query = self.get_move_lines_base_query()
         _where = ""
         _joins = ""
         _group_by = ""
         _params = []
         _select = "SELECT SUM(balance)"
-        _group_by = " GROUP BY "
+        _group_by = " GROUP BY am.move_type, "
         where, params = self.get_move_line_partial_where(
             from_date, to_date, company_ids
         )
         _where += where
         _params += params
         if tax_or_base == "tax":
-            select, where, group_by, params = self.get_balance_where(
-                state_list, type_list
-            )
+            select, where, group_by, params = self.get_balance_where(state_list)
             _where += where
             _params += params
             _select += select
             _group_by += group_by
         elif tax_or_base == "base":
             select, joins, where, group_by, params = self.get_base_balance_where(
-                state_list, type_list
+                state_list
             )
             _where += where
             _joins += joins
@@ -156,8 +171,8 @@ class AccountTax(models.Model):
             "{group_by_clause}"
         )
 
-    def get_balance_where(self, state_list, type_list):
-        select = ", aml.tax_line_id  as tax_id"
+    def get_balance_where(self, state_list):
+        select = ", aml.tax_line_id  as tax_id, am.move_type"
         where = (
             " AND am.state IN %s"
             " AND  aml.tax_line_id IS NOT NULL"
@@ -165,13 +180,10 @@ class AccountTax(models.Model):
         )
         group_by = "aml.tax_line_id"
         params = [tuple(state_list)]
-        if type_list:
-            where += " AND am.move_type IN %s"
-            params += [tuple(type_list)]
         return select, where, group_by, params
 
-    def get_base_balance_where(self, state_list, type_list):
-        select = ", rel.account_tax_id as tax_id"
+    def get_base_balance_where(self, state_list):
+        select = ", rel.account_tax_id as tax_id, am.move_type"
         joins = (
             " INNER JOIN account_move_line_account_tax_rel AS rel "
             "ON aml.id = rel.account_move_line_id"
@@ -179,14 +191,11 @@ class AccountTax(models.Model):
         group_by = "rel.account_tax_id"
         where = " AND am.state IN %s" " AND aml.tax_exigible = True "
         params = [tuple(state_list)]
-        if type_list:
-            where += " AND am.move_type IN %s"
-            params += [tuple(type_list)]
         return select, joins, where, group_by, params
 
     def get_move_lines_domain(self, tax_or_base="tax", move_type=None):
         _select, _group_by, query, params = self.get_move_lines_query(
-            tax_or_base=tax_or_base, move_type=move_type
+            tax_or_base=tax_or_base
         )
         _select = "SELECT aml.id"
         _group_by = ""
@@ -194,6 +203,10 @@ class AccountTax(models.Model):
             query += " AND aml.tax_line_id = " + str(self.id)
         elif tax_or_base == "base":
             query += " AND rel.account_tax_id = " + str(self.id)
+        type_list = self.get_target_type_list(move_type)
+        if type_list:
+            query += " AND am.move_type IN %s"
+            params += [tuple(type_list)]
         query = query.format(select_clause=_select, group_by_clause=_group_by)
         self.env.cr.execute(query, params)  # pylint: disable=E8103
         amls = []

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -64,7 +64,9 @@ class AccountTax(models.Model):
                 )
             )
         """
-        self.env.cr.execute(req, (company_ids, from_date, to_date, company_ids))
+        self.env.cr.execute(
+            req, (company_ids, from_date, to_date, company_ids)
+        )  # pylint: disable=E8103
         return [r[0] for r in self.env.cr.fetchall()]
 
     def _compute_has_moves(self):
@@ -116,58 +118,103 @@ class AccountTax(models.Model):
             state = []
         return state
 
-    def get_move_line_partial_domain(self, from_date, to_date, company_ids):
-        return [
-            ("date", "<=", to_date),
-            ("date", ">=", from_date),
-            ("company_id", "in", company_ids),
-        ]
+    def get_move_line_partial_where(self, from_date, to_date, company_ids):
+        query = "aml.date <= %s AND aml.date >= %s AND aml.company_id IN %s"
+        params = [to_date, from_date, tuple(company_ids)]
+        return query, params
 
     def compute_balance(self, tax_or_base="tax", move_type=None):
+        # There's really bad performace in m2m fields.
+        # So we better do a direct query.
+        # See https://github.com/odoo/odoo/issues/30350
         self.ensure_one()
-        domain = self.get_move_lines_domain(
+        query, params = self.get_move_lines_query(
             tax_or_base=tax_or_base, move_type=move_type
         )
-        # balance is debit - credit whereas on tax return you want to see what
-        # vat has to be paid so:
-        # VAT on sales (credit) - VAT on purchases (debit).
+        _select = "sum(aml.balance)"
+        query = query.format(select_clause=_select)
+        self.env.cr.execute(query, params)  # pylint: disable=E8103
+        res = self.env.cr.fetchone()
+        balance = 0.0
+        if res:
+            balance = res[0]
+        return balance and -balance or 0.0
 
-        balance = self.env["account.move.line"].read_group(domain, ["balance"], [])[0][
-            "balance"
-        ]
-        return balance and -balance or 0
-
-    def get_balance_domain(self, state_list, type_list):
-        domain = [
-            ("move_id.state", "in", state_list),
-            ("tax_line_id", "=", self.id),
-            ("tax_exigible", "=", True),
-        ]
-        if type_list:
-            domain.append(("move_id.move_type", "in", type_list))
-        return domain
-
-    def get_base_balance_domain(self, state_list, type_list):
-        domain = [
-            ("move_id.state", "in", state_list),
-            ("tax_ids", "in", self.id),
-            ("tax_exigible", "=", True),
-        ]
-        if type_list:
-            domain.append(("move_id.move_type", "in", type_list))
-        return domain
-
-    def get_move_lines_domain(self, tax_or_base="tax", move_type=None):
+    def get_move_lines_query(self, tax_or_base="tax", move_type=None):
         from_date, to_date, company_ids, target_move = self.get_context_values()
         state_list = self.get_target_state_list(target_move)
         type_list = self.get_target_type_list(move_type)
-        domain = self.get_move_line_partial_domain(from_date, to_date, company_ids)
-        balance_domain = []
+        base_query = self.get_move_lines_base_query()
+        _where = ""
+        _joins = ""
+        _params = []
+        where, params = self.get_move_line_partial_where(
+            from_date, to_date, company_ids
+        )
+        _where += where
+        _params += params
         if tax_or_base == "tax":
-            balance_domain = self.get_balance_domain(state_list, type_list)
+            where, params = self.get_balance_where(state_list, type_list)
+            _where += where
+            _params += params
         elif tax_or_base == "base":
-            balance_domain = self.get_base_balance_domain(state_list, type_list)
-        domain.extend(balance_domain)
+            joins, where, params = self.get_base_balance_where(state_list, type_list)
+            _where += where
+            _joins += joins
+            _params += params
+        query = base_query.format(
+            select_clause="{select_clause}",
+            where_clause=_where,
+            additional_joins=_joins,
+        )
+        return query, _params
+
+    def get_move_lines_base_query(self):
+        return (
+            "SELECT {select_clause} FROM account_move_line AS aml "
+            "INNER JOIN account_move AS am ON aml.move_id = am.id "
+            "{additional_joins}"
+            " WHERE {where_clause}"
+        )
+
+    def get_balance_where(self, state_list, type_list):
+        where = (
+            " AND am.state IN %s AND "
+            "aml.tax_line_id = %s AND "
+            "aml.tax_exigible = True"
+        )
+        params = [tuple(state_list), self.id]
+        if type_list:
+            where += " AND am.move_type IN %s"
+            params += [tuple(type_list)]
+        return where, params
+
+    def get_base_balance_where(self, state_list, type_list):
+        joins = (
+            " INNER JOIN account_move_line_account_tax_rel AS rel "
+            "ON aml.id = rel.account_move_line_id"
+            " INNER JOIN account_tax as tax "
+            "ON tax.id = rel.account_tax_id"
+        )
+
+        where = " AND am.state IN %s" " AND tax.id = %s" " AND aml.tax_exigible = True "
+        params = [tuple(state_list), self.id]
+        if type_list:
+            where += " AND am.move_type IN %s"
+            params += [tuple(type_list)]
+        return joins, where, params
+
+    def get_move_lines_domain(self, tax_or_base="tax", move_type=None):
+        query, params = self.get_move_lines_query(
+            tax_or_base=tax_or_base, move_type=move_type
+        )
+        _select = "aml.id"
+        query = query.format(select_clause=_select)
+        self.env.cr.execute(query, params)  # pylint: disable=E8103
+        amls = []
+        for (aml_id,) in self.env.cr.fetchall():
+            amls.append(aml_id)
+        domain = [("id", "in", amls)]
         return domain
 
     def get_lines_action(self, tax_or_base="tax", move_type=None):

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -18,6 +18,11 @@ class AccountTax(models.Model):
     base_balance_refund = fields.Float(
         string="Base Balance Refund", compute="_compute_balance"
     )
+    has_moves = fields.Boolean(
+        compute="_compute_balance",
+        search="_search_has_moves",
+        string="Has balance in period",
+    )
 
     def get_context_values(self):
         context = self.env.context
@@ -30,8 +35,11 @@ class AccountTax(models.Model):
         )
 
     @api.model
-    def _is_unsupported_search_operator(self, operator):
-        return operator != "="
+    def _search_has_moves(self, operator, value):
+        assert isinstance(value, bool), "Not implemented"
+        assert operator == "=", "Not implemented"
+        ids_with_moves = self.search([]).filtered(lambda t: t.has_moves == value)
+        return [("id", "in", ids_with_moves.ids)]
 
     def _compute_regular_and_refund(self, total):
         tax_ids = total.keys()
@@ -43,9 +51,9 @@ class AccountTax(models.Model):
             move_types = total[tax_id].keys()
             for move_type in move_types:
                 if move_type in ["receivable_refund", "payable_refund"]:
-                    total_refund[tax_id] += total[tax_id][move_type]
+                    total_refund[tax_id] += (-1) * total[tax_id][move_type]
                 else:
-                    total_regular[tax_id] += total[tax_id][move_type]
+                    total_regular[tax_id] += (-1) * total[tax_id][move_type]
         return total_regular, total_refund
 
     def _compute_balance(self):
@@ -61,8 +69,8 @@ class AccountTax(models.Model):
         founded_taxes_ids = set(list(total_balance_tax.keys())).union(
             set(list(total_balance_base.keys()))
         )
-        for tax_id in list(founded_taxes_ids):
-            tax = self.browse(tax_id)
+        for tax in self:
+            tax.has_moves = tax.id in list(founded_taxes_ids)
             tax.balance_regular = (
                 total_balance_regular[tax.id]
                 if tax.id in total_balance_regular.keys()

--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -128,17 +128,16 @@ class AccountTax(models.Model):
         # So we better do a direct query.
         # See https://github.com/odoo/odoo/issues/30350
         self.ensure_one()
-        query, params = self.get_move_lines_query(
+        _select, _group_by, query, params = self.get_move_lines_query(
             tax_or_base=tax_or_base, move_type=move_type
         )
-        _select = "sum(aml.balance)"
-        query = query.format(select_clause=_select)
+        _select = "SUM(aml.balance)"
+        query = query.format(select_clause=_select, group_by_clause=_group_by)
         self.env.cr.execute(query, params)  # pylint: disable=E8103
-        res = self.env.cr.fetchone()
-        balance = 0.0
-        if res:
-            balance = res[0]
-        return balance and -balance or 0.0
+        total_balance = {}
+        for balance, tax_id in self.env.cr.fetchall():
+            total_balance[tax_id] = balance
+        return False  # TODO
 
     def get_move_lines_query(self, tax_or_base="tax", move_type=None):
         from_date, to_date, company_ids, target_move = self.get_context_values()
@@ -147,27 +146,39 @@ class AccountTax(models.Model):
         base_query = self.get_move_lines_base_query()
         _where = ""
         _joins = ""
+        _group_by = ""
         _params = []
+        _select = "SELECT SUM(balance)"
+        _group_by = "GROUP BY "
         where, params = self.get_move_line_partial_where(
             from_date, to_date, company_ids
         )
         _where += where
         _params += params
         if tax_or_base == "tax":
-            where, params = self.get_balance_where(state_list, type_list)
+            select, where, group_by, params = self.get_balance_where(
+                state_list, type_list
+            )
             _where += where
             _params += params
+            _select += select
+            _group_by += group_by
         elif tax_or_base == "base":
-            joins, where, params = self.get_base_balance_where(state_list, type_list)
+            select, joins, where, group_by, params = self.get_base_balance_where(
+                state_list, type_list
+            )
             _where += where
             _joins += joins
             _params += params
+            _select += select
+            _group_by += group_by
         query = base_query.format(
             select_clause="{select_clause}",
             where_clause=_where,
             additional_joins=_joins,
+            group_by="{group_by_clause}",
         )
-        return query, _params
+        return _select, _group_by, query, _params
 
     def get_move_lines_base_query(self):
         return (
@@ -175,41 +186,44 @@ class AccountTax(models.Model):
             "INNER JOIN account_move AS am ON aml.move_id = am.id "
             "{additional_joins}"
             " WHERE {where_clause}"
+            "{group_by_clause}"
         )
 
     def get_balance_where(self, state_list, type_list):
+        select = ", tax_line_id  as tax_id"
         where = (
             " AND am.state IN %s AND "
             "aml.tax_line_id = %s AND "
             "aml.tax_exigible = True"
         )
+        group_by = "aml.tax_line_id"
         params = [tuple(state_list), self.id]
         if type_list:
             where += " AND am.move_type IN %s"
             params += [tuple(type_list)]
-        return where, params
+        return select, where, group_by, params
 
     def get_base_balance_where(self, state_list, type_list):
+        select = ", rel.account_tax_id as tax_id"
         joins = (
             " INNER JOIN account_move_line_account_tax_rel AS rel "
             "ON aml.id = rel.account_move_line_id"
-            " INNER JOIN account_tax as tax "
-            "ON tax.id = rel.account_tax_id"
         )
-
+        group_by = "rel.account_tax_id"
         where = " AND am.state IN %s" " AND tax.id = %s" " AND aml.tax_exigible = True "
         params = [tuple(state_list), self.id]
         if type_list:
             where += " AND am.move_type IN %s"
             params += [tuple(type_list)]
-        return joins, where, params
+        return select, joins, where, group_by, params
 
     def get_move_lines_domain(self, tax_or_base="tax", move_type=None):
-        query, params = self.get_move_lines_query(
+        _select, _group_by, query, params = self.get_move_lines_query(
             tax_or_base=tax_or_base, move_type=move_type
         )
         _select = "aml.id"
-        query = query.format(select_clause=_select)
+        _group_by = ""
+        query = query.format(select_clause=_select, group_by_clause=_group_by)
         self.env.cr.execute(query, params)  # pylint: disable=E8103
         amls = []
         for (aml_id,) in self.env.cr.fetchall():

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -65,6 +65,11 @@
                 <field name="name" />
                 <field name="description" string="Short Name" />
                 <field name="type_tax_use" />
+                <filter
+                    name="filter_has_moves"
+                    string="Has Moves"
+                    domain="[('has_moves', '=', True)]"
+                />
                 <group expand="0" string="Group By">
                     <filter
                         name="tax_group"
@@ -86,6 +91,7 @@
         <field name="name">Taxes Balance</field>
         <field name="res_model">account.tax</field>
         <field name="view_mode">tree</field>
+        <field name="context">{"search_default_filter_has_moves":1}</field>
         <field name="view_id" ref="view_tax_tree_balance" />
         <field name="search_view_id" ref="view_tax_search_balance" />
     </record>

--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -86,7 +86,6 @@
         <field name="name">Taxes Balance</field>
         <field name="res_model">account.tax</field>
         <field name="view_mode">tree</field>
-        <field name="domain">[('has_moves', '=', True)]</field>
         <field name="view_id" ref="view_tax_tree_balance" />
         <field name="search_view_id" ref="view_tax_search_balance" />
     </record>


### PR DESCRIPTION
The tax balance report searches using a m2m field, which kills performance in large databases. We need direct SQL queries in order to work around this issue. See https://github.com/odoo/odoo/issues/30350

cc @Yajo @pedrobaeza @JoanSForgeFlow 