### PR TITLE
[14.0][FIX] account_financial_report: Filter column creation to have correct offset in Journal Ledger

### DIFF
--- a/account_financial_report/report/templates/journal_ledger.xml
+++ b/account_financial_report/report/templates/journal_ledger.xml
@@ -172,7 +172,9 @@
     </template>
     <template id="account_financial_report.report_journal_ledger_journal_first_line">
         <div class="act_as_row lines">
-            <div class="act_as_cell" name="Sequence" />
+            <t t-if="with_auto_sequence">
+                <div class="act_as_cell" name="Sequence" />
+            </t>
             <div class="act_as_cell" name="entry" />
             <div class="act_as_cell" name="date" />
             <div class="act_as_cell" name="account" />


### PR DESCRIPTION
Fixes https://github.com/OCA/account-financial-reporting/issues/815
Seems like a missing change from https://github.com/OCA/account-financial-reporting/commit/0e3b4d29722b9018b58d611b16af945279790265

@tv-openbig I could only reproduce the error in the Journal Ledger. Let me now the appropriate steps to reproduce it in other reports if that is the case.

@Tecnativa
ping @pedrobaeza @ValentinVinagre 