### PR TITLE
[IMP] account_move_line_report_xls: Add missing description for report model

### DIFF
--- a/account_move_line_report_xls/report/account_move_line_xlsx.py
+++ b/account_move_line_report_xls/report/account_move_line_xlsx.py
@@ -19,6 +19,7 @@ IR_TRANSLATION_NAME = "move.line.list.xls"
 class AccountMoveLineXlsx(models.AbstractModel):
     _name = "report.account_move_line_report_xls.account_move_line_xlsx"
     _inherit = "report.report_xlsx.abstract"
+    _description = "XLSX report for account move lines."
 
     def _(self, src):
         lang = self.env.context.get("lang", "en_US")


### PR DESCRIPTION
Otherwise the following warning is raised:
WARNING openerp_test odoo.models: The model report.account_move_line_report_xls.account_move_line_xlsx has no _description

latest occurrence in `14.0`: https://runbot2-3.odoo-community.org/runbot/static/build/3520123-14-0-1bf577/logs/job_20_test_all.txt