### PR TITLE
[13.0][FIX] Fix relation hierarchy level filtering

### DIFF
--- a/account_financial_report/models/account_group.py
+++ b/account_financial_report/models/account_group.py
@@ -39,7 +39,7 @@ class AccountGroup(models.Model):
                 self.parent_id.complete_code, self.code_prefix
             )
         else:
-            self.complete_code = self.code_prefix
+            self.complete_code = self.code_prefix or ""
 
     @api.depends("parent_id", "parent_id.level")
     def _compute_level(self):

--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -30,5 +30,9 @@
   * Harald Panten
   * Valentin Vinagre
 
+* `XCG Consulting <https://xcg-consulting.fr>`__:
+
+  * Vincent Hatakeyama
+
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/report/aged_partner_balance_xlsx.py
+++ b/account_financial_report/report/aged_partner_balance_xlsx.py
@@ -39,7 +39,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                     "width": 14,
                 },
                 3: {
-                    "header": _(u"Age ≤ 30 d."),
+                    "header": _("Age ≤ 30 d."),
                     "field": "30_days",
                     "field_footer_total": "30_days",
                     "field_footer_percent": "percent_30_days",
@@ -47,7 +47,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                     "width": 14,
                 },
                 4: {
-                    "header": _(u"Age ≤ 60 d."),
+                    "header": _("Age ≤ 60 d."),
                     "field": "60_days",
                     "field_footer_total": "60_days",
                     "field_footer_percent": "percent_60_days",
@@ -55,7 +55,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                     "width": 14,
                 },
                 5: {
-                    "header": _(u"Age ≤ 90 d."),
+                    "header": _("Age ≤ 90 d."),
                     "field": "90_days",
                     "field_footer_total": "90_days",
                     "field_footer_percent": "percent_90_days",
@@ -63,7 +63,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                     "width": 14,
                 },
                 6: {
-                    "header": _(u"Age ≤ 120 d."),
+                    "header": _("Age ≤ 120 d."),
                     "field": "120_days",
                     "field_footer_total": "120_days",
                     "field_footer_percent": "percent_120_days",
@@ -105,7 +105,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                 "width": 14,
             },
             9: {
-                "header": _(u"Age ≤ 30 d."),
+                "header": _("Age ≤ 30 d."),
                 "field": "30_days",
                 "field_footer_total": "30_days",
                 "field_footer_percent": "percent_30_days",
@@ -114,7 +114,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                 "width": 14,
             },
             10: {
-                "header": _(u"Age ≤ 60 d."),
+                "header": _("Age ≤ 60 d."),
                 "field": "60_days",
                 "field_footer_total": "60_days",
                 "field_footer_percent": "percent_60_days",
@@ -123,7 +123,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                 "width": 14,
             },
             11: {
-                "header": _(u"Age ≤ 90 d."),
+                "header": _("Age ≤ 90 d."),
                 "field": "90_days",
                 "field_footer_total": "90_days",
                 "field_footer_percent": "percent_90_days",
@@ -132,7 +132,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                 "width": 14,
             },
             12: {
-                "header": _(u"Age ≤ 120 d."),
+                "header": _("Age ≤ 120 d."),
                 "field": "120_days",
                 "field_footer_total": "120_days",
                 "field_footer_percent": "percent_120_days",

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -89,18 +89,9 @@
                                 />
                             </t>
                             <t t-if="balance['type'] == 'account_type'">
-                                <t t-if="limit_hierarchy_level">
-                                    <t t-if="show_hierarchy_level > balance['level']">
-                                        <t
-                                            t-call="account_financial_report.report_trial_balance_line"
-                                        />
-                                    </t>
-                                </t>
-                                <t t-if="not limit_hierarchy_level">
-                                    <t
-                                        t-call="account_financial_report.report_trial_balance_line"
-                                    />
-                                </t>
+                                <t
+                                    t-call="account_financial_report.report_trial_balance_line"
+                                />
                             </t>
                         </t>
                     </t>

--- a/account_financial_report/report/trial_balance_xlsx.py
+++ b/account_financial_report/report/trial_balance_xlsx.py
@@ -143,7 +143,8 @@ class TrialBalanceXslx(models.AbstractModel):
         return [
             [
                 _("Date range filter"),
-                _("From: %s To: %s") % (report.date_from, report.date_to),
+                _("From: %(date_from)s To: %(date_to)s")
+                % {"date_from": report.date_from, "date_to": report.date_to},
             ],
             [
                 _("Target moves filter"),
@@ -161,7 +162,7 @@ class TrialBalanceXslx(models.AbstractModel):
             ],
             [
                 _("Limit hierarchy levels"),
-                _("Level %s" % report.show_hierarchy_level)
+                _("Level %s") % report.show_hierarchy_level
                 if report.limit_hierarchy_level
                 else _("No limit"),
             ],
@@ -195,12 +196,8 @@ class TrialBalanceXslx(models.AbstractModel):
         if not show_partner_details:
             for balance in trial_balance:
                 if hierarchy_on == "relation":
-                    if limit_hierarchy_level:
-                        if show_hierarchy_level > balance["level"]:
-                            # Display account lines
-                            self.write_line_from_dict(balance)
-                    else:
-                        self.write_line_from_dict(balance)
+                    # filtering by level is done at the data level
+                    self.write_line_from_dict(balance)
                 elif hierarchy_on == "computed":
                     if limit_hierarchy_level:
                         if show_hierarchy_level == balance["level"] or (
@@ -276,7 +273,7 @@ class TrialBalanceXslx(models.AbstractModel):
             line_object.currency_id = line_object.report_account_id.currency_id
         elif type_object == "account":
             line_object.currency_id = line_object.currency_id
-        super(TrialBalanceXslx, self).write_line(line_object)
+        super().write_line(line_object)
 
     def write_account_footer(self, account, name_value):
         """Specific function to write account footer for Trial Balance"""


### PR DESCRIPTION
There was several issue:
- the option to hide parent hierarchy was not working
- the filtering level used was computed differently that the one in the computation hierarchy, starting at 0. On top of that children had the same level as their parent group, instead of having a different value, making it impossible to filter them.
- the ordering was using a complete code but it did not contain the code of the account itself, breaking ordering.

The filtering of accounts and groups is done when generating data, so that allows testing and makes sure all reports type display the same data.

I18N errors reported by pylint have also been fixed, and black run on the module.