### PR TITLE
[IMP] add recompute button to reports

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, fields, api
+from odoo.tools.safe_eval import safe_eval
+from odoo.tools import pycompat
 
 
 class AgedPartnerBalanceReport(models.TransientModel):
@@ -196,6 +198,22 @@ class AgedPartnerBalanceReportCompute(models.TransientModel):
             [('report_name', '=', report_name),
              ('report_type', '=', report_type)], limit=1)
         return report.report_action(self, config=False)
+
+    @api.multi
+    def recompute_report(self):
+        self.ensure_one()
+        self.account_ids.unlink()
+        self.compute_data_for_report()
+        action = self.env.ref(
+            'account_financial_report.action_report_aged_partner_balance')
+        vals = action.read()[0]
+        ctx = vals.get('context', {})
+        if isinstance(ctx, pycompat.string_types):
+            ctx = safe_eval(ctx)
+        ctx['active_id'] = self.id
+        ctx['active_ids'] = self.ids
+        vals['context'] = ctx
+        return vals
 
     def _get_html(self):
         result = {}

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models, fields, api
+from odoo.tools.safe_eval import safe_eval
+from odoo.tools import pycompat
 from odoo.tools import float_is_zero
 
 
@@ -213,6 +215,22 @@ class TrialBalanceReportCompute(models.TransientModel):
             [('report_name', '=', report_name),
              ('report_type', '=', report_type)],
             limit=1).report_action(self, config=False)
+
+    @api.multi
+    def recompute_report(self):
+        self.ensure_one()
+        self.account_ids.unlink()
+        self.compute_data_for_report()
+        action = self.env.ref(
+            'account_financial_report.action_report_trial_balance')
+        vals = action.read()[0]
+        ctx = vals.get('context', {})
+        if isinstance(ctx, pycompat.string_types):
+            ctx = safe_eval(ctx)
+        ctx['active_id'] = self.id
+        ctx['active_ids'] = self.ids
+        vals['context'] = ctx
+        return vals
 
     def _get_html(self):
         result = {}

--- a/account_financial_report/static/src/js/account_financial_report_backend.js
+++ b/account_financial_report/static/src/js/account_financial_report_backend.js
@@ -14,6 +14,7 @@ odoo.define('account_financial_report.account_financial_report_backend', functio
         events: {
             'click .o_account_financial_reports_print': 'print',
             'click .o_account_financial_reports_export': 'export',
+            'click .o_account_financial_reports_recompute': 'recompute',
         },
         init: function (parent, action) {
             this.actionManager = parent;
@@ -99,6 +100,17 @@ odoo.define('account_financial_report.account_financial_report_backend', functio
                 context: self.odoo_context,
             }).then(function (result) {
                 self.do_action(result);
+            });
+        },
+        recompute: function () {
+            var self = this;
+            this._rpc({
+                model: this.given_context.model,
+                method: 'recompute_report',
+                args: [this.given_context.active_id],
+                context: self.odoo_context,
+            }).then(function () {
+                location.reload();
             });
         },
         canBeRemoved: function () {

--- a/account_financial_report/view/report_template.xml
+++ b/account_financial_report/view/report_template.xml
@@ -16,6 +16,7 @@
         <div class="button_row">
             <button class="o_account_financial_reports_print btn btn-sm oe_button"><span class="fa fa-print"/> Print</button>
             <button class="o_account_financial_reports_export btn btn-sm oe_button"><span class="fa fa-download"/> Export</button>
+            <button class="o_account_financial_reports_recompute btn btn-sm oe_button"><span class="fa fa-refresh"/> Reload</button>
         </div>
     </template>
 


### PR DESCRIPTION
Sometimes it is useful to recompute the same report after changing
some entries. With recompute button it is possible without the need
to use the wizard, which requires to configure the report again.