### PR TITLE
[14.0][IMP] account_financial_report: Completes hide_parent_hierarchy_level functionality

### DIFF
--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -31,6 +31,7 @@
 
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Saran Lim. <saranl@ecosoft.co.th>
+* Omar Castiñeira <omar@comunitea.com>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -72,28 +72,19 @@
                         <!--                            <t t-set="style" t-value="'font-size: ' + str(14 - line.level) + 'px; margin-left: ' + str(line.level * 4) + 'px;'"/>-->
                         <!--                        </t>-->
                         <t t-if="hierarchy_on == 'relation'">
-                            <t t-if="balance['type'] == 'group_type'">
+                            <t t-if="limit_hierarchy_level">
                                 <t
-                                    t-set="style"
-                                    t-value="style + 'font-weight: bold; color: blue;'"
-                                />
-                                <t
-                                    t-call="account_financial_report.report_trial_balance_line"
-                                />
-                            </t>
-                            <t t-if="balance['type'] == 'account_type'">
-                                <t t-if="limit_hierarchy_level">
-                                    <t t-if="show_hierarchy_level > balance['level']">
-                                        <t
-                                            t-call="account_financial_report.report_trial_balance_line"
-                                        />
-                                    </t>
-                                </t>
-                                <t t-if="not limit_hierarchy_level">
+                                    t-if="show_hierarchy_level > balance['level'] and (not hide_parent_hierarchy_level or (show_hierarchy_level - 1) == balance['level'])"
+                                >
                                     <t
                                         t-call="account_financial_report.report_trial_balance_line"
                                     />
                                 </t>
+                            </t>
+                            <t t-if="not limit_hierarchy_level">
+                                <t
+                                    t-call="account_financial_report.report_trial_balance_line"
+                                />
                             </t>
                         </t>
                     </t>

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -539,7 +539,9 @@ class TrialBalanceReport(models.AbstractModel):
         account_group_relation = {}
         for account in accounts:
             accounts_data[account.id]["complete_code"] = (
-                account.group_id.complete_code if account.group_id.id else ""
+                account.group_id.complete_code + " / " + account.code
+                if account.group_id.id
+                else ""
             )
             if account.group_id.id:
                 if account.group_id.id not in account_group_relation.keys():
@@ -744,6 +746,7 @@ class TrialBalanceReport(models.AbstractModel):
             "show_partner_details": data["show_partner_details"],
             "limit_hierarchy_level": data["limit_hierarchy_level"],
             "hierarchy_on": hierarchy_on,
+            "hide_parent_hierarchy_level": data["hide_parent_hierarchy_level"],
             "trial_balance": trial_balance,
             "total_amount": total_amount,
             "accounts_data": accounts_data,

--- a/account_financial_report/report/trial_balance_xlsx.py
+++ b/account_financial_report/report/trial_balance_xlsx.py
@@ -187,6 +187,7 @@ class TrialBalanceXslx(models.AbstractModel):
         show_hierarchy_level = res_data["show_hierarchy_level"]
         foreign_currency = res_data["foreign_currency"]
         limit_hierarchy_level = res_data["limit_hierarchy_level"]
+        hide_parent_hierarchy_level = res_data["hide_parent_hierarchy_level"]
         if not show_partner_details:
             # Display array header for account lines
             self.write_array_header(report_data)
@@ -196,7 +197,10 @@ class TrialBalanceXslx(models.AbstractModel):
             for balance in trial_balance:
                 if hierarchy_on == "relation":
                     if limit_hierarchy_level:
-                        if show_hierarchy_level > balance["level"]:
+                        if show_hierarchy_level > balance["level"] and (
+                            not hide_parent_hierarchy_level
+                            or (show_hierarchy_level - 1) == balance["level"]
+                        ):
                             # Display account lines
                             self.write_line_from_dict(balance, report_data)
                     else:


### PR DESCRIPTION
Hi,

Field "parent_hierarchy_level"  is named as "Do not display parent levels" in trial balance, but it doesn't have any functionality, I'm trying to add it. 
On the other hand, testing this source I detected that the level of real account is the same that his group. At Spain is typical print trial balance with 3 digits, with level 3 the report prints the last group and the accounts owned by the group.

Regards 