### PR TITLE
[13.0][account_financial_report][fix] display correct target_move in Trial Balance XLSX

### DIFF
--- a/account_financial_report/report/trial_balance_xlsx.py
+++ b/account_financial_report/report/trial_balance_xlsx.py
@@ -148,7 +148,7 @@ class TrialBalanceXslx(models.AbstractModel):
             [
                 _("Target moves filter"),
                 _("All posted entries")
-                if report.target_move == "all"
+                if report.target_move == "posted"
                 else _("All entries"),
             ],
             [


### PR DESCRIPTION
When you choose Target Moves = All entries it displays "Posted Entries" in the XLSX report and vice-versa.

cc @AaronHForgeFlow @AdriaGForgeFlow @LoisRForgeFlow @JordiMForgeFlow 