### PR TITLE
Revert "[10.0][IMP] account_financial_report_qweb: Improve performances"

### DIFF
--- a/account_financial_report_qweb/report/open_items.py
+++ b/account_financial_report_qweb/report/open_items.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # © 2016 Julien Coux (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from datetime import timedelta
 
 from odoo import models, fields, api, _
 
@@ -416,6 +415,10 @@ FROM
                 account_partial_reconcile pr
                     ON ml.balance < 0 AND pr.credit_move_id = ml.id
             LEFT JOIN
+                account_move_line ml_future
+                    ON ml.balance < 0 AND pr.debit_move_id = ml_future.id
+                    AND ml_future.date > %s
+            LEFT JOIN
                 account_move_line ml_past
                     ON ml.balance < 0 AND pr.debit_move_id = ml_past.id
                     AND ml_past.date <= %s
@@ -426,19 +429,26 @@ FROM
                 account_partial_reconcile pr
                     ON ml.balance > 0 AND pr.debit_move_id = ml.id
             LEFT JOIN
+                account_move_line ml_future
+                    ON ml.balance > 0 AND pr.credit_move_id = ml_future.id
+                    AND ml_future.date > %s
+            LEFT JOIN
                 account_move_line ml_past
                     ON ml.balance > 0 AND pr.credit_move_id = ml_past.id
                     AND ml_past.date <= %s
         """
         sub_query += """
-            LEFT JOIN account_full_reconcile afr ON afr.id = ml.full_reconcile_id
             WHERE
                 ra.report_id = %s
-            AND ml.full_reconcile_id IS NULL OR afr.create_date >= %s
             GROUP BY
                 ml.id,
                 ml.balance,
                 ml.amount_currency
+            HAVING
+                (
+                    ml.full_reconcile_id IS NULL
+                    OR MAX(ml_future.id) IS NOT NULL
+                )
         """
         return sub_query
 
@@ -607,20 +617,17 @@ ORDER BY
 ORDER BY
     a.code, ml.date, ml.id
             """
-        full_reconcile_date = fields.Datetime.to_string(
-            fields.Datetime.from_string(self.date_at) + timedelta(days=1))
         self.env.cr.execute(
             query_inject_move_line,
             (self.date_at,
-             self.id,
-             full_reconcile_date,
              self.date_at,
              self.id,
-             full_reconcile_date,
+             self.date_at,
+             self.date_at,
+             self.id,
              self.env.uid,
              self.id,
-             self.date_at,
-             )
+             self.date_at,)
         )
 
     def _compute_partners_and_accounts_cumul(self):


### PR DESCRIPTION
This reverts commit 3d5e66991892cec9995401e50c9018f5bbb0e127.

PR https://github.com/OCA/account-financial-reporting/pull/655/files was incorrect due to this line:
https://github.com/OCA/account-financial-reporting/pull/655/files#diff-c87a48df934f9645d23d82970b5a5c51c0fbf14b00a1ea48d8a9e64e57d4ae41R437

This will drive incorrect results in the open items reports when you report on a past date.

For example create the following journal entries that involve the account 'Accounts receivable':

- Entry 1 (01/01/2021)
- Entry 2 (03/01/2021)

Then match them today (21/05/2021).

If you run the report on 10/01/2021 the report will show Entry 1 and Entry 2 as open.
Only when you run the open items report with date 22/05/2021 will the entries disappear from the open items report because they have been matched.


