### PR TITLE
14.0 fix null error partner statement xlsx

### DIFF
--- a/partner_statement/report/outstanting_statement_xlsx.py
+++ b/partner_statement/report/outstanting_statement_xlsx.py
@@ -60,11 +60,11 @@ class OutstandingStatementXslx(models.AbstractModel):
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:
-                    if (line.get("name", "") in line.get("ref", "")) or (
+                    if (line.get("ref", "") in line.get("name", "")) or (
                         line.get("name", "") == line.get("ref", "")
                     ):
                         name_to_show = line.get("name", "")
-                    elif line.get("ref", "") not in line.get("name", ""):
+                    else:
                         name_to_show = line.get("ref", "")
             sheet.write(
                 row_pos, 0, line.get("move_id", ""), FORMATS["format_tcell_left"]


### PR DESCRIPTION
The excel logic in determining name_to_show is wrong. 

By using get everywhere, but with the value gaurenteed to be in the dict we can get NULL values. This cause the report to fail. Moreover the prior reference to name in ref and then setting to name is also incorrect. If the name was in the ref we should use the ref. Furthermore, the name is simply the move_name in default Odoo invoices and this is included 2 columns prior. It therefore makes sense to display the ref if available, or else the name or else the empty string. This hugely simplifies the code as well.

Depends #846 - once that is merged I can tidy up this commit history.