### PR TITLE
[13.0][FIX] account_financial_report: Truncate the displayed information and respect the width of the table in the report.

### DIFF
--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -137,588 +137,574 @@
         </div>
     </template>
     <template id="account_financial_report.report_general_ledger_lines">
-        <div class="act_as_table data_table" style="width: 100%;">
+        <div class="act_as_table data_table">
             <!-- Display table headers for lines -->
-            <div class="act_as_thead">
-                <div class="act_as_row labels">
-                    <!--## date-->
-                    <div class="act_as_cell first_column" style="width: 3.51%;">
-                        Date</div>
-                    <!--## move-->
-                    <div class="act_as_cell" style="width: 8.03%">Entry</div>
-                    <!--## journal-->
-                    <div class="act_as_cell" style="width: 4.13%;">Journal</div>
-                    <!--## account code-->
-                    <div class="act_as_cell" style="width: 4.75%;">Account</div>
-                    <!--## account code-->
-                    <div class="act_as_cell" style="width: 8.89%;">Taxes</div>
-                    <!--## partner-->
-                    <div class="act_as_cell" style="width: 12.01%;">Partner
-                    </div>
-                    <!--## ref - label-->
-                    <div class="act_as_cell" style="width: 16.9%;">Ref -
-                        Label</div>
-                    <t t-if="show_cost_center">
-                        <!--## cost_center-->
-                        <div
-                            class="act_as_cell"
-                            style="width: 8.03%;"
-                        >Analytic Account</div>
-                    </t>
-                    <t t-if="show_analytic_tags">
-                        <!--## analytic tags-->
-                        <div class="act_as_cell" style="width: 4.75%;">Tags</div>
-                    </t>
-                    <!--## matching_number-->
-                    <div class="act_as_cell" style="width: 2.41%;">Rec.</div>
-                    <!--## debit-->
-                    <div class="act_as_cell amount" style="width: 8.02%;">Debit</div>
-                    <!--## credit-->
-                    <div class="act_as_cell amount" style="width: 8.02%;">Credit</div>
-                    <!--## balance cumulated-->
-                    <div
-                        class="act_as_cell amount"
-                        style="width: 8.02%;"
-                    >Cumul. Bal.</div>
-                    <t t-if="foreign_currency">
-                        <!--## currency_name-->
-                        <div class="act_as_cell" style="width: 2.08%;">Cur.</div>
-                        <!--## amount_currency-->
-                        <div
-                            class="act_as_cell amount"
-                            style="width: 5.19%;"
-                        >Amount cur.</div>
-                    </t>
-                </div>
-            </div>
-            <!-- Display first line with initial balance -->
-            <div class="act_as_row lines">
-                <!--## date-->
-                <div class="act_as_cell" />
-                <!--## move-->
-                <div class="act_as_cell" />
-                <!--## journal-->
-                <div class="act_as_cell" />
-                <!--## account code-->
-                <div class="act_as_cell" />
-                <!--## taxes-->
-                <div class="act_as_cell" />
-                <!--## partner-->
-                <div class="act_as_cell" />
-                <!--## ref - label-->
-                <div class="act_as_cell amount">Initial balance</div>
-                <t t-if="show_cost_center">
-                    <!--## cost_center-->
-                    <div class="act_as_cell" />
-                </t>
-                <t t-if="show_analytic_tags">
-                    <!--## analytic tags-->
-                    <div class="act_as_cell" />
-                </t>
-                <!--## matching_number-->
-                <div class="act_as_cell" />
-                <!--## debit-->
-                <div class="act_as_cell amount">
-                    <t t-if="type == 'account_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=', account['id']),
-                                     ('date', '&lt;', date_from),
-                                     ('debit', '&lt;&gt;', 0)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                    <t t-if="type == 'partner_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=', account['id']),
-                                     ('partner_id', '=', partner['id']),
-                                     ('date', '&lt;', date_from),
-                                     ('debit', '&lt;&gt;', 0)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                </div>
-                <!--## credit-->
-                <div class="act_as_cell amount">
-                    <t t-if="type == 'account_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=',  account['id']),
-                                     ('date', '&lt;', date_from),
-                                     ('credit', '&lt;&gt;', 0)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                    <t t-if="type == 'partner_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=', account['id']),
-                                     ('partner_id', '=', partner['id']),
-                                     ('date', '&lt;', date_from),
-                                     ('credit', '&lt;&gt;', 0)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                </div>
-                <!--## balance cumulated-->
-                <div class="act_as_cell amount">
-                    <t t-if="type == 'account_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=', account['id']),
-                                     ('date', '&lt;', date_from)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                    <t t-if="type == 'partner_type'">
-                        <t
-                            t-set="domain"
-                            t-value="[('account_id', '=', account['id']),
-                                     ('partner_id', '=', partner['id']),
-                                     ('date', '&lt;', date_from)]"
-                        />
-                        <span t-att-domain="domain" res-model="account.move.line">
-                            <t
-                                t-raw="account_or_partner_object['init_bal']['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                            />
-                        </span>
-                    </t>
-                </div>
-                <t t-if="foreign_currency">
-                    <t
-                        t-if="o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
-                    >
-                        <div class="act_as_cell amount" style="width: 2.08%;">
-                            <span
-                                t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'currency_name')"
-                            />
-                        </div>
-                        <div class="act_as_cell amount" style="width: 5.19%;">
+            <table class="table_layout_fixed">
+                <thead>
+                    <tr>
+                        <!--## date-->
+                        <th style="width: 6%;">Date</th>
+                        <!--## move-->
+                        <th style="width: 8.03%">Entry</th>
+                        <!--## journal-->
+                        <th style="width: 4.13%;">Journal</th>
+                        <!--## account code-->
+                        <th style="width: 4.75%;">Account</th>
+                        <!--## taxes-->
+                        <th style="width: 6.89%;">Taxes</th>
+                        <!--## partner-->
+                        <th style="width: 12.01%;">Partner</th>
+                        <!--## ref - label-->
+                        <th style="width: 16.4%;">Ref -Label</th>
+                        <t t-if="show_cost_center">
+                            <!--## cost_center-->
+                            <th style="width: 8.03%;">Analytic Account</th>
+                        </t>
+                        <t t-if="show_analytic_tags">
+                            <!--## analytic tags-->
+                            <th style="width: 4.75%;">Tags</th>
+                        </t>
+                        <!--## matching_number-->
+                        <th style="width: 2.41%;">Rec.</th>
+                        <!--## debit-->
+                        <th style="width: 8.02%;">Debit</th>
+                        <!--## credit-->
+                        <th style="width: 8.02%;">Credit</th>
+                        <!--## balance cumulated-->
+                        <th style="width: 8.02%;">Cumul. Bal.</th>
+                        <t t-if="foreign_currency">
+                            <!--## currency_name-->
+                            <th style="width: 2.08%;">Cur.</th>
+                            <!--## amount_currency-->
+                            <th style="width: 5.19%;">Amount cur.</th>
+                        </t>
+                    </tr>
+                </thead>
+                <tbody>
+                    <!-- Display first line with initial balance -->
+                    <tr>
+                        <!--## date-->
+                        <td />
+                        <!--## move-->
+                        <td />
+                        <!--## journal-->
+                        <td />
+                        <!--## account code-->
+                        <td />
+                        <!--## taxes-->
+                        <td />
+                        <!--## partner-->
+                        <td />
+                        <!--## ref - label-->
+                        <td>Initial balance</td>
+                        <t t-if="show_cost_center">
+                            <!--## cost_center-->
+                            <td />
+                        </t>
+                        <t t-if="show_analytic_tags">
+                            <!--## analytic tags-->
+                            <td />
+                        </t>
+                        <!--## matching_number-->
+                        <td />
+                        <!--## debit-->
+                        <td>
                             <t t-if="type == 'account_type'">
                                 <t
                                     t-set="domain"
