### PR TITLE
[14.0][FIX] account_financial_report: Display the correct name of initial balance and ending balance in general ledger

### DIFF
--- a/account_financial_report/i18n/account_financial_report.pot
+++ b/account_financial_report/i18n/account_financial_report.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 14.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-21 15:15+0000\n"
+"PO-Revision-Date: 2022-09-21 15:15+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1301,6 +1303,11 @@ msgid "Partner ending balance"
 msgstr ""
 
 #. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Partner initial balance"
+msgstr ""
+
+#. module: account_financial_report
 #: model:ir.model.fields.selection,name:account_financial_report.selection__general_ledger_report_wizard__grouped_by__partners
 msgid "Partners"
 msgstr ""
@@ -1570,8 +1577,14 @@ msgstr ""
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_ending_cumul
 #, python-format
 msgid "Tax ending balance"
+msgstr ""
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Tax initial balance"
 msgstr ""
 
 #. module: account_financial_report

--- a/account_financial_report/i18n/es.po
+++ b/account_financial_report/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-20 07:00+0000\n"
-"PO-Revision-Date: 2022-09-20 09:01+0200\n"
+"POT-Creation-Date: 2022-09-21 15:15+0000\n"
+"PO-Revision-Date: 2022-09-21 17:17+0200\n"
 "Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -749,7 +749,7 @@ msgstr "Número de asiento"
 #: code:addons/account_financial_report/static/src/xml/report.xml:0
 #, python-format
 msgid "Export"
-msgstr ""
+msgstr "Exportar"
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.aged_partner_balance_wizard
@@ -881,7 +881,6 @@ msgstr "Asistente de informe de Libro Mayor"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_a_f_r_report_general_ledger_xlsx
-#, fuzzy
 msgid "General Ledger XLSL Report"
 msgstr "Libro mayor XLSX"
 
@@ -896,6 +895,8 @@ msgid ""
 "General Ledger can be computed only if selected company have\n"
 "                        only one unaffected earnings account."
 msgstr ""
+"El Libro mayor solo se puede calcular si la empresa seleccionada tiene solo "
+"una cuenta de resultados no afectados."
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_journal_ledger_report_wizard__group_option
@@ -983,13 +984,12 @@ msgstr ""
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.report_trial_balance_lines_header
-#, fuzzy
 msgid ""
 "Initial\n"
 "                    balance"
 msgstr ""
 "Balance\n"
-"                        inicial moneda"
+"                        inicial"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
@@ -1020,7 +1020,7 @@ msgstr "Apunte contable"
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_general_ledger_report_wizard__domain
 msgid "Journal Items Domain"
-msgstr ""
+msgstr "Dominio Apuntes Contables"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/journal_ledger_xlsx.py:0
@@ -1053,9 +1053,8 @@ msgstr "Libro diario XLSX"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_a_f_r_report_journal_ledger_xlsx
-#, fuzzy
 msgid "Journal Ledger XLSX Report"
-msgstr "Informe Diario de contabilidad"
+msgstr "Informe Libro de diario XLSX"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/journal_ledger_xlsx.py:0
@@ -1254,9 +1253,8 @@ msgstr "Partidas abiertas XLSX"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_a_f_r_report_open_items_xlsx
-#, fuzzy
 msgid "Open Items XLSX Report"
-msgstr "Partidas abiertas XLSX"
+msgstr "Informe Partidas abiertas XLSX"
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.journal_ledger_wizard
@@ -1315,6 +1313,11 @@ msgid "Partner ending balance"
 msgstr "Saldo final de empresa"
 
 #. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Partner initial balance"
+msgstr "Saldo inicial de empresa"
+
+#. module: account_financial_report
 #: model:ir.model.fields.selection,name:account_financial_report.selection__general_ledger_report_wizard__grouped_by__partners
 msgid "Partners"
 msgstr "Empresas"
@@ -1355,7 +1358,7 @@ msgstr "Posteado"
 #: code:addons/account_financial_report/static/src/xml/report.xml:0
 #, python-format
 msgid "Print"
-msgstr ""
+msgstr "Imprimir"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
@@ -1402,7 +1405,7 @@ msgstr "Ref - Etiqueta"
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_ir_actions_report
 msgid "Report Action"
-msgstr ""
+msgstr "Acción Informe"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/aged_partner_balance_xlsx.py:0
@@ -1419,7 +1422,7 @@ msgstr "Remanente"
 #: model_terms:ir.ui.view,arch_db:account_financial_report.report_journal_ledger_journal_table_header
 #, python-format
 msgid "Sequence"
-msgstr ""
+msgstr "Secuencia"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
@@ -1434,14 +1437,13 @@ msgstr "Mostrar"
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_general_ledger_report_wizard__show_cost_center
-#, fuzzy
 msgid "Show Analytic Account"
-msgstr "Mostrar etiquetas analíticas"
+msgstr "Mostrar cuenta analítica"
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_journal_ledger_report_wizard__with_auto_sequence
 msgid "Show Auto Sequence"
