### PR TITLE
[13.0][FIX] account_financial_report: Add sorting to move line records in journal ledger.

### DIFF
--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -84,7 +84,10 @@ class JournalLedgerReport(models.AbstractModel):
         return [("display_type", "=", False), ("move_id", "in", move_ids)]
 
     def _get_move_lines_order(self, move_ids, wizard, journal_ids):
-        return ""
+        """Add `move_id` to make sure the order of the records is correct
+        (especially if we use auto-sequence).
+        """
+        return "move_id"
 
     def _get_move_lines_data(self, ml, wizard, ml_taxes, auto_sequence):
         base_debit = (


### PR DESCRIPTION
It is necessary to add the `move_id` field to make sure that the order of the records is correct (especially if we use auto-sequence).

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT38775