-                                    t-value="[('account_id', '=', account['id']),
-                                             ('date', '&lt;', o.date_from)]"
+                                    t-value="[('account_id', '=', account['id']),                                      ('date', '&lt;', date_from),                                      ('debit', '&lt;&gt;', 0)]"
                                 />
                                 <span
                                     t-att-domain="domain"
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-raw="account_or_partner_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                        t-raw="account_or_partner_object['init_bal']['debit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                     />
                                 </span>
                             </t>
                             <t t-if="type == 'partner_type'">
                                 <t
                                     t-set="domain"
-                                    t-value="[('account_id', '=', account['id']),
-                                             ('partner_id', '=', partner['id']),
-                                             ('date', '&lt;', o.date_from)]"
+                                    t-value="[('account_id', '=', account['id']),                                      ('partner_id', '=', partner['id']),                                      ('date', '&lt;', date_from),                                      ('debit', '&lt;&gt;', 0)]"
                                 />
                                 <span
                                     t-att-domain="domain"
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-raw="account_or_partner_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                        t-raw="account_or_partner_object['init_bal']['debit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                     />
                                 </span>
                             </t>
-                        </div>
-                    </t>
-                    <t
-                        t-if="not o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
-                    >
-                        <div class="act_as_cell" style="width: 2.08%;" />
-                        <div class="act_as_cell" style="width: 5.19%;" />
-                    </t>
-                </t>
-            </div>
-            <!-- Display each lines -->
-            <t t-foreach="account_or_partner_object['move_lines']" t-as="line">
-                <!-- # lines or centralized lines -->
-                <div class="act_as_row lines">
-                    <!--## date-->
-                    <div class="act_as_cell left">
-                        <t t-if="line['id']">
-                            <!--## We don't use t-field because it throws an error on click -->
-                            <span
-                                t-att-res-id="line['id']"
-                                res-model="account.move.line"
-                                view-type="form"
-                            >
+                        </td>
+                        <!--## credit-->
+                        <td>
+                            <t t-if="type == 'account_type'">
                                 <t
-                                    t-esc="line['date']"
-                                    t-options="{'widget': 'date'}"
+                                    t-set="domain"
+                                    t-value="[('account_id', '=',  account['id']),                                      ('date', '&lt;', date_from),                                      ('credit', '&lt;&gt;', 0)]"
                                 />
-                            </span>
-                        </t>
-                        <t t-else="">
-                            <span>
-                                <!--## We don't use t-field because it throws an error on click -->
-                                <t
-                                    t-esc="line['date']"
-                                    t-options="{'widget': 'date'}"
-                                />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## move-->
-                    <div class="act_as_cell left">
-                        <t t-if="line['entry_id']">
-                            <span
-                                t-att-res-id="line['entry_id']"
-                                res-model="account.move"
-                                view-type="form"
-                            >
-                                <t t-raw="line['entry']" />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## journal-->
-                    <div class="act_as_cell left">
-                        <span
-                            t-att-res-id="line['journal_id']"
-                            res-model="account.journal"
-                            view-type="form"
-                        >
-                            <t
-                                t-raw="o._get_atr_from_dict(line['journal_id'], journals_data, 'code')"
-                            />
-                        </span>
-                    </div>
-                    <!--## account code-->
-                    <div class="act_as_cell left">
-                        <span
-                            t-att-res-id="account['id']"
-                            res-model="account.account"
-                            view-type="form"
-                        >
-                            <t
-                                t-raw="o._get_atr_from_dict(account['id'], accounts_data, 'code')"
-                            />
-                        </span>
-                    </div>
-                    <!--## taxes-->
-                    <div class="act_as_cell left">
-                        <t t-if="taxes_data and line['tax_ids']">
-                            <t t-foreach="line['tax_ids']" t-as="tax_id">
                                 <span
-                                    t-esc="o._get_atr_from_dict(tax_id, taxes_data, 'tax_name')"
-                                />
-                            </t>
-                        </t>
-                    </div>
-                    <!--## partner-->
-                    <div class="act_as_cell left">
-                        <t t-if="line['partner_id']">
-                            <span
-                                t-att-res-id="line['partner_id']"
-                                res-model="res.partner"
-                                view-type="form"
-                            >
-                                <t t-raw="line['partner_name']" />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## ref - label-->
-                    <div class="act_as_cell left">
-                        <t t-if="line['id']">
-                            <span
-                                t-att-res-id="line['id']"
-                                res-model="account.move.line"
-                                view-type="form"
-                            >
-                                <t t-raw="line['ref_label']" />
-                            </span>
-                        </t>
-                        <t t-else="">
-                            <span>
-                                <t t-raw="line['ref_label']" />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## cost_center-->
-                    <t t-if="show_cost_center">
-                        <div class="act_as_cell left">
-                            <t t-if="line['analytic_account_id']">
-                                <span
-                                    t-att-res-id="line['analytic_account_id']"
-                                    res-model="account.analytic.account"
-                                    view-type="form"
+                                    t-att-domain="domain"
+                                    res-model="account.move.line"
                                 >
-                                    <t t-raw="line['analytic_account']" />
+                                    <t
+                                        t-raw="account_or_partner_object['init_bal']['credit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
                                 </span>
                             </t>
-                        </div>
-                    </t>
-                    <t t-if="show_analytic_tags">
-                        <!--## analytic tags-->
-                        <div class="act_as_cell left">
-                            <t t-if="line['tag_ids']">
-                                <t t-foreach="line['tag_ids']" t-as="tag_id">
-                                    <span
-                                        t-esc="o._get_atr_from_dict(tag_id, tags_data, 'name')"
+                            <t t-if="type == 'partner_type'">
+                                <t
+                                    t-set="domain"
+                                    t-value="[('account_id', '=', account['id']),                                      ('partner_id', '=', partner['id']),                                      ('date', '&lt;', date_from),                                      ('credit', '&lt;&gt;', 0)]"
+                                />
+                                <span
+                                    t-att-domain="domain"
+                                    res-model="account.move.line"
+                                >
+                                    <t
+                                        t-raw="account_or_partner_object['init_bal']['credit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                                     />
-                                </t>
+                                </span>
                             </t>
-                        </div>
-                    </t>
-                    <!--## matching_number-->
-                    <div class="act_as_cell">
-                        <t t-if="line['rec_id']">
-                            <span
-                                t-att-res-id="line['rec_id']"
-                                res-model="account.full.reconcile"
-                                view-type="form"
+                        </td>
+                        <!--## balance cumulated-->
+                        <td>
+                            <t t-if="type == 'account_type'">
+                                <t
+                                    t-set="domain"
+                                    t-value="[('account_id', '=', account['id']),                                      ('date', '&lt;', date_from)]"
+                                />
+                                <span
+                                    t-att-domain="domain"
+                                    res-model="account.move.line"
+                                >
+                                    <t
+                                        t-raw="account_or_partner_object['init_bal']['balance']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                            <t t-if="type == 'partner_type'">
+                                <t
+                                    t-set="domain"
+                                    t-value="[('account_id', '=', account['id']),                                      ('partner_id', '=', partner['id']),                                      ('date', '&lt;', date_from)]"
+                                />
+                                <span
+                                    t-att-domain="domain"
+                                    res-model="account.move.line"
+                                >
+                                    <t
+                                        t-raw="account_or_partner_object['init_bal']['balance']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                        </td>
+                        <t t-if="foreign_currency">
+                            <t
+                                t-if="o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
                             >
-                                <t t-raw="line['rec_name']" />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## debit-->
-                    <div class="act_as_cell amount">
-                        <t t-if="line['id']">
-                            <span
-                                t-att-res-id="line['id']"
-                                res-model="account.move.line"
-                                view-type="form"
+                                <td>
+                                    <span
+                                        t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'currency_name')"
+                                    />
+                                </td>
+                                <td>
+                                    <t t-if="type == 'account_type'">
+                                        <t
+                                            t-set="domain"
+                                            t-value="[('account_id', '=', account['id']),                                              ('date', '&lt;', o.date_from)]"
+                                        />
+                                        <span
+                                            t-att-domain="domain"
+                                            res-model="account.move.line"
+                                        >
+                                            <t
+                                                t-raw="account_or_partner_object['init_bal']['bal_curr']"
+                                                t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                            />
+                                        </span>
+                                    </t>
+                                    <t t-if="type == 'partner_type'">
+                                        <t
+                                            t-set="domain"
+                                            t-value="[('account_id', '=', account['id']),                                              ('partner_id', '=', partner['id']),                                              ('date', '&lt;', o.date_from)]"
+                                        />
+                                        <span
+                                            t-att-domain="domain"
+                                            res-model="account.move.line"
+                                        >
+                                            <t
+                                                t-raw="account_or_partner_object['init_bal']['bal_curr']"
+                                                t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                            />
+                                        </span>
+                                    </t>
+                                </td>
+                            </t>
+                            <t
+                                t-if="not o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
                             >
