### PR TITLE
[14.0][FIX] account_financial_report: allow navigation on all fields

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -278,6 +278,7 @@ class OpenItemsReport(models.AbstractModel):
                     "ref_label": ref_label,
                     "journal_id": move_line["journal_id"][0],
                     "move_name": move_line["move_id"][1],
+                    "entry_id": move_line["move_id"][0],
                     "currency_id": move_line["currency_id"][0]
                     if move_line["currency_id"]
                     else False,

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -179,7 +179,7 @@
             <!--## move-->
             <div class="act_as_cell left">
                 <span
-                    t-att-res-id="line['move_id']"
+                    t-att-res-id="line['entry_id']"
                     res-model="account.move"
                     view-type="form"
                 >
@@ -188,16 +188,34 @@
             </div>
             <!--## journal-->
             <div class="act_as_cell left">
-                <span t-esc="journals_data[line['journal_id']]['code']" />
+                <span
+                    t-att-res-id="journals_data[line['journal_id']]['id']"
+                    res-model="account.journal"
+                    view-type="form"
+                >
+                    <t t-esc="journals_data[line['journal_id']]['code']" />
+                </span>
             </div>
             <!--## account code-->
             <div class="act_as_cell left">
-                <span t-esc="accounts_data[account_id]['code']" />
+                <span
+                    t-att-res-id="accounts_data[account_id]['id']"
+                    res-model="account.account"
+                    view-type="form"
+                >
+                    <t t-esc="accounts_data[account_id]['code']" />
+                </span>
             </div>
             <!--## partner-->
             <div class="act_as_cell left">
-                <!--                        <span t-if="line.get('partner_id', False)" t-esc="line['partner_id']"/>-->
-                <span t-esc="line['partner_name']" />
+                <span
+                    t-if="line.get('partner_id', False)"
+                    t-att-res-id="line['partner_id']"
+                    res-model="res.partner"
+                    view-type="form"
+                >
+                    <t t-esc="line['partner_name']" />
+                </span>
             </div>
             <!--## ref - label-->
             <div class="act_as_cell left">

--- a/account_financial_report/tests/test_journal_ledger.py
+++ b/account_financial_report/tests/test_journal_ledger.py
@@ -237,6 +237,7 @@ class TestJournalReport(AccountTestInvoicingCommon):
         )
         move_form.partner_id = self.partner_2
         move_form.journal_id = self.journal_purchase
+        move_form.invoice_date = Date.today()
         with move_form.invoice_line_ids.new() as line_form:
             line_form.name = "test"
             line_form.quantity = 1.0

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -88,7 +88,7 @@
         </field>
     </record>
     <record id="action_open_items_wizard" model="ir.actions.act_window">
-        <field name="name">Open Itemsr</field>
+        <field name="name">Open Items</field>
         <field name="res_model">open.items.report.wizard</field>
         <field name="view_mode">form</field>
         <field name="view_id" ref="open_items_wizard" />


### PR DESCRIPTION
- Pass res_id correctly to lines to allow navigation on the fields

- In the open items ledger, the res_id attribute of the invoice
in the report was getting: (id, move_name)
The result was that, when clicking the line, it would redirect
to a new record, instead of the existing.
This passes only the id to the line, solving that issue.

- Fix menu item name

Forward port of https://github.com/OCA/account-financial-reporting/pull/776 and https://github.com/OCA/account-financial-reporting/pull/775, plus another fix to the menu name in v14

@Tecnativa
TT29371

ping @pedrobaeza @victoralmau 