### PR TITLE
[13.0][FIX] account_financial_report: Display the correct name of initial balance and ending balance in general ledger

### DIFF
--- a/account_financial_report/i18n/account_financial_report.pot
+++ b/account_financial_report/i18n/account_financial_report.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2022-09-21 15:29+0000\n"
+"PO-Revision-Date: 2022-09-21 15:29+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -1341,6 +1343,11 @@ msgid "Partner ending balance"
 msgstr ""
 
 #. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Partner initial balance"
+msgstr ""
+
+#. module: account_financial_report
 #: model:ir.model.fields.selection,name:account_financial_report.selection__general_ledger_report_wizard__grouped_by__partners
 msgid "Partners"
 msgstr ""
@@ -1604,8 +1611,14 @@ msgstr ""
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_ending_cumul
 #, python-format
 msgid "Tax ending balance"
+msgstr ""
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Tax initial balance"
 msgstr ""
 
 #. module: account_financial_report

--- a/account_financial_report/i18n/es.po
+++ b/account_financial_report/i18n/es.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-20 07:00+0000\n"
-"PO-Revision-Date: 2022-09-21 15:40+0000\n"
-"Last-Translator: Víctor Martínez <victor.martinez@tecnativa.com>\n"
+"POT-Creation-Date: 2022-09-21 15:29+0000\n"
+"PO-Revision-Date: 2022-09-21 17:30+0200\n"
+"Last-Translator: Pedro M. Baeza <pedro.baeza@gmail.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
@@ -1371,6 +1371,11 @@ msgid "Partner ending balance"
 msgstr "Saldo final de empresa"
 
 #. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Partner initial balance"
+msgstr "Saldo inicial de empresa"
+
+#. module: account_financial_report
 #: model:ir.model.fields.selection,name:account_financial_report.selection__general_ledger_report_wizard__grouped_by__partners
 msgid "Partners"
 msgstr "Empresas"
@@ -1636,9 +1641,15 @@ msgstr "Etiquetas de impuestos"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_ending_cumul
 #, python-format
 msgid "Tax ending balance"
 msgstr "Saldo final de impuesto"
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.report_general_ledger_lines
+msgid "Tax initial balance"
+msgstr "Saldo inicial de impuesto"
 
 #. module: account_financial_report
 #: code:addons/account_financial_report/report/general_ledger_xlsx.py:0

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -55,7 +55,7 @@
                     <t t-if="'list_grouped' in account">
                         <!-- Display account partners -->
                         <t t-foreach="account['list_grouped']" t-as="group_item">
-                            <t t-set="type" t-value='"partner_type"' />
+                            <t t-set="type" t-value='"grouped_type"' />
                             <div class="page_break">
                                 <!-- Display partner header -->
                                 <div class="act_as_caption account_title">
@@ -78,7 +78,7 @@
                                         t-set="account_or_group_item_object"
                                         t-value="group_item"
                                     />
-                                    <t t-set="type" t-value='"partner_type"' />
+                                    <t t-set="type" t-value='"grouped_type"' />
                                 </t>
                             </div>
                         </t>
@@ -204,7 +204,13 @@
                 <!--## partner-->
                 <div class="act_as_cell" />
                 <!--## ref - label-->
-                <div class="act_as_cell amount">Initial balance</div>
+                <div class="act_as_cell amount">
+                    <t t-if='type == "account_type"'>Initial balance</t>
+                    <t t-if='type == "grouped_type"'>
+                        <t t-if="'partners' in account">Partner initial balance</t>
+                        <t t-if="'taxes' in account">Tax initial balance</t>
+                    </t>
+                </div>
                 <t t-if="show_cost_center">
                     <!--## cost_center-->
                     <div class="act_as_cell" />
@@ -231,7 +237,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -263,7 +269,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -294,7 +300,7 @@
                             />
                         </span>
                     </t>
-                    <t t-if="type == 'partner_type'">
+                    <t t-if="type == 'grouped_type'">
                         <t
                             t-set="domain"
                             t-value="[('account_id', '=', account['id']),
@@ -328,7 +334,7 @@
                                     />
                                 </span>
                             </t>
-                            <t t-if="type == 'partner_type'">
+                            <t t-if="type == 'grouped_type'">
                                 <t
                                     t-set="domain"
                                     t-value="[('account_id', '=', account['id']),
@@ -625,12 +631,12 @@
                         style="width: 16.9%;"
                     >Ending balance</div>
                 </t>
-                <t t-if='type == "partner_type"'>
+                <t t-if='type == "grouped_type"'>
                     <div class="act_as_cell first_column" style="width: 41.32%;" />
-                    <div
-                        class="act_as_cell right"
-                        style="width: 16.9%;"
-                    >Partner ending balance</div>
+                    <div class="act_as_cell right" style="width: 16.9%;">
+                        <t t-if="'partners' in account">Partner ending balance</t>
+                        <t t-if="'taxes' in account">Tax ending balance</t>
+                    </div>
                 </t>
                 <t t-if="show_cost_center">
                     <!--## cost_center-->
@@ -687,7 +693,7 @@
                                     </a>
                                 </span>
                             </t>
-                            <t t-if="type == 'partner_type'">
+                            <t t-if="type == 'grouped_type'">
                                 <t
                                     t-set="domain"
                                     t-value="[('account_id', '=', account['id']),


### PR DESCRIPTION
Display the correct name of initial balance and ending balance in general ledger (forgotten in https://github.com/OCA/account-financial-reporting/pull/915)

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa TT38721