### PR TITLE
[14.0][FIX] account_tax_balance: Remove unnecessary text from button

### DIFF
--- a/account_tax_balance/views/account_tax_view.xml
+++ b/account_tax_balance/views/account_tax_view.xml
@@ -15,42 +15,42 @@
                 <button
                     type="object"
                     name="view_tax_regular_lines"
-                    string="View tax regular lines"
+                    title="View tax regular lines"
                     icon="fa-search-plus"
                 />
                 <field name="base_balance_regular" sum="Base Total" />
                 <button
                     type="object"
                     name="view_base_regular_lines"
-                    string="View base regular lines"
+                    title="View base regular lines"
                     icon="fa-search-plus"
                 />
                 <field name="balance_refund" sum="Total" />
                 <button
                     type="object"
                     name="view_tax_refund_lines"
-                    string="View tax refund lines"
+                    title="View tax refund lines"
                     icon="fa-search-plus"
                 />
                 <field name="base_balance_refund" sum="Base Total" />
                 <button
                     type="object"
                     name="view_base_refund_lines"
-                    string="View base refund lines"
+                    title="View base refund lines"
                     icon="fa-search-plus"
                 />
                 <field name="balance" sum="Total" />
                 <button
                     type="object"
                     name="view_tax_lines"
-                    string="View tax lines"
+                    title="View tax lines"
                     icon="fa-search-plus"
                 />
                 <field name="base_balance" sum="Base Total" />
                 <button
                     type="object"
                     name="view_base_lines"
-                    string="View base lines"
+                    title="View base lines"
                     icon="fa-search-plus"
                 />
             </tree>


### PR DESCRIPTION
In previous versions, string was converted to button title and wasn't displayed
Now it was being shown, so this converts it back to the button title

Before:
![image](https://user-images.githubusercontent.com/38977934/118473066-7de5e200-b701-11eb-8434-2ae29e920103.png)

After:
![image](https://user-images.githubusercontent.com/38977934/118473123-8b9b6780-b701-11eb-8ff7-766a429e28cf.png)

@Tecnativa
TT29027

ping @pedrobaeza @victoralmau 