-msgstr ""
+msgstr "Mostrar auto secuencia"
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_aged_partner_balance_report_wizard__show_move_line_details
@@ -1584,9 +1586,15 @@ msgstr "Etiquetas de impuestos"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_ending_cumul
 #, python-format
 msgid "Tax ending balance"
 msgstr "Saldo final de impuesto"
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Tax initial balance"
+msgstr "Saldo inicial de impuesto"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
@@ -1637,6 +1645,8 @@ msgstr "El nivel de jerarquía a filtrar debe ser mayor que 0."
 #: model:ir.model.fields,help:account_financial_report.field_general_ledger_report_wizard__domain
 msgid "This domain will be used to select specific domain for Journal Items"
 msgstr ""
+"Este dominio se usará para seleccionar dominios específicos para Apuntes "
+"Contables"
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.report_trial_balance_filters
@@ -1685,7 +1695,6 @@ msgstr "Balance de Sumas y Saldos XLSX"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_a_f_r_report_trial_balance_xlsx
-#, fuzzy
 msgid "Trial Balance XLSX Report"
 msgstr "Balance de Sumas y Saldos XLSX"
 
@@ -1695,6 +1704,8 @@ msgid ""
 "Trial Balance can be computed only if selected company have only\n"
 "                        one unaffected earnings account."
 msgstr ""
+"El balance de sumas y saldos solo puede calcularse si la compañía "
+"seleccionada tiene una y solo una cuenta de ganancias."
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_general_ledger_report_wizard__unaffected_earnings_account
@@ -1755,15 +1766,13 @@ msgstr "Informe de Impuestos"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_account_financial_report_vat_report
-#, fuzzy
 msgid "Vat Report Report"
-msgstr "Informe de Impuestos"
+msgstr "Informe de IVA"
 
 #. module: account_financial_report
 #: model:ir.model,name:account_financial_report.model_report_a_f_r_report_vat_report_xlsx
-#, fuzzy
 msgid "Vat Report XLSX Report"
-msgstr "Informe de impuestos XLSX"
+msgstr "Informe de IVA XLSX"
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.aged_partner_balance_wizard
@@ -1802,7 +1811,7 @@ msgstr "Si"
 #: code:addons/account_financial_report/report/general_ledger.py:0
 #, python-format
 msgid "future"
-msgstr ""
+msgstr "futuro"
 
 #. module: account_financial_report
 #: model_terms:ir.ui.view,arch_db:account_financial_report.aged_partner_balance_wizard

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -58,7 +58,7 @@
                     <t t-if="'list_grouped' in account">
                         <!-- Display account partners -->
                         <t t-foreach="account['list_grouped']" t-as="group_item">
-                            <t t-set="type" t-value='"partner_type"' />
+                            <t t-set="type" t-value='"grouped_type"' />
                             <div class="page_break">
                                 <!-- Display partner header -->
                                 <div class="act_as_caption account_title">
@@ -81,7 +81,7 @@
                                         t-set="account_or_group_item_object"
                                         t-value="group_item"
                                     />
-                                    <t t-set="type" t-value='"partner_type"' />
+                                    <t t-set="type" t-value='"grouped_type"' />
                                 </t>
                             </div>
                         </t>
@@ -210,7 +210,13 @@
                 <!--## partner-->
                 <div class="act_as_cell" />
                 <!--## ref - label-->
-                <div class="act_as_cell amount">Initial balance</div>
+                <div class="act_as_cell amount">
+                    <t t-if='type == "account_type"'>Initial balance</t>
+                    <t t-if='type == "grouped_type"'>
+                        <t t-if="'partners' in account">Partner initial balance</t>
+                        <t t-if="'taxes' in account">Tax initial balance</t>
+                    </t>
+                </div>
                 <t t-if="show_cost_center">
                     <!--## cost_center-->
                     <div class="act_as_cell" />
@@ -237,7 +243,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -269,7 +275,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -300,7 +306,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -334,7 +340,7 @@
                                     />
                                 </span>
                             </t>
-                            <t t-if="type == 'partner_type'">
+                            <t t-if="type == 'grouped_type'">
                                 <t
                                     t-set="domain"
                                     t-value="[('account_id', '=', account['id']),
@@ -634,10 +640,11 @@
                         style="width: 16.9%;"
                     >Ending balance</div>
                 </t>
-                <t t-if='type == "partner_type"'>
+                <t t-if='type == "grouped_type"'>
                     <div class="act_as_cell first_column" style="width: 41.32%;" />
                     <div class="act_as_cell right" style="width: 16.9%;">
-                        Partner ending balance
+                        <t t-if="'partners' in account">Partner ending balance</t>
+                        <t t-if="'taxes' in account">Tax ending balance</t>
                     </div>
                 </t>
                 <t t-if="show_cost_center">
@@ -695,7 +702,7 @@
                                     </a>
                                 </span>
                             </t>
-                            <t t-if="type == 'partner_type'">
+                            <t t-if="type == 'grouped_type'">
                                 <t
                                     t-set="domain"
                                     t-value="[('account_id', '=', account['id']),


### PR DESCRIPTION
Display the correct name of initial balance and ending balance in general ledger (forgotten in https://github.com/OCA/account-financial-reporting/pull/917)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT38721