### PR TITLE
[13.0][account_financial_reporting] fix errors related to multicompany

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -369,6 +369,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             "doc_model": "open.items.report.wizard",
             "docs": self.env["open.items.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
+            "company_currency": company.currency_id,
             "currency_name": company.currency_id.name,
             "date_at": date_at,
             "only_posted_moves": only_posted_moves,

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -258,6 +258,7 @@ class OpenItemsReport(models.AbstractModel):
             "foreign_currency": data["foreign_currency"],
             "show_partner_details": data["show_partner_details"],
             "company_name": company.display_name,
+            "company_currency": company.currency_id,
             "currency_name": company.currency_id.name,
             "date_at": date_at_object.strftime("%d/%m/%Y"),
             "hide_account_at_0": data["hide_account_at_0"],

--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -137,49 +137,49 @@
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## current-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['current']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## age_30_days-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['30_days']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## age_60_days-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['60_days']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## age_90_days-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['90_days']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## age_120_days-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['120_days']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## older-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['older']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
         </div>
@@ -315,7 +315,7 @@
                         >
                             <t
                                 t-raw="line['residual']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </div>
@@ -324,7 +324,7 @@
                         <t t-if="line.current == 0">
                             <span
                                 t-field="line.current"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -334,7 +334,7 @@
                             >
                                 <t
                                     t-raw="line['current']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -344,7 +344,7 @@
                         <t t-if="line.age_30_days == 0">
                             <span
                                 t-field="line.age_30_days"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -354,7 +354,7 @@
                             >
                                 <t
                                     t-raw="line['30_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -364,7 +364,7 @@
                         <t t-if="line.age_60_days == 0">
                             <span
                                 t-field="line.age_60_days"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -374,7 +374,7 @@
                             >
                                 <t
                                     t-raw="line['60_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -384,7 +384,7 @@
                         <t t-if="line.age_90_days == 0">
                             <span
                                 t-field="line.age_90_days"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -394,7 +394,7 @@
                             >
                                 <t
                                     t-raw="line['90_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -404,7 +404,7 @@
                         <t t-if="line.age_120_days == 0">
                             <span
                                 t-field="line.age_120_days"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -414,7 +414,7 @@
                             >
                                 <t
                                     t-raw="line['120_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -424,7 +424,7 @@
                         <t t-if="line.older == 0">
                             <span
                                 t-field="line.older"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </t>
                         <t t-else="">
@@ -434,7 +434,7 @@
                             >
                                 <t
                                     t-raw="line['older']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -456,49 +456,49 @@
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['residual']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## current-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['current']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## age_30_days-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['30_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## age_60_days-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['60_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## age_90_days-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['90_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## age_120_days-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['120_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## older-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['older']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
             </div>
@@ -515,49 +515,49 @@
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## current-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_30_days-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['30_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_60_days-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['60_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_90_days-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['90_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_120_days-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['120_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## older-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['older']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                 </t>
@@ -570,49 +570,49 @@
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## current-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_30_days-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['30_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_60_days-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['60_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_90_days-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['90_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## age_120_days-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['120_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                     <!--## older-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['older']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </div>
                 </t>

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -229,7 +229,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -244,7 +244,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -261,7 +261,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -276,7 +276,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -292,7 +292,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -306,7 +306,7 @@
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
                                 t-raw="account_or_partner_object['init_bal']['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -516,7 +516,7 @@
                             >
                                 <t
                                     t-raw="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -524,7 +524,7 @@
                             <span>
                                 <t
                                     t-raw="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -539,7 +539,7 @@
                             >
                                 <t
                                     t-raw="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -547,7 +547,7 @@
                             <span>
                                 <t
                                     t-raw="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -562,7 +562,7 @@
                             >
                                 <t
                                     t-raw="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -570,7 +570,7 @@
                             <span>
                                 <t
                                     t-raw="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                 />
                             </span>
                         </t>
@@ -640,21 +640,21 @@
                 <div class="act_as_cell amount" style="width: 8.02%;">
                     <span
                         t-esc="account_or_partner_object['fin_bal']['debit']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## credit-->
                 <div class="act_as_cell amount" style="width: 8.02%;">
                     <span
                         t-esc="account_or_partner_object['fin_bal']['credit']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## balance cumulated-->
                 <div class="act_as_cell amount" style="width: 8.02%;">
                     <span
                         t-esc="account_or_partner_object['fin_bal']['balance']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## currency_name + amount_currency-->

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -210,14 +210,14 @@
                 <span
                     t-if="line.get('original', False)"
                     t-esc="line['original']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <!--## amount_residual-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="line['amount_residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                 />
             </div>
             <t t-if="foreign_currency">
@@ -276,13 +276,13 @@
                     <t t-if='type == "account_type"'>
                         <span
                             t-esc="total_amount[account_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </t>
                     <t t-if='type == "partner_type"'>
                         <span
                             t-esc="total_amount[account_id][partner_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </t>
                 </div>

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -300,7 +300,7 @@
                             <t
                                 t-att-style="style"
                                 t-esc="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -314,7 +314,7 @@
                             <t
                                 t-att-style="style"
                                 t-raw="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -330,7 +330,7 @@
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </span>
                 </t>
@@ -350,7 +350,7 @@
                             <t
                                 t-att-style="style"
                                 t-esc="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -366,7 +366,7 @@
                             <t
                                 t-att-style="style"
                                 t-raw="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -384,7 +384,7 @@
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </span>
                 </t>
@@ -404,7 +404,7 @@
                             <t
                                 t-att-style="style"
                                 t-esc="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -420,7 +420,7 @@
                             <t
                                 t-att-style="style"
                                 t-raw="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -438,7 +438,7 @@
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </span>
                 </t>
@@ -458,7 +458,7 @@
                             <t
                                 t-att-style="style"
                                 t-esc="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -473,7 +473,7 @@
                             <t
                                 t-att-style="style"
                                 t-raw="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -491,7 +491,7 @@
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </span>
                 </t>
@@ -509,7 +509,7 @@
                             <t
                                 t-att-style="style"
                                 t-esc="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -522,7 +522,7 @@
                             <t
                                 t-att-style="style"
                                 t-raw="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </span>
                     </t>
@@ -538,7 +538,7 @@
                         <t
                             t-att-style="style"
                             t-esc="total_amount[account_id][partner_id]['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                         />
                     </span>
                 </t>
@@ -716,7 +716,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                        <t t-att-style="style" t-raw="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                        <t t-att-style="style" t-raw="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': company_currency}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Debit&ndash;&gt;-->
@@ -731,7 +731,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-raw="account.debit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-raw="account.debit" t-options="{'widget': 'monetary', 'display_currency': company_currency}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Credit&ndash;&gt;-->
@@ -746,7 +746,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-raw="account.credit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-raw="account.credit" t-options="{'widget': 'monetary', 'display_currency': company_currency}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Period Balance &ndash;&gt;-->
@@ -761,7 +761,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-raw="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-raw="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': company_currency}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Ending balance&ndash;&gt;-->
@@ -773,7 +773,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style" >-->
-    <!--                            <t t-att-style="style" t-raw="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-raw="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': company_currency}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                <t t-if="foreign_currency">-->
@@ -832,35 +832,35 @@
                 <div class="act_as_cell amount" style="width: 9%;">
                     <span
                         t-esc="total_amount[account_id]['initial_balance']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## Debit-->
                 <div class="act_as_cell amount" style="width: 9%;">
                     <span
                         t-esc="total_amount[account_id]['debit']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## Credit-->
                 <div class="act_as_cell amount" style="width: 9%;">
                     <span
                         t-esc="total_amount[account_id]['credit']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## Period balance-->
                 <div class="act_as_cell amount" style="width: 9%;">
                     <span
                         t-esc="total_amount[account_id]['balance']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <!--## Ending balance-->
                 <div class="act_as_cell amount" style="width: 9%;">
                     <span
                         t-esc="total_amount[account_id]['ending_balance']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                     />
                 </div>
                 <t t-if="foreign_currency">

--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -72,14 +72,14 @@
                             <t
                                 t-att-style="style"
                                 t-raw="tag_or_group['net']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </div>
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t
                                 t-att-style="style"
                                 t-raw="tag_or_group['tax']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
                         </div>
                     </div>
@@ -114,7 +114,7 @@
                                         <t
                                             t-att-style="style"
                                             t-raw="tax['net']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                         />
                                     </span>
                                 </div>
@@ -133,7 +133,7 @@
                                         <t
                                             t-att-style="style"
                                             t-raw="tax['tax']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                         />
                                     </span>
                                 </div>

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -229,6 +229,7 @@ class VATReport(models.AbstractModel):
             "doc_model": "open.items.report.wizard",
             "docs": self.env["open.items.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
+            "company_currency": company.currency_id,
             "currency_name": company.currency_id.name,
             "date_to": data["date_to"],
             "date_from": data["date_from"],

--- a/account_financial_report/wizard/abstract_wizard.py
+++ b/account_financial_report/wizard/abstract_wizard.py
@@ -33,6 +33,7 @@ class AbstractWizard(models.AbstractModel):
         default=lambda self: self.env.company.id,
         required=False,
         string="Company",
+        domain=lambda self: [("id", "in", self.env.companies.ids)],
     )
 
     def button_export_html(self):


### PR DESCRIPTION
- Display the currency of the company that was selected by the user, not
  the company that the user is currently active on.
- In the wizards, show only the companies that the user has chosen to work on,
  instead of all companies.

cc @JoanSForgeFlow @MateuGForgeFlow @LoisRForgeFlow @MiquelRForgeFlow 