-                                <t
-                                    t-raw="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
+                                <td />
+                                <td />
+                            </t>
                         </t>
-                        <t t-else="">
-                            <span>
-                                <t
-                                    t-raw="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## credit-->
-                    <div class="act_as_cell amount">
-                        <t t-if="line['id']">
-                            <span
-                                t-att-res-id="line['id']"
-                                res-model="account.move.line"
-                                view-type="form"
-                            >
-                                <t
-                                    t-raw="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
-                        </t>
-                        <t t-else="">
-                            <span>
-                                <t
-                                    t-raw="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
-                        </t>
-                    </div>
-                    <!--## balance cumulated-->
-                    <div class="act_as_cell amount">
-                        <t t-if="line['id']">
-                            <span
-                                t-att-res-id="line['id']"
-                                res-model="account.move.line"
-                                view-type="form"
-                            >
-                                <t
-                                    t-raw="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
-                        </t>
-                        <t t-else="">
-                            <span>
-                                <t
-                                    t-raw="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                                />
-                            </span>
-                        </t>
-                    </div>
-                    <t t-if="foreign_currency">
-                        <t t-if="line['currency_id']">
-                            <!--## currency_name-->
-                            <div class="act_as_cell amount" style="width: 2.08%;">
-                                <span t-esc="line['currency_id'][1]" />
-                            </div>
-                            <!--## amount_currency-->
-                            <div class="act_as_cell amount" style="width: 5.19%;">
+                    </tr>
+                    <!-- Display each lines -->
+                    <tr t-foreach="account_or_partner_object['move_lines']" t-as="line">
+                        <!--## date-->
+                        <td>
+                            <t t-if="line['id']">
+                                <!--## We don't use t-field because it throws an error on click -->
                                 <span
                                     t-att-res-id="line['id']"
                                     res-model="account.move.line"
                                     view-type="form"
                                 >
