### PR TITLE
[FIX] account_financial_report: Hide zero accounts also for partner details

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -59,7 +59,7 @@
             <!-- Display partner lines -->
             <t t-if="show_partner_details">
                 <t t-set="padding" t-value="0"/>
-                <t t-foreach="o.account_ids" t-as="account">
+                <t t-foreach="o.account_ids.filtered(lambda a: not a.hide_line)" t-as="account">
                     <div class="page_break">
                         <t t-set="style" t-value="'font-size:8px;'"/>
                         <t t-set="padding" t-value="account.level * 4"/>


### PR DESCRIPTION
**Steps**:

1. Create and validate invoices
2. Click on Invoicing > Reporting > OCA accounting reports > Trial balance
3. In the popup:
    - Select the period of the created invoices
    - Check **Show Partner Details**
    - Check **Hide accounts at 0**
4. Click **View**

**Actual behavior**
Accounts with no movements are shown, for instance:
![Trial Balance - Odoo](https://user-images.githubusercontent.com/101628000/171143087-954491c2-b364-483b-a99f-dfe1d53a61b6.png)


**Expected behavior**
Accounts with no movements are hidden