### PR TITLE
[13.0][FIX] account_financial_report: allow navigation on all fields

### DIFF
--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -186,16 +186,34 @@
             </div>
             <!--## journal-->
             <div class="act_as_cell left">
-                <span t-esc="journals_data[line['journal_id']]['code']" />
+                <span
+                    t-att-res-id="journals_data[line['journal_id']]['id']"
+                    res-model="account.journal"
+                    view-type="form"
+                >
+                    <t t-esc="journals_data[line['journal_id']]['code']" />
+                </span>
             </div>
             <!--## account code-->
             <div class="act_as_cell left">
-                <span t-esc="accounts_data[account_id]['code']" />
+                <span
+                    t-att-res-id="accounts_data[account_id]['id']"
+                    res-model="account.account"
+                    view-type="form"
+                >
+                    <t t-esc="accounts_data[account_id]['code']" />
+                </span>
             </div>
             <!--## partner-->
             <div class="act_as_cell left">
-                <!--                        <span t-if="line.get('partner_id', False)" t-esc="line['partner_id']"/>-->
-                <span t-esc="line['partner_name']" />
+                <span
+                    t-if="line.get('partner_id', False)"
+                    t-att-res-id="line['partner_id']"
+                    res-model="res.partner"
+                    view-type="form"
+                >
+                    <t t-esc="line['partner_name']" />
+                </span>
             </div>
             <!--## ref - label-->
             <div class="act_as_cell left">


### PR DESCRIPTION
As with #775 , do the same for the **journal**, **account** and **partner** columns, to allow navigation to the related records.
This was present in v12, but was lost in the migration process. 
In this case, there isn't any new data being passed to the report, we are just reusing data already present, so no performance issues should come up.

@Tecnativa
TT29371

ping @pedrobaeza @victoralmau 