### PR TITLE
[12.0][FIX] account_financial_report: Speed up open items

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -394,6 +394,9 @@ FROM
                 ) AS partial_amount_currency,
                 ml.currency_id
             FROM
+        """
+        if not only_empty_partner_line:
+            sub_query += """
                 report_open_items_partner rp
             INNER JOIN
                 report_open_items_account ra
@@ -401,13 +404,14 @@ FROM
             INNER JOIN
                 account_move_line ml
                     ON ra.account_id = ml.account_id
-        """
-        if not only_empty_partner_line:
-            sub_query += """
                     AND rp.partner_id = ml.partner_id
             """
         elif only_empty_partner_line:
             sub_query += """
+                report_open_items_account ra
+            INNER JOIN
+                account_move_line ml
+                    ON ra.account_id = ml.account_id
                     AND ml.partner_id IS NULL
             """
         if not positive_balance:

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -612,16 +612,6 @@ AND
 AND
     rp.partner_id IS NULL
         """
-        if not only_empty_partner_line:
-            query_inject_move_line += """
-ORDER BY
-    a.code, p.name, ml.date, ml.id
-            """
-        elif only_empty_partner_line:
-            query_inject_move_line += """
-ORDER BY
-    a.code, ml.date, ml.id
-            """
         self.env.cr.execute(
             query_inject_move_line,
             (self.date_at,


### PR DESCRIPTION
before, we got the Cartesian product of move lines and partners in the `only_empty_partner_line=True` case, which is potentially huge and here grinds the database to a halt. Thanks @StefanRijnhart for pushing me in the right direction.

The sorting also cost a few percent performance, so I removed that too as I don't see how it's helpful.