### PR TITLE
[15.0][FIX] account_tax_balance: Recompute balance for different dates

### DIFF
--- a/account_tax_balance/models/account_tax.py
+++ b/account_tax_balance/models/account_tax.py
@@ -81,6 +81,12 @@ class AccountTax(models.Model):
         ids_with_moves = self._account_tax_ids_with_moves()
         return [("id", "in", ids_with_moves)]
 
+    @api.depends_context(
+        "from_date",
+        "to_date",
+        "company_ids",
+        "target_move",
+    )
     def _compute_balance(self):
         for tax in self:
             tax.balance_regular = tax.compute_balance(


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-financial-reporting/pull/836.

_Suggested by @AaronHForgeFlow in https://github.com/OCA/account-financial-reporting/issues/836#issuecomment-1024268029_:
> @SimoRubi can you please forward fort this to 15.0?

