### PR TITLE
[13.0][FIX] account_financial_reporting: Pass res_id correctly to lines

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -151,6 +151,7 @@ class OpenItemsReport(models.AbstractModel):
                     "ref_label": ref_label,
                     "journal_id": move_line["journal_id"][0],
                     "move_name": move_line["move_id"][1],
+                    "entry_id": move_line["move_id"][0],
                     "currency_id": move_line["currency_id"][0]
                     if move_line["currency_id"]
                     else False,

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -177,7 +177,7 @@
             <!--## move-->
             <div class="act_as_cell left">
                 <span
-                    t-att-res-id="line['move_id']"
+                    t-att-res-id="line['entry_id']"
                     res-model="account.move"
                     view-type="form"
                 >


### PR DESCRIPTION
In the open items ledger, the res_id attribute of the invoice
in the report was getting: (id, move_name)
The result was that, when clicking the line, it would redirect
to a new record, instead of the existing.
This passes only the id to the line, solving that issue.

@Tecnativa
TT29371

ping @pedrobaeza @victoralmau 