### PR TITLE
[14.0][FIX] mis_template_financial_report: Remove balance of "Current Year Earnings" in Profit.

### DIFF
--- a/mis_template_financial_report/data/mis_report_kpi.xml
+++ b/mis_template_financial_report/data/mis_report_kpi.xml
@@ -19,7 +19,7 @@
         <field name="description">Profit</field>
         <field
             name="expression"
-        >-balp[('user_type_id', 'in', (ref('account.data_account_type_other_income').id, ref('account.data_account_type_revenue').id, ref('account.data_unaffected_earnings').id,))][]</field>
+        >-balp[('user_type_id', 'in', (ref('account.data_account_type_other_income').id, ref('account.data_account_type_revenue').id,))][]</field>
         <field name="auto_expand_accounts">true</field>
         <field name="auto_expand_accounts_style_id" ref="style_details" />
         <field name="style_id" ref="style_header" />


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/account-financial-reporting/pull/899

Remove balance of "Current Year Earnings" in Profit.

According to the explanation https://github.com/OCA/account-financial-reporting/issues/888#issuecomment-1171101484 it is not necessary.

Related to: https://github.com/OCA/account-financial-reporting/issues/888

Please @pedrobaeza can you review it?

@Tecnativa TT37837