### PR TITLE
[15.0][IMP] account_financial_report: common format for all amounts

### DIFF
--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -248,11 +248,17 @@
                     </div>
                     <!--## amount_total_due_currency-->
                     <div class="act_as_cell amount">
-                        <span t-esc="line['amount_currency']" />
+                        <span
+                            t-esc="line['amount_currency']"
+                            t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(line['currency_id'])}"
+                        />
                     </div>
                     <!--## amount_residual_currency-->
                     <div class="act_as_cell amount">
-                        <span t-esc="line['amount_residual_currency']" />
+                        <span
+                            t-esc="line['amount_residual_currency']"
+                            t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(line['currency_id'])}"
+                        />
                     </div>
                 </t>
                 <t t-if="not line['currency_id']">

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -7,10 +7,12 @@ import time
 from datetime import date
 
 from odoo import api, fields
+from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestGeneralLedgerReport(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/account_financial_report/tests/test_journal_ledger.py
+++ b/account_financial_report/tests/test_journal_ledger.py
@@ -7,11 +7,13 @@ from datetime import datetime
 from dateutil.relativedelta import relativedelta
 
 from odoo.fields import Date
+from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestJournalReport(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/account_financial_report/tests/test_open_items.py
+++ b/account_financial_report/tests/test_open_items.py
@@ -2,9 +2,12 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tests import tagged
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestOpenItems(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -3,9 +3,12 @@
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
+from odoo.tests import tagged
+
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestTrialBalanceReport(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls, chart_template_ref=None):

--- a/account_financial_report/tests/test_vat_report.py
+++ b/account_financial_report/tests/test_vat_report.py
@@ -6,11 +6,13 @@ import time
 from datetime import date
 
 from odoo import fields
+from odoo.tests import tagged
 from odoo.tests.common import Form
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
+@tagged("post_install", "-at_install")
 class TestVATReport(AccountTestInvoicingCommon):
     @classmethod
     def init_invoice(

--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -265,6 +265,7 @@ class TestAccountTaxBalance(HttpCase):
         self.assertEqual(tax.balance, 17.5)
 
 
+@odoo.tests.tagged("post_install", "-at_install")
 class TestInvoicingBalance(AccountTestInvoicingCommon):
     def test_balance_recomputation(self):
         """Check that balances are computed correctly for different dates."""


### PR DESCRIPTION
In the open items report, the currency original and residual
fields were being displayed as regular float fields. With
this change they are printed with the corresponding format
for the currency of the journal item.

Forward port of #892 

@ForgeFlow