### PR TITLE
[14.0][FIX] account_financial_report: sort based partner name in open_items report

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -197,7 +197,7 @@ class OpenItemsReport(models.AbstractModel):
 
     @api.model
     def _order_open_items_by_date(
-        self, open_items_move_lines_data, show_partner_details
+        self, open_items_move_lines_data, show_partner_details, partners_data
     ):
         new_open_items = {}
         if not show_partner_details:
@@ -212,7 +212,10 @@ class OpenItemsReport(models.AbstractModel):
         else:
             for acc_id in open_items_move_lines_data.keys():
                 new_open_items[acc_id] = {}
-                for prt_id in open_items_move_lines_data[acc_id]:
+                for prt_id in sorted(
+                    open_items_move_lines_data[acc_id],
+                    key=lambda i: partners_data[i]["name"],
+                ):
                     new_open_items[acc_id][prt_id] = {}
                     move_lines = []
                     for move_line in open_items_move_lines_data[acc_id][prt_id]:
@@ -250,7 +253,7 @@ class OpenItemsReport(models.AbstractModel):
 
         total_amount = self._calculate_amounts(open_items_move_lines_data)
         open_items_move_lines_data = self._order_open_items_by_date(
-            open_items_move_lines_data, show_partner_details
+            open_items_move_lines_data, show_partner_details, partners_data
         )
         return {
             "doc_ids": [wizard_id],


### PR DESCRIPTION
**open_items** report do not display account partners in alphabetical order.

this PR will fix it ordering based partner name.