-                                    <t t-raw="line['bal_curr']" />
+                                    <t
+                                        t-esc="line['date']"
+                                        t-options="{'widget': 'date'}"
+                                    />
                                 </span>
-                            </div>
+                            </t>
+                            <t t-else="">
+                                <span>
+                                    <!--## We don't use t-field because it throws an error on click -->
+                                    <t
+                                        t-esc="line['date']"
+                                        t-options="{'widget': 'date'}"
+                                    />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## move-->
+                        <td>
+                            <t t-if="line['entry_id']">
+                                <span
+                                    t-att-res-id="line['entry_id']"
+                                    res-model="account.move"
+                                    view-type="form"
+                                >
+                                    <t t-raw="line['entry']" />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## journal-->
+                        <td>
+                            <span
+                                t-att-res-id="line['journal_id']"
+                                res-model="account.journal"
+                                view-type="form"
+                            >
+                                <t
+                                    t-raw="o._get_atr_from_dict(line['journal_id'], journals_data, 'code')"
+                                />
+                            </span>
+                        </td>
+                        <!--## account code-->
+                        <td>
+                            <span
+                                t-att-res-id="account['id']"
+                                res-model="account.account"
+                                view-type="form"
+                            >
+                                <t
+                                    t-raw="o._get_atr_from_dict(account['id'], accounts_data, 'code')"
+                                />
+                            </span>
+                        </td>
+                        <!--## taxes-->
+                        <td>
+                            <t t-if="taxes_data and line['tax_ids']">
+                                <t t-foreach="line['tax_ids']" t-as="tax_id">
+                                    <span
+                                        t-esc="o._get_atr_from_dict(tax_id, taxes_data, 'tax_name')"
+                                    />
+                                </t>
+                            </t>
+                        </td>
+                        <!--## partner-->
+                        <td>
+                            <t t-if="line['partner_id']">
+                                <span
+                                    t-att-res-id="line['partner_id']"
+                                    res-model="res.partner"
+                                    view-type="form"
+                                >
+                                    <t t-raw="line['partner_name']" />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## ref - label-->
+                        <td>
+                            <t t-if="line['id']">
+                                <span
+                                    t-att-res-id="line['id']"
+                                    res-model="account.move.line"
+                                    view-type="form"
+                                >
+                                    <t t-raw="line['ref_label']" />
+                                </span>
+                            </t>
+                            <t t-else="">
+                                <span>
+                                    <t t-raw="line['ref_label']" />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## cost_center-->
+                        <t t-if="show_cost_center">
+                            <td>
+                                <t t-if="line['analytic_account_id']">
+                                    <span
+                                        t-att-res-id="line['analytic_account_id']"
+                                        res-model="account.analytic.account"
+                                        view-type="form"
+                                    >
+                                        <t t-raw="line['analytic_account']" />
+                                    </span>
+                                </t>
+                            </td>
                         </t>
