### PR TITLE
[13.0][FIX] account_financial_report: Don't include unaffected account if accounts are filtered

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -159,6 +159,10 @@ class GeneralLedgerReport(models.AbstractModel):
         cost_center_ids,
         extra_domain,
     ):
+        # If explicit list of accounts is provided,
+        # don't include unaffected earnings account
+        if account_ids:
+            unaffected_earnings_account = False
         base_domain = []
         if company_id:
             base_domain += [("company_id", "=", company_id)]
@@ -249,29 +253,38 @@ class GeneralLedgerReport(models.AbstractModel):
                 ]
         accounts_ids = list(gen_ld_data.keys())
         unaffected_id = unaffected_earnings_account
-        if unaffected_id not in accounts_ids:
-            accounts_ids.append(unaffected_id)
-            self._initialize_account(gen_ld_data, unaffected_id, foreign_currency)
-        pl_initial_balance = self._get_pl_initial_balance(
-            account_ids, company_id, fy_start_date, foreign_currency, base_domain
-        )
-        gen_ld_data[unaffected_id]["init_bal"]["debit"] += pl_initial_balance["debit"]
-        gen_ld_data[unaffected_id]["init_bal"]["credit"] += pl_initial_balance["credit"]
-        gen_ld_data[unaffected_id]["init_bal"]["balance"] += pl_initial_balance[
-            "balance"
-        ]
-        gen_ld_data[unaffected_id]["fin_bal"]["debit"] += pl_initial_balance["debit"]
-        gen_ld_data[unaffected_id]["fin_bal"]["credit"] += pl_initial_balance["credit"]
-        gen_ld_data[unaffected_id]["fin_bal"]["balance"] += pl_initial_balance[
-            "balance"
-        ]
-        if foreign_currency:
-            gen_ld_data[unaffected_id]["init_bal"]["bal_curr"] += pl_initial_balance[
-                "bal_curr"
+        if unaffected_id:
+            if unaffected_id not in accounts_ids:
+                accounts_ids.append(unaffected_id)
+                self._initialize_account(gen_ld_data, unaffected_id, foreign_currency)
+            pl_initial_balance = self._get_pl_initial_balance(
+                account_ids, company_id, fy_start_date, foreign_currency, base_domain
+            )
+            gen_ld_data[unaffected_id]["init_bal"]["debit"] += pl_initial_balance[
+                "debit"
             ]
-            gen_ld_data[unaffected_id]["fin_bal"]["bal_curr"] += pl_initial_balance[
-                "bal_curr"
+            gen_ld_data[unaffected_id]["init_bal"]["credit"] += pl_initial_balance[
+                "credit"
             ]
+            gen_ld_data[unaffected_id]["init_bal"]["balance"] += pl_initial_balance[
+                "balance"
+            ]
+            gen_ld_data[unaffected_id]["fin_bal"]["debit"] += pl_initial_balance[
+                "debit"
+            ]
+            gen_ld_data[unaffected_id]["fin_bal"]["credit"] += pl_initial_balance[
+                "credit"
+            ]
+            gen_ld_data[unaffected_id]["fin_bal"]["balance"] += pl_initial_balance[
+                "balance"
+            ]
+            if foreign_currency:
+                gen_ld_data[unaffected_id]["init_bal"][
+                    "bal_curr"
+                ] += pl_initial_balance["bal_curr"]
+                gen_ld_data[unaffected_id]["fin_bal"]["bal_curr"] += pl_initial_balance[
+                    "bal_curr"
+                ]
         return gen_ld_data, partners_data, partner_ids
 
     @api.model

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -319,6 +319,9 @@ class TrialBalanceReport(models.AbstractModel):
         accounts_domain = [("company_id", "=", company_id)]
         if account_ids:
             accounts_domain += [("id", "in", account_ids)]
+            # If explicit list of accounts is provided,
+            # don't include unaffected earnings account
+            unaffected_earnings_account = False
         accounts = self.env["account.account"].search(accounts_domain)
         tb_initial_acc = []
         for account in accounts:
@@ -424,19 +427,23 @@ class TrialBalanceReport(models.AbstractModel):
             )
         accounts_ids = list(total_amount.keys())
         unaffected_id = unaffected_earnings_account
-        if unaffected_id not in accounts_ids:
-            accounts_ids.append(unaffected_id)
-            total_amount[unaffected_id] = {}
-            total_amount[unaffected_id]["initial_balance"] = 0.0
-            total_amount[unaffected_id]["balance"] = 0.0
-            total_amount[unaffected_id]["credit"] = 0.0
-            total_amount[unaffected_id]["debit"] = 0.0
-            total_amount[unaffected_id]["ending_balance"] = 0.0
-            if foreign_currency:
-                total_amount[unaffected_id]["initial_currency_balance"] = 0.0
-                total_amount[unaffected_id]["ending_currency_balance"] = 0.0
+        if unaffected_id:
+            if unaffected_id not in accounts_ids:
+                accounts_ids.append(unaffected_id)
+                total_amount[unaffected_id] = {}
+                total_amount[unaffected_id]["initial_balance"] = 0.0
+                total_amount[unaffected_id]["balance"] = 0.0
+                total_amount[unaffected_id]["credit"] = 0.0
+                total_amount[unaffected_id]["debit"] = 0.0
+                total_amount[unaffected_id]["ending_balance"] = 0.0
+                if foreign_currency:
+                    total_amount[unaffected_id]["initial_currency_balance"] = 0.0
+                    total_amount[unaffected_id]["ending_currency_balance"] = 0.0
         accounts_data = self._get_accounts_data(accounts_ids)
-        pl_initial_balance, pl_initial_currency_balance = self._get_pl_initial_balance(
+        (
+            pl_initial_balance,
+            pl_initial_currency_balance,
+        ) = self._get_pl_initial_balance(
             account_ids,
             journal_ids,
             partner_ids,
@@ -446,15 +453,16 @@ class TrialBalanceReport(models.AbstractModel):
             show_partner_details,
             foreign_currency,
         )
-        total_amount[unaffected_id]["ending_balance"] += pl_initial_balance
-        total_amount[unaffected_id]["initial_balance"] += pl_initial_balance
-        if foreign_currency:
-            total_amount[unaffected_id][
-                "ending_currency_balance"
-            ] += pl_initial_currency_balance
-            total_amount[unaffected_id][
-                "initial_currency_balance"
-            ] += pl_initial_currency_balance
+        if unaffected_id:
+            total_amount[unaffected_id]["ending_balance"] += pl_initial_balance
+            total_amount[unaffected_id]["initial_balance"] += pl_initial_balance
+            if foreign_currency:
+                total_amount[unaffected_id][
+                    "ending_currency_balance"
+                ] += pl_initial_currency_balance
+                total_amount[unaffected_id][
+                    "initial_currency_balance"
+                ] += pl_initial_currency_balance
         return total_amount, accounts_data, partners_data
 
     def _get_hierarchy_groups(

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -88,7 +88,7 @@ class TestGeneralLedgerReport(common.TransactionCase):
         move = self.env["account.move"].create(move_vals)
         move.post()
 
-    def _get_report_lines(self, with_partners=False):
+    def _get_report_lines(self, with_partners=False, account_ids=False):
         centralize = True
         if with_partners:
             centralize = False
@@ -100,6 +100,7 @@ class TestGeneralLedgerReport(common.TransactionCase):
                 "target_move": "posted",
                 "hide_account_at_0": False,
                 "company_id": company.id,
+                "account_ids": account_ids,
                 "fy_start_date": self.fy_date_start,
                 "centralize": centralize,
             }
@@ -177,6 +178,9 @@ class TestGeneralLedgerReport(common.TransactionCase):
             self.income_account.id, general_ledger
         )
         self.assertFalse(check_income_account)
+        self.assertTrue(
+            self.check_account_in_report(self.unaffected_account.id, general_ledger)
+        )
 
         # Add a move at the previous day of the first day of fiscal year
         # to check the initial balance
@@ -265,6 +269,21 @@ class TestGeneralLedgerReport(common.TransactionCase):
         self.assertEqual(income_fin_balance["debit"], 1000)
         self.assertEqual(income_fin_balance["credit"], 0)
         self.assertEqual(income_fin_balance["balance"], 1000)
+
+        # Re Generate the general ledger line
+        res_data = self._get_report_lines(
+            account_ids=(self.receivable_account + self.income_account).ids
+        )
+        general_ledger = res_data["general_ledger"]
+        self.assertTrue(
+            self.check_account_in_report(self.receivable_account.id, general_ledger)
+        )
+        self.assertTrue(
+            self.check_account_in_report(self.income_account.id, general_ledger)
+        )
+        self.assertFalse(
+            self.check_account_in_report(self.unaffected_account.id, general_ledger)
+        )
 
         # Add another move at the end day of fiscal year
         # to check that it correctly used on report

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -153,7 +153,9 @@ class TestTrialBalanceReport(common.TransactionCase):
         move = self.env["account.move"].create(move_vals)
         move.post()
 
-    def _get_report_lines(self, with_partners=False, hierarchy_on="computed"):
+    def _get_report_lines(
+        self, with_partners=False, account_ids=False, hierarchy_on="computed"
+    ):
         company = self.env.ref("base.main_company")
         trial_balance = self.env["trial.balance.report.wizard"].create(
             {
@@ -163,6 +165,7 @@ class TestTrialBalanceReport(common.TransactionCase):
                 "hide_account_at_0": True,
                 "hierarchy_on": hierarchy_on,
                 "company_id": company.id,
+                "account_ids": account_ids,
                 "fy_start_date": self.fy_date_start,
                 "show_partner_details": with_partners,
             }
@@ -237,14 +240,6 @@ class TestTrialBalanceReport(common.TransactionCase):
         self.assertTrue(self.account200 in self.group2.compute_account_ids)
 
     def test_01_account_balance_computed(self):
-        # Make sure there's no account of type "Current Year Earnings" in the
-        # groups - We change the code
-        earning_accs = self.env["account.account"].search(
-            [("user_type_id", "=", self.env.ref("account.data_unaffected_earnings").id)]
-        )
-        for acc in earning_accs:
-            if acc.code.startswith("1") or acc.code.startswith("2"):
-                acc.code = "999" + acc.code
         # Generate the general ledger line
         res_data = self._get_report_lines()
         trial_balance = res_data["trial_balance"]
@@ -257,6 +252,9 @@ class TestTrialBalanceReport(common.TransactionCase):
             self.account200.id, trial_balance
         )
         self.assertFalse(check_income_account)
+        self.assertTrue(
+            self.check_account_in_report(self.unaffected_account.id, trial_balance)
+        )
 
         # Add a move at the previous day of the first day of fiscal year
         # to check the initial balance
@@ -318,6 +316,18 @@ class TestTrialBalanceReport(common.TransactionCase):
             self.account200.id, trial_balance
         )
         self.assertTrue(check_income_account)
+
+        # Re Generate the trial balance line with an account filter
+        res_data = self._get_report_lines(
+            account_ids=(self.account100 + self.account200).ids
+        )
+        trial_balance = res_data["trial_balance"]
+        self.assertTrue(self.check_account_in_report(self.account100.id, trial_balance))
+        self.assertTrue(self.check_account_in_report(self.account200.id, trial_balance))
+        # Unaffected account should not be present
+        self.assertFalse(
+            self.check_account_in_report(self.unaffected_account.id, trial_balance)
+        )
 
         # Check the initial and final balance
         account_receivable_lines = self._get_account_lines(


### PR DESCRIPTION
When generating a General Ledger or a Trial Balance, if some accounts are already filtered in the wizard, don't show the information related to the unaffected earnings account.

@Tecnativa
TT29658

ping @pedrobaeza @CarlosRoca13 