### PR TITLE
[13.0][fix][partner_statement] correct default company

### DIFF
--- a/partner_statement/wizard/statement_common.py
+++ b/partner_statement/wizard/statement_common.py
@@ -14,7 +14,7 @@ class StatementCommon(models.AbstractModel):
     def _get_company(self):
         return (
             self.env["res.company"].browse(self.env.context.get("force_company"))
-            or self.env.user.company_id
+            or self.env.company
         )
 
     name = fields.Char()


### PR DESCRIPTION
Otherwise it results in an error message when trying to open the report, if you are not in the right company.

cc @ForgeFlow
