### PR TITLE
[14.0][FIX] account_financial_report: Incorrect format definition

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -73,17 +73,22 @@ class AbstractReportXslx(models.AbstractModel):
             ),
             "format_header_amount": workbook.add_format(
                 {"bold": True, "border": True, "bg_color": "#FFFFCC"}
-            ).set_num_format("#,##0." + "0" * currency_id.decimal_places),
-            "format_amount": workbook.add_format().set_num_format(
-                "#,##0." + "0" * currency_id.decimal_places
             ),
+            "format_amount": workbook.add_format(),
             "format_amount_bold": workbook.add_format({"bold": True}).set_num_format(
                 "#,##0." + "0" * currency_id.decimal_places
             ),
             "format_percent_bold_italic": workbook.add_format(
                 {"bold": True, "italic": True}
-            ).set_num_format("#,##0.00%"),
+            ),
         }
+        report_data["formats"]["format_amount"].set_num_format(
+            "#,##0." + "0" * currency_id.decimal_places
+        )
+        report_data["formats"]["format_header_amount"].set_num_format(
+            "#,##0." + "0" * currency_id.decimal_places
+        )
+        report_data["formats"]["format_percent_bold_italic"].set_num_format("#,##0.00%")
 
     def _set_column_width(self, report_data):
         """Set width for all defined columns.


### PR DESCRIPTION
The formats **format_amount**, **format_header_amount** and **format_percent_bold_italic** weren't saved correctly in the format's dictionary and when using them in a cell they didn't apply their style.