### PR TITLE
[13.0][FIX+IMP] mis_builder_cash_flow: Proper SQL expression + default for v13 + target moves

### DIFF
--- a/mis_builder_cash_flow/README.rst
+++ b/mis_builder_cash_flow/README.rst
@@ -43,6 +43,10 @@ To use this module, you need to:
 
 #. Go to Accounting > Reports > MIS Reporting > MIS Reports and choose "Cash Flow" report
 #. You can add forecast lines on Accounting > Reports > MIS Reporting > Cash Flow Forecast Line
+#. If you select on "Target Moves" the value "All Posted Entries", you will get only
+   lines for already posted invoices/entries + the forecast lines.
+#. Selecting "All Entries", draft invoices/entries are also included.
+#. In any case, cancelled invoices/entries are not included.
 
 Known issues / Roadmap
 ======================
@@ -75,6 +79,9 @@ Contributors
 * Juan José Scarafía <jjs@adhoc.com.ar>
 * Gonzalo Ruzafa <gr@adhoc.com.ar>
 * Alberto Martín <alberto.martin@guadaltech.es>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Pedro M. Baeza
 
 Maintainers
 ~~~~~~~~~~~

--- a/mis_builder_cash_flow/__manifest__.py
+++ b/mis_builder_cash_flow/__manifest__.py
@@ -1,4 +1,5 @@
 # Copyright 2019 ADHOC SA
+# Copyright 2021 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/mis_builder_cash_flow/models/__init__.py
+++ b/mis_builder_cash_flow/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 ADHOC SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from . import mis_cash_flow_forecast_line
 from . import account_account
+from . import mis_cash_flow_forecast_line
+from . import mis_report_instance

--- a/mis_builder_cash_flow/models/mis_cash_flow_forecast_line.py
+++ b/mis_builder_cash_flow/models/mis_cash_flow_forecast_line.py
@@ -23,7 +23,7 @@ class MisCashFlowForecastLine(models.Model):
         "res.company",
         string="Company",
         required=True,
-        default=lambda self: self.env.user.company_id.id,
+        default=lambda self: self.env.company,
         index=True,
     )
 

--- a/mis_builder_cash_flow/models/mis_report_instance.py
+++ b/mis_builder_cash_flow/models/mis_report_instance.py
@@ -1,0 +1,17 @@
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import models
+
+
+class MisReportInstancePeriod(models.Model):
+    _inherit = "mis.report.instance.period"
+
+    def _get_additional_move_line_filter(self):
+        """Add the posted condition ."""
+        domain = super()._get_additional_move_line_filter()
+        if (
+            self._get_aml_model_name() == "mis.cash_flow"
+            and self.report_instance_id.target_move == "posted"
+        ):
+            domain += [("state", "=", "posted")]
+        return domain

--- a/mis_builder_cash_flow/readme/CONTRIBUTORS.rst
+++ b/mis_builder_cash_flow/readme/CONTRIBUTORS.rst
@@ -1,3 +1,6 @@
 * Juan José Scarafía <jjs@adhoc.com.ar>
 * Gonzalo Ruzafa <gr@adhoc.com.ar>
 * Alberto Martín <alberto.martin@guadaltech.es>
+* `Tecnativa <https://www.tecnativa.com>`_:
+
+  * Pedro M. Baeza

--- a/mis_builder_cash_flow/readme/USAGE.rst
+++ b/mis_builder_cash_flow/readme/USAGE.rst
@@ -2,3 +2,7 @@ To use this module, you need to:
 
 #. Go to Accounting > Reports > MIS Reporting > MIS Reports and choose "Cash Flow" report
 #. You can add forecast lines on Accounting > Reports > MIS Reporting > Cash Flow Forecast Line
+#. If you select on "Target Moves" the value "All Posted Entries", you will get only
+   lines for already posted invoices/entries + the forecast lines.
+#. Selecting "All Entries", draft invoices/entries are also included.
+#. In any case, cancelled invoices/entries are not included.