-                        <t t-if="not line['currency_id']">
-                            <!--## currency_name-->
-                            <div class="act_as_cell amount" style="width: 2.08%;" />
-                            <!--## amount_currency-->
-                            <div class="act_as_cell amount" style="width: 5.19%;" />
+                        <!--## analytic tags-->
+                        <t t-if="show_analytic_tags">
+                            <td>
+                                <t t-if="line['tag_ids']">
+                                    <t t-foreach="line['tag_ids']" t-as="tag_id">
+                                        <span
+                                            t-esc="o._get_atr_from_dict(tag_id, tags_data, 'name')"
+                                        />
+                                    </t>
+                                </t>
+                            </td>
                         </t>
-                    </t>
-                </div>
-            </t>
+                        <!--## matching_number-->
+                        <td>
+                            <t t-if="line['rec_id']">
+                                <span
+                                    t-att-res-id="line['rec_id']"
+                                    res-model="account.full.reconcile"
+                                    view-type="form"
+                                >
+                                    <t t-raw="line['rec_name']" />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## debit-->
+                        <td>
+                            <t t-if="line['id']">
+                                <span
+                                    t-att-res-id="line['id']"
+                                    res-model="account.move.line"
+                                    view-type="form"
+                                >
+                                    <t
+                                        t-raw="line['debit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                            <t t-else="">
+                                <span>
+                                    <t
+                                        t-raw="line['debit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## credit-->
+                        <td>
+                            <t t-if="line['id']">
+                                <span
+                                    t-att-res-id="line['id']"
+                                    res-model="account.move.line"
+                                    view-type="form"
+                                >
+                                    <t
+                                        t-raw="line['credit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                            <t t-else="">
+                                <span>
+                                    <t
+                                        t-raw="line['credit']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                        </td>
+                        <!--## balance cumulated-->
+                        <td>
+                            <t t-if="line['id']">
+                                <span
+                                    t-att-res-id="line['id']"
+                                    res-model="account.move.line"
+                                    view-type="form"
+                                >
+                                    <t
+                                        t-raw="line['balance']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                            <t t-else="">
+                                <span>
+                                    <t
+                                        t-raw="line['balance']"
+                                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                                    />
+                                </span>
+                            </t>
+                        </td>
+                        <t t-if="foreign_currency">
+                            <t t-if="line['currency_id']">
+                                <!--## currency_name-->
+                                <td>
+                                    <span t-esc="line['currency_id'][1]" />
+                                </td>
+                                <!--## amount_currency-->
+                                <td>
+                                    <span
+                                        t-att-res-id="line['id']"
+                                        res-model="account.move.line"
+                                        view-type="form"
+                                    >
+                                        <t t-raw="line['bal_curr']" />
+                                    </span>
+                                </td>
+                            </t>
+                            <t t-if="not line['currency_id']">
+                                <!--## currency_name-->
+                                <td />
+                                <!--## amount_currency-->
+                                <td />
+                            </t>
+                        </t>
+                    </tr>
+                </tbody>
+            </table>
         </div>
     </template>
     <template id="account_financial_report.report_general_ledger_ending_cumul">
         <!-- Display ending balance line for account or partner -->
