### PR TITLE
[14.0][IMP] account_financial_report: common format for all amounts

### DIFF
--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -248,11 +248,17 @@
                     </div>
                     <!--## amount_total_due_currency-->
                     <div class="act_as_cell amount">
-                        <span t-esc="line['amount_currency']" />
+                        <span
+                            t-esc="line['amount_currency']"
+                            t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(line['currency_id'])}"
+                        />
                     </div>
                     <!--## amount_residual_currency-->
                     <div class="act_as_cell amount">
-                        <span t-esc="line['amount_residual_currency']" />
+                        <span
+                            t-esc="line['amount_residual_currency']"
+                            t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(line['currency_id'])}"
+                        />
                     </div>
                 </t>
                 <t t-if="not line['currency_id']">


### PR DESCRIPTION
In the open items report, the currency original and residual
fields were being displayed as regular float fields. With
this change they are printed with the corresponding format
for the currency of the journal item.

![image](https://user-images.githubusercontent.com/23449160/179781252-88281097-2e60-4ce2-9471-6e837b6acc01.png)

@ForgeFlow