### PR TITLE
[13.0][FIX] account_financial_report: Fix tests

### DIFF
--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -240,6 +240,13 @@ class TestTrialBalanceReport(common.TransactionCase):
         self.assertTrue(self.account200 in self.group2.compute_account_ids)
 
     def test_01_account_balance_computed(self):
+        # Change code of the P&L for not being automatically included
+        # in group 1 balances
+        earning_accs = self.env["account.account"].search(
+            [("user_type_id", "=", self.env.ref("account.data_unaffected_earnings").id)]
+        )
+        for acc in earning_accs:
+            acc.code = "999" + acc.code
         # Generate the general ledger line
         res_data = self._get_report_lines()
         trial_balance = res_data["trial_balance"]


### PR DESCRIPTION
Parially revert test changes in https://github.com/OCA/account-financial-reporting/pull/779/commits/ac4eef006f62ed14ec23a08bf027c1304e29fdce

This is needed in contexts where a different localization and accounting configuration is loaded

@Tecnativa
TT29658

ping @pedrobaeza @victoralmau 