-        <div class="act_as_table list_table" style="width: 100%;">
-            <div class="act_as_row labels" style="font-weight: bold;">
-                <!--## date-->
-                <t t-if='type == "account_type"'>
-                    <div class="act_as_cell first_column" style="width: 41.32%;"><span
-                            t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'code')"
-                        /> - <span
-                            t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'name')"
-                        /></div>
-                    <div
-                        class="act_as_cell right"
-                        style="width: 16.9%;"
-                    >Ending balance</div>
-                </t>
-                <t t-if='type == "partner_type"'>
-                    <div class="act_as_cell first_column" style="width: 41.32%;" />
-                    <div
-                        class="act_as_cell right"
-                        style="width: 16.9%;"
-                    >Partner ending balance</div>
-                </t>
-                <t t-if="show_cost_center">
-                    <!--## cost_center-->
-                    <div class="act_as_cell" style="width: 8.03%" />
-                </t>
-                <t t-if="show_analytic_tags">
-                    <!--## analytic tags-->
-                    <div class="act_as_cell" style="width: 4.75%;" />
-                </t>
-                <!--## matching_number-->
-                <div class="act_as_cell" style="width: 2.41%;" />
-                <!--## debit-->
-                <div class="act_as_cell amount" style="width: 8.02%;">
-                    <span
-                        t-esc="account_or_partner_object['fin_bal']['debit']"
-                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                    />
-                </div>
-                <!--## credit-->
-                <div class="act_as_cell amount" style="width: 8.02%;">
-                    <span
-                        t-esc="account_or_partner_object['fin_bal']['credit']"
-                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                    />
-                </div>
-                <!--## balance cumulated-->
-                <div class="act_as_cell amount" style="width: 8.02%;">
-                    <span
-                        t-esc="account_or_partner_object['fin_bal']['balance']"
-                        t-options="{'widget': 'monetary', 'display_currency': company_currency}"
-                    />
-                </div>
-                <!--## currency_name + amount_currency-->
-                <t t-if="foreign_currency">
-                    <t
-                        t-if="o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
-                    >
-                        <div class="act_as_cell amount" style="width: 2.08%;">
+        <div class="act_as_table data_table">
+            <table class="table_layout_fixed">
+                <tfoot>
+                    <tr>
+                        <!--## date-->
+                        <t t-if="type == &quot;account_type&quot;">
+                            <td style="width: 41.32%;"><span
+                                    t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'code')"
+                                /> - <span
+                                    t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'name')"
+                                /></td>
+                            <td style="width: 16.9%;">Ending balance</td>
+                        </t>
+                        <t t-if="type == &quot;partner_type&quot;">
+                            <td style="width: 41.32%;" />
+                            <td style="width: 16.9%;">Partner ending balance</td>
+                        </t>
+                        <t t-if="show_cost_center">
+                            <!--## cost_center-->
+                            <td style="width: 8.03%" />
+                        </t>
+                        <t t-if="show_analytic_tags">
+                            <!--## analytic tags-->
+                            <td style="width: 4.75%;" />
+                        </t>
+                        <!--## matching_number-->
+                        <td style="width: 2.41%;" />
+                        <!--## debit-->
+                        <td style="width: 8.02%;">
                             <span
