### PR TITLE
[13.0][FIX] account_financial_report: open_items

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -90,11 +90,29 @@ class AbstractReport(models.AbstractModel):
         for move_line in move_lines:
             ml_id = move_line["id"]
             if ml_id in debit_ids:
-                move_line["amount_residual"] += debit_amount[ml_id]
-                move_line["amount_residual_currency"] += debit_amount_currency[ml_id]
+                if move_line.get("amount_residual", False):
+                    move_line["amount_residual"] += debit_amount[ml_id]
+                else:
+                    move_line["amount_residual"] = debit_amount[ml_id]
+                if move_line.get("amount_residual_currency", False):
+                    move_line["amount_residual_currency"] += debit_amount_currency[
+                        ml_id
+                    ]
+                else:
+                    move_line["amount_residual_currency"] = debit_amount_currency[ml_id]
             if ml_id in credit_ids:
-                move_line["amount_residual_currency"] += credit_amount_currency[ml_id]
-                move_line["amount_residual"] -= credit_amount[ml_id]
+                if move_line.get("amount_residual", False):
+                    move_line["amount_residual"] -= credit_amount[ml_id]
+                else:
+                    move_line["amount_residual"] = -credit_amount[ml_id]
+                if move_line.get("amount_residual_currency", False):
+                    move_line["amount_residual_currency"] -= credit_amount_currency[
+                        ml_id
+                    ]
+                else:
+                    move_line["amount_residual_currency"] = -credit_amount_currency[
+                        ml_id
+                    ]
         return move_lines
 
     def _get_accounts_data(self, accounts_ids):

--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -68,6 +68,8 @@ class AbstractReport(models.AbstractModel):
         company_id,
         partner_ids,
         only_posted_moves,
+        debit_amount_currency,
+        credit_amount_currency,
     ):
         debit_ids = set(debit_ids)
         credit_ids = set(credit_ids)
@@ -89,7 +91,9 @@ class AbstractReport(models.AbstractModel):
             ml_id = move_line["id"]
             if ml_id in debit_ids:
                 move_line["amount_residual"] += debit_amount[ml_id]
+                move_line["amount_residual_currency"] += debit_amount_currency[ml_id]
             if ml_id in credit_ids:
+                move_line["amount_residual_currency"] += credit_amount_currency[ml_id]
                 move_line["amount_residual"] -= credit_amount[ml_id]
         return move_lines
 

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -70,25 +70,41 @@ class AgedPartnerBalanceReport(models.AbstractModel):
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
-        fields = ["debit_move_id", "credit_move_id", "amount"]
+        fields = ["debit_move_id", "credit_move_id", "amount", "amount_currency"]
         accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
             domain=domain, fields=fields
         )
         debit_amount = {}
+        debit_amount_currency = {}
         credit_amount = {}
+        credit_amount_currency = {}
         for account_partial_reconcile_data in accounts_partial_reconcile:
             debit_move_id = account_partial_reconcile_data["debit_move_id"][0]
             credit_move_id = account_partial_reconcile_data["credit_move_id"][0]
             if debit_move_id not in debit_amount.keys():
                 debit_amount[debit_move_id] = 0.0
+                debit_amount_currency[debit_move_id] = 0.0
+            debit_amount_currency[debit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             debit_amount[debit_move_id] += account_partial_reconcile_data["amount"]
             if credit_move_id not in credit_amount.keys():
                 credit_amount[credit_move_id] = 0.0
+                credit_amount_currency[credit_move_id] = 0.0
             credit_amount[credit_move_id] += account_partial_reconcile_data["amount"]
+            credit_amount_currency[credit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             account_partial_reconcile_data.update(
                 {"debit_move_id": debit_move_id, "credit_move_id": credit_move_id}
             )
-        return accounts_partial_reconcile, debit_amount, credit_amount
+        return (
+            accounts_partial_reconcile,
+            debit_amount,
+            credit_amount,
+            debit_amount_currency,
+            credit_amount_currency,
+        )
 
     def _get_move_lines_data(
         self,
@@ -115,6 +131,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 acc_partial_rec,
                 debit_amount,
                 credit_amount,
+                debit_amount_currency,
+                credit_amount_currency,
             ) = self._get_account_partial_reconciled(company_id, date_at_object)
             if acc_partial_rec:
                 ml_ids = list(map(operator.itemgetter("id"), move_lines))
@@ -135,6 +153,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                     company_id,
                     partner_ids,
                     only_posted_moves,
+                    debit_amount_currency,
+                    credit_amount_currency,
                 )
         move_lines = [
             move_line

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -16,25 +16,41 @@ class OpenItemsReport(models.AbstractModel):
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
-        fields = ["debit_move_id", "credit_move_id", "amount"]
+        fields = ["debit_move_id", "credit_move_id", "amount", "amount_currency"]
         accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
             domain=domain, fields=fields
         )
         debit_amount = {}
+        debit_amount_currency = {}
         credit_amount = {}
+        credit_amount_currency = {}
         for account_partial_reconcile_data in accounts_partial_reconcile:
             debit_move_id = account_partial_reconcile_data["debit_move_id"][0]
             credit_move_id = account_partial_reconcile_data["credit_move_id"][0]
             if debit_move_id not in debit_amount.keys():
                 debit_amount[debit_move_id] = 0.0
+                debit_amount_currency[debit_move_id] = 0.0
             debit_amount[debit_move_id] += account_partial_reconcile_data["amount"]
+            debit_amount_currency[debit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             if credit_move_id not in credit_amount.keys():
                 credit_amount[credit_move_id] = 0.0
+                credit_amount_currency[credit_move_id] = 0.0
             credit_amount[credit_move_id] += account_partial_reconcile_data["amount"]
+            credit_amount_currency[credit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             account_partial_reconcile_data.update(
                 {"debit_move_id": debit_move_id, "credit_move_id": credit_move_id}
             )
-        return accounts_partial_reconcile, debit_amount, credit_amount
+        return (
+            accounts_partial_reconcile,
+            debit_amount,
+            credit_amount,
+            debit_amount_currency,
+            credit_amount_currency,
+        )
 
     def _get_data(
         self,
@@ -60,6 +76,8 @@ class OpenItemsReport(models.AbstractModel):
                 acc_partial_rec,
                 debit_amount,
                 credit_amount,
+                debit_amount_currency,
+                credit_amount_currency,
             ) = self._get_account_partial_reconciled(company_id, date_at_object)
             if acc_partial_rec:
                 ml_ids = list(map(operator.itemgetter("id"), move_lines))
@@ -80,6 +98,8 @@ class OpenItemsReport(models.AbstractModel):
                     company_id,
                     partner_ids,
                     only_posted_moves,
+                    debit_amount_currency,
+                    credit_amount_currency,
                 )
         move_lines = [
             move_line


### PR DESCRIPTION
Fixed the amount_residual_currency on partial reconcile

The amount_residual_currency shown is now is the actual amount_residual_currency, it is not taking into account the partial reconciled records.

@ForgeFlow

Updated:

In order to reproduce the error please do:

1. Create an invoice for a different currency in 2021
2. Create a payment in 2022
3. Run the open items report at the end of 2021

The amount residual is correct but the amount residual currency is incorrect

