### PR TITLE
[14.0][FIX] account_financial_reporting: wrong view_id

### DIFF
--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -103,7 +103,7 @@
         <field name="res_model">open.items.report.wizard</field>
         <field name="binding_model_id" ref="base.model_res_partner" />
         <field name="view_mode">form</field>
-        <field name="view_id" ref="general_ledger_wizard" />
+        <field name="view_id" ref="open_items_wizard" />
         <field
             name="context"
             eval="{


### PR DESCRIPTION
Set the correct `view_id` on `res.partner` action.