### PR TITLE
[FIX][14.0] partner-statement: Remove need to groupby on amount_currency in Activity Statement

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -18,14 +18,14 @@ class ActivityStatement(models.AbstractModel):
             self._cr.mogrify(
                 """
             SELECT l.partner_id, l.currency_id, l.company_id,
-            CASE WHEN l.currency_id is not null AND l.amount_currency > 0.0
-                THEN sum(l.amount_currency)
-                ELSE sum(l.debit)
-            END as debit,
-            CASE WHEN l.currency_id is not null AND l.amount_currency < 0.0
-                THEN sum(l.amount_currency * (-1))
-                ELSE sum(l.credit)
-            END as credit
+            sum(CASE WHEN l.currency_id is not null AND l.amount_currency > 0.0
+                THEN l.amount_currency
+                ELSE l.debit
+            END) as debit,
+            sum(CASE WHEN l.currency_id is not null AND l.amount_currency < 0.0
+                THEN l.amount_currency * (-1)
+                ELSE l.credit
+            END) as credit
             FROM account_move_line l
             JOIN account_account aa ON (aa.id = l.account_id)
             JOIN account_account_type at ON (at.id = aa.user_type_id)
@@ -34,7 +34,7 @@ class ActivityStatement(models.AbstractModel):
                 AND at.type = %(account_type)s
                 AND l.date < %(date_start)s AND not l.blocked
                 AND m.state IN ('posted')
-            GROUP BY l.partner_id, l.currency_id, l.amount_currency, l.company_id
+            GROUP BY l.partner_id, l.currency_id, l.company_id
         """,
                 locals(),
             ),
@@ -94,14 +94,14 @@ class ActivityStatement(models.AbstractModel):
                     ELSE ''
                 END as ref,
                 l.blocked, l.currency_id, l.company_id,
-                CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
-                    THEN sum(l.amount_currency)
-                    ELSE sum(l.debit)
-                END as debit,
-                CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
-                    THEN sum(l.amount_currency * (-1))
-                    ELSE sum(l.credit)
-                END as credit,
+                sum(CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
+                    THEN l.amount_currency
+                    ELSE l.debit
+                END) as debit,
+                sum(CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
+                    THEN l.amount_currency * (-1)
+                    ELSE l.credit
+                END) as credit,
                 CASE WHEN l.date_maturity is null
                     THEN l.date
                     ELSE l.date_maturity
@@ -130,7 +130,7 @@ class ActivityStatement(models.AbstractModel):
                         THEN 'Payment'
                     ELSE ''
                 END,
-                l.blocked, l.currency_id, l.amount_currency, l.company_id
+                l.blocked, l.currency_id, l.company_id
         """,
                 locals(),
             ),


### PR DESCRIPTION
By aggregating before the case statement there is no need to group by amount_currency.

In earlier versions of Odoo this bug only presented in multicurrency transactions as company currency transactions
would have an amount_currency of 0.0 and group by 0.0 just fine.

In later versions of Odoo amount_currency is always set and this causes otherwise identical move lines
that should be summed to display seperately. However, amount_currency was required in groupby because it
was part of a non aggregated case statement with the sum inside.

By reversing the nesting we remove the need to group by amount_currency. This is safe because we already group by
currency_id and aggregates are not evaluated until after group by completes.