### PR TITLE
[14.0][FIX] account_financial_report: fix method parameter order

### DIFF
--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -185,8 +185,8 @@ class OpenItemsXslx(models.AbstractModel):
                 self.write_ending_balance_from_dict(
                     accounts_data[account_id],
                     type_object,
-                    report_data,
                     total_amount,
+                    report_data,
                     account_id,
                 )
 

--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -160,8 +160,8 @@ class OpenItemsXslx(models.AbstractModel):
                             type_object,
                             total_amount,
                             report_data,
-                            account_id,
-                            partner_id,
+                            account_id=account_id,
+                            partner_id=partner_id,
                         )
 
                         # Line break
@@ -187,7 +187,7 @@ class OpenItemsXslx(models.AbstractModel):
                     type_object,
                     total_amount,
                     report_data,
-                    account_id,
+                    account_id=account_id,
                 )
 
                 # 2 lines break


### PR DESCRIPTION
Fixes the order of the values passed to write_ending_balance_from_dict()