### PR TITLE
[13.0][IMP] account_financial_report: added 'auto sequence' option in Journal Ledger.

### DIFF
--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -24,6 +24,10 @@
   * Alexandre D. Díaz
 
 * Lois Rilo <lois.rilo@forgeflow.com>
+* `Sygel <https://www.sygel.es>`__:
+
+  * Harald Panten
+  * Valentin Vinagre
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -86,7 +86,7 @@ class JournalLedgerReport(models.AbstractModel):
     def _get_move_lines_order(self, move_ids, wizard, journal_ids):
         return ""
 
-    def _get_move_lines_data(self, ml, wizard, ml_taxes):
+    def _get_move_lines_data(self, ml, wizard, ml_taxes, auto_sequence):
         base_debit = (
             base_credit
         ) = tax_debit = tax_credit = base_balance = tax_balance = 0.0
@@ -118,6 +118,7 @@ class JournalLedgerReport(models.AbstractModel):
             "tax_credit": tax_credit,
             "base_balance": base_balance,
             "tax_balance": tax_balance,
+            "auto_sequence": str(auto_sequence).zfill(6),
         }
 
     def _get_account_data(self, accounts):
@@ -202,6 +203,7 @@ class JournalLedgerReport(models.AbstractModel):
         partners = self.env["res.partner"]
         currencies = self.env["res.currency"]
         tax_lines = self.env["account.tax"]
+        auto_sequence = len(move_ids)
         for ml in move_lines:
             if ml.account_id not in accounts:
                 accounts |= ml.account_id
@@ -213,13 +215,14 @@ class JournalLedgerReport(models.AbstractModel):
                 tax_lines |= ml.tax_line_id
             if ml.move_id.id not in Move_Lines.keys():
                 Move_Lines[ml.move_id.id] = []
+                auto_sequence -= 1
             taxes = (
                 ml.id in move_line_ids_taxes_data.keys()
                 and move_line_ids_taxes_data[ml.id]
                 or {}
             )
             Move_Lines[ml.move_id.id].append(
-                self._get_move_lines_data(ml, wizard, taxes)
+                self._get_move_lines_data(ml, wizard, taxes, auto_sequence)
             )
         account_ids_data = self._get_account_data(accounts)
         partner_ids_data = self._get_partner_data(partners)
@@ -350,6 +353,7 @@ class JournalLedgerReport(models.AbstractModel):
             "date_from": data["date_from"],
             "date_to": data["date_to"],
             "move_target": data["move_target"],
+            "with_auto_sequence": data["with_auto_sequence"],
             "account_ids_data": account_ids_data,
             "partner_ids_data": partner_ids_data,
             "currency_ids_data": currency_ids_data,

--- a/account_financial_report/report/journal_ledger_xlsx.py
+++ b/account_financial_report/report/journal_ledger_xlsx.py
@@ -27,6 +27,11 @@ class JournalLedgerXslx(models.AbstractModel):
             {"header": _("Account"), "field": "account_code", "width": 9},
         ]
 
+        if report.with_auto_sequence:
+            columns.insert(
+                0, {"header": _("Sequence"), "field": "auto_sequence", "width": 10}
+            )
+
         if report.with_account_name:
             columns.append(
                 {"header": _("Account Name"), "field": "account_name", "width": 15}
@@ -221,6 +226,7 @@ class JournalLedgerXslx(models.AbstractModel):
                 line["partner"] = self._get_partner_name(
                     line["partner_id"], partner_ids_data
                 )
+                line["auto_sequence"] = line["auto_sequence"]
                 line["account_code"] = account_code
                 line["account_name"] = account_name
                 line["currency_name"] = currency_name

--- a/account_financial_report/report/templates/journal_ledger.xml
+++ b/account_financial_report/report/templates/journal_ledger.xml
@@ -12,6 +12,7 @@
         </t>
     </template>
     <template id="report_journal_ledger_base">
+        <t t-set="with_auto_sequence" t-value="with_auto_sequence" />
         <t t-set="display_currency" t-value="foreign_currency" />
         <t t-set="display_account_name" t-value="with_account_name" />
         <t t-set="title">Journal Ledger - <t t-raw="company_name" /> - <t
@@ -87,13 +88,27 @@
             <t t-set="account_column_style">
                 width: 8.11%;
             </t>
-            <t t-set="label_column_style">
-                width: 38.92%;
+            <t t-if="not with_auto_sequence">
+                <t t-set="label_column_style">
+                    width: 38.92%;
+                </t>
+            </t>
+            <t t-else="">
+                <t t-set="label_column_style">
+                    width: 31.35%;
+                </t>
             </t>
         </t>
         <t t-else="">
-            <t t-set="account_column_style">
-                width: 23.78%;
+            <t t-if="not with_auto_sequence">
+                <t t-set="account_column_style">
+                    width: 23.78%;
+                </t>
+            </t>
+            <t t-else="">
+                <t t-set="account_column_style">
+                    width: 16.21%;
+                </t>
             </t>
             <t t-set="label_column_style">
                 width: 23.24%;
@@ -101,8 +116,18 @@
         </t>
         <div class="act_as_thead">
             <div class="act_as_row labels">
+                <t t-if="with_auto_sequence">
+                    <div
+                        class="act_as_cell first_column"
+                        name="entry"
+                        style="width: 7.57%;"
+                    >
+                        Sequence
+                    </div>
+                </t>
                 <div
-                    class="act_as_cell first_column"
+                    t-att-class="'act_as_cell' if with_auto_sequence else 'act_as_cell first_column'"
+                    class="act_as_cell"
                     name="entry"
                     style="width: 7.57%;"
                 >
@@ -150,6 +175,7 @@
     </template>
     <template id="account_financial_report.report_journal_ledger_journal_first_line">
         <div class="act_as_row lines">
+            <div class="act_as_cell" name="Sequence" />
             <div class="act_as_cell" name="entry" />
             <div class="act_as_cell" name="date" />
             <div class="act_as_cell" name="account" />
@@ -199,6 +225,9 @@
         </t>
     </template>
     <template id="account_financial_report.report_journal_move_line">
+        <div class="act_as_cell left" name="auto_sequence" t-if="with_auto_sequence">
+            <span t-if="display_move_info" t-esc="move_line['auto_sequence']" />
+        </div>
         <div class="act_as_cell left" name="entry">
             <t t-if="display_move_info">
                 <span

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -34,6 +34,7 @@ class JournalLedgerReportWizard(models.TransientModel):
         required=True,
     )
     with_account_name = fields.Boolean(default=False)
+    with_auto_sequence = fields.Boolean(string="Show Auto Sequence", default=False)
 
     @api.model
     def _get_move_targets(self):
@@ -108,6 +109,7 @@ class JournalLedgerReportWizard(models.TransientModel):
             "group_option": self.group_option,
             "with_account_name": self.with_account_name,
             "account_financial_report_lang": self.env.lang,
+            "with_auto_sequence": self.with_auto_sequence,
         }
 
     def _export(self, report_type):

--- a/account_financial_report/wizard/journal_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/journal_ledger_wizard_view.xml
@@ -31,6 +31,7 @@
                         <field name="group_option" />
                         <field name="foreign_currency" />
                         <field name="with_account_name" />
+                        <field name="with_auto_sequence" />
                     </group>
                     <group />
                 </group>


### PR DESCRIPTION
Added 'auto sequence' option in Ledger.
This option is necessary because in v.13 the Journal Ledger only shows the invoice number, but does not have a correlative sequence with versions prior to v.13.
The size of columns has also been changed for this new value.