--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -50,6 +50,12 @@ class MisCashFlow(models.Model):
     account_internal_type = fields.Selection(
         related="account_id.user_type_id.type", readonly=True
     )
+    state = fields.Selection(selection="_selection_parent_state",)
+
+    def _selection_parent_state(self):
+        return self.env["account.move"].fields_get(allfields=["state"])["state"][
+            "selection"
+        ]
 
     def init(self):
         query = """
@@ -75,6 +81,7 @@ class MisCashFlow(models.Model):
                 aml.partner_id as partner_id,
                 aml.company_id as company_id,
                 aml.name as name,
+                aml.parent_state as state,
                 COALESCE(aml.date_maturity, aml.date) as date
             FROM account_move_line as aml
             WHERE aml.parent_state != 'cancel'
@@ -99,6 +106,7 @@ class MisCashFlow(models.Model):
                 fl.partner_id as partner_id,
                 fl.company_id as company_id,
                 fl.name as name,
+                'posted' as state,
                 fl.date as date
             FROM mis_cash_flow_forecast_line as fl
         """

--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -57,7 +57,7 @@ class MisCashFlow(models.Model):
                 -- we use negative id to avoid duplicates and we don't use
                 -- ROW_NUMBER() because the performance was very poor
                 -aml.id as id,
-                CAST('move_line' AS varchar) as line_type,
+                'move_line' as line_type,
                 aml.id as move_line_id,
                 aml.account_id as account_id,
                 CASE
@@ -77,10 +77,11 @@ class MisCashFlow(models.Model):
                 aml.name as name,
                 COALESCE(aml.date_maturity, aml.date) as date
             FROM account_move_line as aml
+            WHERE aml.parent_state != 'cancel'
             UNION ALL
             SELECT
                 fl.id as id,
-                CAST('forecast_line' AS varchar) as line_type,
+                'forecast_line' as line_type,
                 NULL as move_line_id,
                 fl.account_id as account_id,
                 CASE

--- a/mis_builder_cash_flow/static/description/index.html
+++ b/mis_builder_cash_flow/static/description/index.html
@@ -394,6 +394,10 @@ The forecast is based on two types of date:</p>
 <ol class="arabic simple">
 <li>Go to Accounting &gt; Reports &gt; MIS Reporting &gt; MIS Reports and choose “Cash Flow” report</li>
 <li>You can add forecast lines on Accounting &gt; Reports &gt; MIS Reporting &gt; Cash Flow Forecast Line</li>
+<li>If you select on “Target Moves” the value “All Posted Entries”, you will get only
+lines for already posted invoices/entries + the forecast lines.</li>
+<li>Selecting “All Entries”, draft invoices/entries are also included.</li>
+<li>In any case, cancelled invoices/entries are not included.</li>
 </ol>
 </div>
 <div class="section" id="known-issues-roadmap">
@@ -424,6 +428,10 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <li>Juan José Scarafía &lt;<a class="reference external" href="mailto:jjs&#64;adhoc.com.ar">jjs&#64;adhoc.com.ar</a>&gt;</li>
 <li>Gonzalo Ruzafa &lt;<a class="reference external" href="mailto:gr&#64;adhoc.com.ar">gr&#64;adhoc.com.ar</a>&gt;</li>
 <li>Alberto Martín &lt;<a class="reference external" href="mailto:alberto.martin&#64;guadaltech.es">alberto.martin&#64;guadaltech.es</a>&gt;</li>
+<li><a class="reference external" href="https://www.tecnativa.com">Tecnativa</a>:<ul>
+<li>Pedro M. Baeza</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
- On v13, invoices are journal entries, so we have to explicitly exclude cancelled invoices from the expression. We leave draft ones, as they are good for forecasting.
- Default value for the company of the forecast line doesn't follow new specification, putting an incorrect value.
- Extra improvement: avoid a non needed casting of the fixed column type.

@Tecnativa TT30828