### PR TITLE
[13.0][FIX]account_financial_report: fix VAT report template

### DIFF
--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -70,34 +70,17 @@
                         </div>
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t
-                                t-set="domain"
-                                t-value="[('tax_ids', 'in', [tax.tax_id.id for tax in tag.tax_ids]),
-                                        ('date', '&gt;=', o.date_from),
-                                        ('date', '&lt;=', o.date_to)]"
+                                t-att-style="style"
+                                t-raw="tag_or_group['net']"
+                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
-                            <span t-att-domain="domain" res-model="account.move.line">
-                                <t
-                                    t-att-style="style"
-                                    t-raw="tag_or_group['net']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
-                                />
-                            </span>
                         </div>
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t
-                                t-set="domain"
-                                t-value="[('tax_line_id', 'in', [tax.tax_id.id for tax in tag.tax_ids]),
-                                        ('date', '&gt;=', o.date_from),
-                                        ('date', '&lt;=', o.date_to),
-                                        ('tax_exigible', '=', True)]"
+                                t-att-style="style"
+                                t-raw="tag_or_group['tax']"
+                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
-                            <span t-att-domain="domain" res-model="account.move.line">
-                                <t
-                                    t-att-style="style"
-                                    t-raw="tag_or_group['tax']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
-                                />
-                            </span>
                         </div>
                     </div>
                     <t t-if="tax_detail">
@@ -109,7 +92,7 @@
                                     style="padding-left: 20px; width: 65%;"
                                 >
                                     <span
-                                        t-att-res-id="tax.tax_id.id"
+                                        t-att-res-id="tax['id']"
                                         t-att-res-model="res_model"
                                         view-type="form"
                                     >
@@ -119,9 +102,9 @@
                                 <div class="act_as_cell amount" style="width: 15%;">
                                     <t
                                         t-set="domain"
-                                        t-value="[('tax_ids', 'in', tax.tax_id.ids),
-                                                ('date', '&gt;=', o.date_from),
-                                                ('date', '&lt;=', o.date_to),
+                                        t-value="[('tax_ids', 'in', tax['id']),
+                                                ('date', '&gt;=', date_from),
+                                                ('date', '&lt;=', date_to),
                                                 ('tax_exigible', '=', True)]"
                                     />
                                     <span
@@ -138,9 +121,9 @@
                                 <div class="act_as_cell amount" style="width: 15%;">
                                     <t
                                         t-set="domain"
-                                        t-value="[('tax_line_id', '=', tax.tax_id.id),
-                                                ('date', '&gt;=', o.date_from),
-                                                ('date', '&lt;=', o.date_to),
+                                        t-value="[('tax_line_id', '=', tax['id']),
+                                                ('date', '&gt;=', date_from),
+                                                ('date', '&lt;=', date_to),
                                                 ('tax_exigible', '=', True)]"
                                     />
                                     <span


### PR DESCRIPTION
- Fixes small migration issues to correctly refer to the object handled in the report.
- Remove the domain from the general "net" and "tax" values. The current code implementation only passes the "taxes" as a list when the tax_detail option is set (https://github.com/OCA/account-financial-reporting/blob/5e04d04c4ed88833de08354ac602d175eee2476e/account_financial_report/report/vat_report.py#L151-L152). Without it, the domain can't be built.