-                                t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'currency_name')"
+                                t-esc="account_or_partner_object['fin_bal']['debit']"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
                             />
-                        </div>
-                        <div class="act_as_cell amount" style="width: 5.19%;">
-                            <t t-if="type == 'account_type'">
-                                <t
-                                    t-set="domain"
-                                    t-value="[('account_id', '=', account['id']),
-                                             ('date', '&lt;', date_from)]"
-                                />
-                                <span>
-                                    <a
-                                        t-att-data-t-att-domain="domain"
-                                        t-att-data-res-model="'account.move.line'"
-                                        class="o_account_financial_reports_web_action_monetary_multi"
-                                        style="color: black;"
-                                    >
+                        </td>
+                        <!--## credit-->
+                        <td style="width: 8.02%;">
+                            <span
+                                t-esc="account_or_partner_object['fin_bal']['credit']"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                            />
+                        </td>
+                        <!--## balance cumulated-->
+                        <td style="width: 8.02%;">
+                            <span
+                                t-esc="account_or_partner_object['fin_bal']['balance']"
+                                t-options="{'widget': 'monetary', 'display_currency': company_currency}"
+                            />
+                        </td>
+                        <!--## currency_name + amount_currency-->
+                        <t t-if="foreign_currency">
+                            <t
+                                t-if="o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
+                            >
+                                <td style="width: 2.08%;">
+                                    <span
+                                        t-esc="o._get_atr_from_dict(account['id'], accounts_data, 'currency_name')"
+                                    />
+                                </td>
+                                <td style="width: 5.19%;">
+                                    <t t-if="type == 'account_type'">
                                         <t
