### PR TITLE
[12.0][FIX] account_financial_report: limit scope of Trial Balance query within allowed account groups

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -391,6 +391,9 @@ AND ra.report_id = %s
 
     def _inject_account_group_values(self):
         """Inject report values for report_trial_balance_account"""
+        allowed_groups = self.env["account.group"].search([])
+        if not allowed_groups:
+            return
         query_inject_account_group = """
 INSERT INTO
     report_trial_balance_account
@@ -416,10 +419,14 @@ SELECT
     accgroup.code_prefix,
     accgroup.level
 FROM
-    account_group accgroup"""
+    account_group accgroup
+WHERE
+    accgroup.id in %s
+    """
         query_inject_account_params = (
             self.id,
             self.env.uid,
+            tuple(allowed_groups.ids),
         )
         self.env.cr.execute(query_inject_account_group,
                             query_inject_account_params)


### PR DESCRIPTION
This proposal is to fix a problem encountered while working on a customization project that required field company_id being added on account.group. Notice that such solution was also included in standard Odoo 14.0.
The problem is an access rights error that occurs because of the Trial Balance report query that actually reads all the existing account groups without respecting the read rights permissions.
This proposed solution first gets all the accessible records of account.group model and then use that id list in the query.