### PR TITLE
[13.0][account_financial_report][fix] The aged and open items reports should ignore move lines with a zero balance

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -140,6 +140,9 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             move_line
             for move_line in move_lines
             if move_line["date"] <= date_at_object
+            and not float_is_zero(
+                move_line["debit"] - move_line["credit"], precision_digits=2
+            )
             and not float_is_zero(move_line["amount_residual"], precision_digits=2)
         ]
         for move_line in move_lines:

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -85,6 +85,9 @@ class OpenItemsReport(models.AbstractModel):
             move_line
             for move_line in move_lines
             if move_line["date"] <= date_at_object
+            and not float_is_zero(
+                move_line["debit"] - move_line["credit"], precision_digits=2
+            )
             and not float_is_zero(move_line["amount_residual"], precision_digits=2)
         ]
 

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -88,7 +88,13 @@ class OpenItemsReport(models.AbstractModel):
             and not float_is_zero(
                 move_line["debit"] - move_line["credit"], precision_digits=2
             )
-            and not float_is_zero(move_line["amount_residual"], precision_digits=2)
+            and (
+                not float_is_zero(move_line["amount_residual"], precision_digits=2)
+                or move_line["currency_id"]
+                and not float_is_zero(
+                    move_line["amount_residual_currency"], precision_digits=2
+                )
+            )
         ]
 
         open_items_move_lines_data = {}


### PR DESCRIPTION
Even when they have an amount residual.
Those entries can exist as a result of an exchange rate difference.