### PR TITLE
[13.0][partner_statement][fix] group by move line id in outstanding partner balance

### DIFF
--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -16,7 +16,7 @@ class OutstandingStatement(models.AbstractModel):
         return str(
             self._cr.mogrify(
                 """
-        SELECT m.name AS move_id, l.partner_id, l.date, l.name,
+        SELECT l.id, m.name AS move_id, l.partner_id, l.date, l.name,
             l.blocked, l.currency_id, l.company_id,
             CASE WHEN l.ref IS NOT NULL THEN l.ref ELSE m.ref END as ref,
             CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
@@ -83,7 +83,7 @@ class OutstandingStatement(models.AbstractModel):
               (pr.id IS NOT NULL AND pr.max_date <= %(date_end)s) OR
               (pr.id IS NULL)
             ) AND l.date <= %(date_end)s AND m.state IN ('posted')
-        GROUP BY l.partner_id, m.name, l.date, l.date_maturity, l.name,
+        GROUP BY l.id, l.partner_id, m.name, l.date, l.date_maturity, l.name,
             CASE WHEN l.ref IS NOT NULL THEN l.ref ELSE m.ref END,
             l.blocked, l.currency_id, l.balance, l.amount_currency, l.company_id
             """,


### PR DESCRIPTION
Otherwise in some cases the results are incorrect. In reality we do the grouping because a move line can have multiple partial reconciliations, and we sum them up into each move line.