### PR TITLE
[14][account_financial_report] Fix account group styling in qweb and xlsx

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -238,10 +238,7 @@ class AbstractReportXslx(models.AbstractModel):
             value = line_dict.get(column["field"], False)
             cell_type = column.get("type", "string")
             if cell_type == "string":
-                if (
-                    line_dict.get("account_group_id", False)
-                    and line_dict["account_group_id"]
-                ):
+                if line_dict.get("type", "") == "group_type":
                     report_data["sheet"].write_string(
                         report_data["row_pos"],
                         col_pos,

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -47,6 +47,12 @@
                         <!-- Adapt -->
                         <t t-set="style" t-value="'font-size:12px;'" />
                         <t t-if="show_hierarchy">
+                            <t t-if="balance['type'] == 'group_type'">
+                                <t
+                                    t-set="style"
+                                    t-value="style + 'font-weight: bold; color: blue;'"
+                                />
+                            </t>
                             <t t-if="limit_hierarchy_level">
                                 <t
                                     t-if="show_hierarchy_level > balance['level'] and (not hide_parent_hierarchy_level or (show_hierarchy_level - 1) == balance['level'])"
@@ -206,66 +212,63 @@
             <t t-if="not show_partner_details">
                 <!--## Code-->
                 <t t-if="balance['type'] == 'account_type'">
-                    <div class="act_as_cell left">
+                    <div class="act_as_cell left" t-att-style="style">
                         <span
                             t-att-res-id="balance['id']"
                             res-model="account.account"
                             view-type="form"
                         >
-                            <t t-att-style="style" t-esc="balance['code']" />
+                            <t t-esc="balance['code']" />
                         </span>
                     </div>
                     <!--            ## Account/Partner-->
-                    <div class="act_as_cell left">
+                    <div class="act_as_cell left" t-att-style="style">
                         <span
                             t-att-res-id="balance['id']"
                             res-model="account.account"
                             view-type="form"
                         >
-                            <t t-att-style="style" t-esc="balance['name']" />
+                            <t t-esc="balance['name']" />
                         </span>
                     </div>
                 </t>
                 <t t-if="balance['type'] == 'group_type'">
-                    <div class="act_as_cell left">
+                    <div class="act_as_cell left" t-att-style="style">
                         <t t-set="res_model" t-value="'account.group'" />
                         <span
                             t-att-res-id="balance['id']"
                             res-model="account.group"
                             view-type="form"
                         >
-                            <t t-att-style="style" t-raw="balance['code']" />
+                            <t t-raw="balance['code']" />
                         </span>
                     </div>
-                    <div class="act_as_cell left">
+                    <div class="act_as_cell left" t-att-style="style">
                         <t t-set="res_model" t-value="'account.group'" />
                         <span
                             t-att-res-id="balance['id']"
                             res-model="account.group"
                             view-type="form"
                         >
-                            <t t-att-style="style" t-esc="balance['name']" />
+                            <t t-esc="balance['name']" />
                         </span>
                     </div>
                 </t>
             </t>
             <t t-if="show_partner_details">
-                <div class="act_as_cell left">
+                <div class="act_as_cell left" t-att-style="style">
                     <t t-set="res_model" t-value="'res.partner'" />
                     <span
                         t-att-res-id="partner_id"
                         res-model="res.partner"
                         view-type="form"
                     >
-                        <t
-                            t-att-style="style"
-                            t-esc="partners_data[partner_id]['name']"
-                        />
+                        <t t-esc="partners_data[partner_id]['name']" />
                     </span>
                 </div>
             </t>
             <!--## Initial balance-->
-            <div class="act_as_cell amount">
+            <div class="act_as_cell amount" t-att-style="style">
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="only_posted_moves">
@@ -285,7 +288,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-esc="balance['initial_balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -309,7 +311,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-raw="balance['initial_balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -336,7 +337,6 @@
                     </t>
                     <span t-att-domain="domain" res-model="account.move.line">
                         <t
-                            t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['initial_balance']"
                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                         />
@@ -344,7 +344,7 @@
                 </t>
             </div>
             <!--## Debit-->
-            <div class="act_as_cell amount">
+            <div class="act_as_cell amount" t-att-style="style">
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="only_posted_moves">
@@ -368,7 +368,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-esc="balance['debit']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -396,7 +395,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-raw="balance['debit']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -427,7 +425,6 @@
                     </t>
                     <span t-att-domain="domain" res-model="account.move.line">
                         <t
-                            t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['debit']"
                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                         />
@@ -435,7 +432,7 @@
                 </t>
             </div>
             <!--            &lt;!&ndash;## Credit&ndash;&gt;-->
-            <div class="act_as_cell amount">
+            <div class="act_as_cell amount" t-att-style="style">
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="only_posted_moves">
@@ -459,7 +456,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-esc="balance['credit']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -487,7 +483,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-raw="balance['credit']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -518,7 +513,6 @@
                     </t>
                     <span t-att-domain="domain" res-model="account.move.line">
                         <t
-                            t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['credit']"
                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                         />
@@ -526,7 +520,7 @@
                 </t>
             </div>
             <!--            &lt;!&ndash;## Period balance&ndash;&gt;-->
-            <div class="act_as_cell amount">
+            <div class="act_as_cell amount" t-att-style="style">
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="only_posted_moves">
@@ -550,7 +544,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-esc="balance['balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -576,7 +569,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-raw="balance['balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -607,7 +599,6 @@
                     </t>
                     <span t-att-domain="domain" res-model="account.move.line">
                         <t
-                            t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['balance']"
                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                         />
@@ -615,7 +606,7 @@
                 </t>
             </div>
             <!--            &lt;!&ndash;## Ending balance&ndash;&gt;-->
-            <div class="act_as_cell amount">
+            <div class="act_as_cell amount" t-att-style="style">
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="only_posted_moves">
@@ -635,7 +626,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-esc="balance['ending_balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -656,7 +646,6 @@
                         </t>
                         <span t-att-domain="domain" res-model="account.move.line">
                             <t
-                                t-att-style="style"
                                 t-raw="balance['ending_balance']"
                                 t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                             />
@@ -683,7 +672,6 @@
                     </t>
                     <span t-att-domain="domain" res-model="account.move.line">
                         <t
-                            t-att-style="style"
                             t-esc="total_amount[account_id][partner_id]['ending_balance']"
                             t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
                         />
@@ -699,7 +687,7 @@
                                 <span t-esc="balance['currency_name']" />
                             </div>
                             <!--## Initial balance cur.-->
-                            <div class="act_as_cell amount">
+                            <div class="act_as_cell amount" t-att-style="style">
                                 <t t-if="only_posted_moves">
                                     <t
                                         t-set="domain"
@@ -716,10 +704,7 @@
                                     t-att-domain="domain"
                                     res-model="account.move.line"
                                 >
-                                    <t
-                                        t-att-style="style"
-                                        t-esc="balance['initial_currency_balance']"
-                                    />
+                                    <t t-esc="balance['initial_currency_balance']" />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
                                 <!--                                <t t-set="domain"-->
@@ -745,7 +730,7 @@
                                     t-esc="total_amount[account_id]['currency_name']"
                                 />
                             </div>
-                            <div class="act_as_cell amount">
+                            <div class="act_as_cell amount" t-att-style="style">
                                 <t t-if="only_posted_moves">
                                     <t
                                         t-set="domain"
@@ -766,7 +751,6 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-att-style="style"
                                         t-raw="total_amount[account_id][partner_id]['initial_currency_balance']"
                                     />
                                 </span>
@@ -778,7 +762,7 @@
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="balance['currency_id']">
-                            <div class="act_as_cell amount">
+                            <div class="act_as_cell amount" t-att-style="style">
                                 <t t-if="only_posted_moves">
                                     <t
                                         t-set="domain"
@@ -795,10 +779,7 @@
                                     t-att-domain="domain"
                                     res-model="account.move.line"
                                 >
-                                    <t
-                                        t-att-style="style"
-                                        t-raw="balance['ending_currency_balance']"
-                                    />
+                                    <t t-raw="balance['ending_currency_balance']" />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
                                 <!--                                <t t-set="domain"-->
@@ -817,7 +798,7 @@
                 </t>
                 <t t-if="show_partner_details">
                     <t t-if="total_amount[account_id]['currency_id']">
-                        <div class="act_as_cell amount">
+                        <div class="act_as_cell amount" t-att-style="style">
                             <t t-if="type == 'partner_type'">
                                 <t t-if="only_posted_moves">
                                     <t
@@ -839,7 +820,6 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-att-style="style"
                                         t-raw="total_amount[account_id][partner_id]['ending_currency_balance']"
                                     />
                                 </span>


### PR DESCRIPTION
Bring back some special styling for trial balance account group lines.

Before this PR https://github.com/OCA/account-financial-reporting/pull/866/files, the blue bold style for account group lines in trial balance was still present in the  qweb template but it seems it was not working in the `<t>` tag. 
I guess it has been removed by mistake and it was not seen because it did not work anyway
So I just put back the style and moved it in the `<div>` tags and it seems it solved the problem.

I also fixed this styling in the xlsx report. The related code was testing a `account_group_id` attribute which is not present anymore, I changed the test on the `type` 'group_type'

@ernestotejeda @pedrobaeza @alexis-via @sebastienbeau 
