### PR TITLE
[14.0][FIX] account_financial_report: partner trial balance: sort by partner name

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -597,9 +597,8 @@ class AbstractReportXslx(models.AbstractModel):
                     {"bold": True, "border": True, "bg_color": "#FFFFCC"}
                 )
                 report_data["field_name"] = format_amt
-                format_amount = "#,##0." + (
-                    "0" * line_object["currency_id"].decimal_places
-                )
+                currency = self.env["res.currency"].browse(line_object["currency_id"])
+                format_amount = "#,##0." + ("0" * currency.decimal_places)
                 format_amt.set_num_format(format_amount)
         return format_amt
 

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -244,6 +244,9 @@ class TrialBalanceReport(models.AbstractModel):
                 total_amount[acc_id][prt_id]["ending_currency_balance"] += round(
                     tb["amount_currency"], 2
                 )
+        total_amount[acc_id][prt_id]["partner_name"] = (
+            tb["partner_id"][1] if tb["partner_id"] else _("Missing Partner")
+        )
         return total_amount
 
     @api.model
@@ -267,6 +270,7 @@ class TrialBalanceReport(models.AbstractModel):
             total_amount[acc_id][prt_id]["debit"] = tb["debit"]
             total_amount[acc_id][prt_id]["balance"] = tb["balance"]
             total_amount[acc_id][prt_id]["initial_balance"] = 0.0
+            total_amount[acc_id][prt_id]["partner_name"] = partners_data[prt_id]["name"]
             partners_ids.add(prt_id)
         for tb in tb_initial_prt:
             acc_id = tb["account_id"][0]
@@ -279,6 +283,15 @@ class TrialBalanceReport(models.AbstractModel):
             total_amount = self._compute_acc_prt_amount(
                 total_amount, tb, acc_id, prt_id, foreign_currency
             )
+        # sort on partner_name
+        for acc_id, total_data in total_amount.items():
+            tmp_list = sorted(
+                total_data.items(),
+                key=lambda x: isinstance(x[1], dict) and x[1]["partner_name"] or x[0],
+            )
+            total_amount[acc_id] = {}
+            for key, value in tmp_list:
+                total_amount[acc_id][key] = value
         return total_amount, partners_data
 
     def _remove_accounts_at_cero(self, total_amount, show_partner_details, company):


### PR DESCRIPTION
On v14, trial balance report with "show partners details" = True:
BEFORE
![bug_financial_report-before](https://user-images.githubusercontent.com/1157917/190734315-a1aec614-f0b6-4350-9459-9f9b447d14ae.png)

AFTER:
![bug_financial_report-after](https://user-images.githubusercontent.com/1157917/190734534-04689f70-2753-4faa-a37d-2814085f445f.png)

More info:
With the current implementation, the partners that have debit = credit = 0 are always at the end. In the "before" screenshot, partner AAcorp has an initial balance, but it has debit = credit = 0 so it is displayed at the end.
With the current implementation, each account displays 2 blocks of partners, each block being in alphabetical order:
1) partners that have moves in the period
2) partners that don't have moves in the period

In python 3.7+, dictionary order is guaranteed to be insertion order. (warning: from my experience, insertion order may be different from print order !).

The trial balance report is built by the dictionary "total_amount". So, for a particular account, the order of the partners is the order of insertion of that partner in the total_amount[account_id] dictionary. This is handled by the method _compute_partner_amount() in report/trial_balance.py cf https://github.com/OCA/account-financial-reporting/blob/14.0/account_financial_report/report/trial_balance.py#L249 In that method, there is a first loop on tb_period_prt that inserts partner_id keys in total_amount[account_id] and a second loop on tb_initial_prt which inserts partner_id keys in total_amount[account_id] if that partner wasn't already inserted in the first loop. This explains the bug.

I'm not familiar with the code of account_financial_report, so I'm not sure that this PR is the best fix for the problem. But it solves the bug.