-                                            t-raw="account_or_partner_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                            t-set="domain"
+                                            t-value="[('account_id', '=', account['id']),                                              ('date', '&lt;', date_from)]"
                                         />
-                                    </a>
-                                </span>
-                            </t>
-                            <t t-if="type == 'partner_type'">
-                                <t
-                                    t-set="domain"
-                                    t-value="[('account_id', '=', account['id']),
-                                             ('partner_id', '=', partner['id']),
-                                             ('date', '&lt;', date_from)]"
-                                />
-                                <span>
-                                    <a
-                                        t-att-data-t-att-domain="domain"
-                                        t-att-data-res-model="'account.move.line'"
-                                        class="o_account_financial_reports_web_action_monetary_multi"
-                                        style="color: black;"
-                                    >
+                                        <span>
+                                            <a
+                                                t-att-data-t-att-domain="domain"
+                                                t-att-data-res-model="'account.move.line'"
+                                                class="o_account_financial_reports_web_action_monetary_multi"
+                                                style="color: black;"
+                                            >
+                                                <t
+                                                    t-raw="account_or_partner_object['fin_bal']['bal_curr']"
+                                                    t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                                />
+                                            </a>
+                                        </span>
+                                    </t>
+                                    <t t-if="type == 'partner_type'">
                                         <t
-                                            t-raw="account_or_partner_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                            t-set="domain"
+                                            t-value="[('account_id', '=', account['id']),                                              ('partner_id', '=', partner['id']),                                              ('date', '&lt;', date_from)]"
                                         />
-                                    </a>
-                                </span>
+                                        <span>
+                                            <a
+                                                t-att-data-t-att-domain="domain"
+                                                t-att-data-res-model="'account.move.line'"
+                                                class="o_account_financial_reports_web_action_monetary_multi"
+                                                style="color: black;"
+                                            >
+                                                <t
+                                                    t-raw="account_or_partner_object['fin_bal']['bal_curr']"
+                                                    t-options="{'widget': 'monetary', 'display_currency': o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')}"
+                                                />
+                                            </a>
+                                        </span>
+                                    </t>
+                                </td>
                             </t>
-                        </div>
-                    </t>
-                    <t
-                        t-if="not o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
-                    >
-                        <div class="act_as_cell amount" style="width: 2.08%;" />
-                        <div class="act_as_cell amount" style="width: 5.19%;" />
-                    </t>
-                </t>
-            </div>
+                            <t
+                                t-if="not o._get_atr_from_dict(account['id'], accounts_data, 'currency_id')"
+                            >
+                                <td style="width: 2.08%;" />
+                                <td style="width: 5.19%;" />
+                            </t>
+                        </t>
+                    </tr>
+                </tfoot>
+            </table>
         </div>
     </template>
 </odoo>

--- a/account_financial_report/static/src/css/report.css
+++ b/account_financial_report/static/src/css/report.css
@@ -111,3 +111,22 @@
     margin-left: auto;
     font-family: Helvetica, Arial;
 }
+/*table_layout_fixed*/
+.table_layout_fixed {
+    table-layout: fixed;
+    width: 100%;
+}
+.table_layout_fixed thead,
+.table_layout_fixed tfoot {
+    background-color: #f0f0f0 !important;
+}
+.table_layout_fixed th,
+.table_layout_fixed td {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.table_layout_fixed thead th,
+.table_layout_fixed tbody td {
+    border: 1px solid lightGrey;
+}


### PR DESCRIPTION
Truncate the displayed information and respect the width of the table in the report.

Before
![antes](https://user-images.githubusercontent.com/4117568/142596367-4d63c6f0-cbb9-46ee-a328-18441f3111eb.png)

After
![despues](https://user-images.githubusercontent.com/4117568/142596384-113b3e98-1acf-4d70-9c99-573c83cbb049.png)

I have previously tried not to completely change the report so that the text would be truncated but I have not found a better solution; therefore I have modified the code to change it to a table using this example: http://jsfiddle.net/Curry/jmm3yr0z/

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT32557