### PR TITLE
[14.0][FIX] account_financial_report: Print report with details

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -218,9 +218,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             "ref",
             "reconciled",
         ]
-        move_lines = self.env["account.move.line"].search_read(
-            domain=domain, fields=ml_fields
-        )
+        line_model = self.env["account.move.line"]
+        move_lines = line_model.search_read(domain=domain, fields=ml_fields)
         journals_ids = set()
         partners_ids = set()
         partners_data = {}
@@ -288,6 +287,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                     ref_label = move_line["ref"] + str(" - ") + move_line["name"]
                 move_line_data.update(
                     {
+                        "line_rec": line_model.browse(move_line["id"]),
                         "date": move_line["date"],
                         "entry": move_line["move_id"][1],
                         "jnl_id": move_line["journal_id"][0],

--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -249,7 +249,7 @@
                     <!--## date-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.id"
+                            t-att-res-id="line['line_rec'].id"
                             res-model="account.move.line"
                             view-type="form"
                         >
@@ -260,7 +260,7 @@
                     <!--## move-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.move_id.id"
+                            t-att-res-id="line['line_rec'].move_id.id"
                             res-model="account.move"
                             view-type="form"
                         >
@@ -270,7 +270,7 @@
                     <!--## journal-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.move_id.journal_id.id"
+                            t-att-res-id="line['line_rec'].move_id.journal_id.id"
                             res-model="account.journal"
                             view-type="form"
                         >
@@ -280,7 +280,7 @@
                     <!--## account code-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.account_id.id"
+                            t-att-res-id="line['line_rec'].account_id.id"
                             res-model="account.account"
                             view-type="form"
                         >
@@ -290,7 +290,7 @@
                     <!--## partner-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.partner_id.id"
+                            t-att-res-id="line['line_rec'].partner_id.id"
                             res-model="res.partner"
                             view-type="form"
                         >
@@ -300,7 +300,7 @@
                     <!--## ref - label-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.id"
+                            t-att-res-id="line['line_rec'].id"
                             res-model="account.move.line"
                             view-type="form"
                         >
@@ -310,7 +310,7 @@
                     <!--## date_due-->
                     <div class="act_as_cell left">
                         <span
-                            t-att-res-id="line.move_line_id.id"
+                            t-att-res-id="line['line_rec'].id"
                             res-model="account.move.line"
                             view-type="form"
                         >
@@ -324,7 +324,7 @@
                     <!--## amount_residual-->
                     <div class="act_as_cell amount">
                         <span
-                            domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                            domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                             res-model="account.move.line"
                         >
                             <t
@@ -335,15 +335,15 @@
                     </div>
                     <!--## current-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.current == 0">
+                        <t t-if="line['current'] == 0">
                             <span
-                                t-field="line.current"
+                                t-esc="line['current']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t
@@ -355,15 +355,15 @@
                     </div>
                     <!--## age_30_days-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.age_30_days == 0">
+                        <t t-if="line['30_days'] == 0">
                             <span
-                                t-field="line.age_30_days"
+                                t-esc="line['30_days']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t
@@ -375,15 +375,15 @@
                     </div>
                     <!--## age_60_days-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.age_60_days == 0">
+                        <t t-if="line['60_days'] == 0">
                             <span
-                                t-field="line.age_60_days"
+                                t-esc="line['60_days']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t
@@ -395,15 +395,15 @@
                     </div>
                     <!--## age_90_days-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.age_90_days == 0">
+                        <t t-if="line['90_days'] == 0">
                             <span
-                                t-field="line.age_90_days"
+                                t-esc="line['90_days']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t
@@ -415,15 +415,15 @@
                     </div>
                     <!--## age_120_days-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.age_120_days == 0">
+                        <t t-if="line['120_days'] == 0">
                             <span
-                                t-field="line.age_120_days"
+                                t-esc="line['120_days']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t
@@ -435,15 +435,15 @@
                     </div>
                     <!--## older-->
                     <div class="act_as_cell amount">
-                        <t t-if="line.older == 0">
+                        <t t-if="line['older'] == 0">
                             <span
-                                t-field="line.older"
+                                t-esc="line['older']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
                         </t>
                         <t t-else="">
                             <span
-                                domain="[('id', 'in', (line.move_line_id | line.move_line_id.matched_debit_ids.mapped('debit_move_id') | line.move_line_id.matched_credit_ids.mapped('credit_move_id')).ids)]"
+                                domain="[('id', 'in', (line['line_rec'] | line['line_rec'].matched_debit_ids.mapped('debit_move_id') | line['line_rec'].matched_credit_ids.mapped('credit_move_id')).ids)]"
                                 res-model="account.move.line"
                             >
                                 <t

--- a/account_financial_report/tests/__init__.py
+++ b/account_financial_report/tests/__init__.py
@@ -1,6 +1,7 @@
 # © 2016 Julien Coux (Camptocamp)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).-
 
+from . import test_aged_partner_balance
 from . import test_general_ledger
 from . import test_journal_ledger
 from . import test_open_items

--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -1,0 +1,34 @@
+#  Copyright 2021 Simone Rubino - Agile Business Group
+#  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo.tests import TransactionCase
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, test_reports
+
+
+class TestAgedPartnerBalance(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.wizard_model = self.env["aged.partner.balance.report.wizard"]
+
+    def test_report(self):
+        """Check that report is produced correctly."""
+        wizard = self.wizard_model.create(
+            {
+                "show_move_line_details": True,
+                "receivable_accounts_only": True,
+            }
+        )
+        wizard.onchange_type_accounts_only()
+        data = wizard._prepare_report_aged_partner_balance()
+
+        # Simulate web client behavior:
+        # default value is a datetime.date but web client sends back strings
+        data.update({"date_at": data["date_at"].strftime(DEFAULT_SERVER_DATE_FORMAT)})
+        result = test_reports.try_report(
+            self.env.cr,
+            self.env.uid,
+            "account_financial_report.aged_partner_balance",
+            wizard.ids,
+            data=data,
+        )
+        self.assertTrue(result)


### PR DESCRIPTION
**Steps to reproduce**
Same as https://github.com/OCA/account-financial-reporting/issues/808 but for `14.0`
1. Open Invoicing > Reporting > Aged Partner Balance
2. Check:
    - Show Move Line Details
    - Receivable Accounts Only
3. Click on View

**Actual behavior**
Error:
```
Error message:

Error to render compiling AST
AttributeError: 'dict' object has no attribute 'move_line_id'
Template: account_financial_report.report_aged_partner_balance_move_lines
Path: /t/div/t/div/div[1]/span
Node: <span t-att-res-id="line.move_line_id.id" res-model="account.move.line" view-type="form">
                            <!--## We don't use t-field because it throws an error on click -->
                            <t t-esc="line['date']" t-options="{'widget': 'date'}"/>
                        </span>
                    
The error occured while rendering the template account_financial_report.report_aged_partner_balance_move_lines and evaluating the following expression: <span t-att-res-id="line.move_line_id.id" res-model="account.move.line" view-type="form"> <!--## We don't use t-field because it throws an error on click --> <t t-esc="line['date']" t-options="{'widget': 'date'}"/> </span>
```

**Desired behavior**
Show the Aged partner balance

