### PR TITLE
[12.0][FIX] account_tax_balance: prevent multicompany glitch in tests

### DIFF
--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -168,7 +168,8 @@ class TestAccountTaxBalance(HttpCase):
         self.env['account.move'].create({
             'date': Date.context_today(self.env.user),
             'journal_id': self.env['account.journal'].search(
-                [('type', '=', 'bank')], limit=1).id,
+                [('type', '=', 'bank'),
+                 ('company_id', '=', self.env.user.company_id.id)], limit=1).id,
             'name': 'Test move',
             'line_ids': [(0, 0, {
                 'account_id': liquidity_account_id,


### PR DESCRIPTION
Prevent selecting a journal from another company, resulting in
UserError(_("Cannot create moves for different companies.")).
