### PR TITLE
[14.0][FIX] account_financial_report: variable not defined

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -253,9 +253,9 @@ class GeneralLedgerXslx(models.AbstractModel):
                         }
                     )
                     if foreign_currency:
-                        partner.update(
+                        group_item.update(
                             {
-                                "initial_bal_curr": partner["init_bal"]["bal_curr"],
+                                "initial_bal_curr": group_item["init_bal"]["bal_curr"],
                             }
                         )
                     self.write_initial_balance_from_dict(group_item, report_data)


### PR DESCRIPTION
Superseed https://github.com/OCA/account-financial-reporting/pull/921

Variable name was changed in this commit but it wasn't changed in all the code.
https://github.com/OCA/account-financial-reporting/commit/01efb031e17b510858acfda3214be67be022dd9a#diff-23868768c260356890af524cba5a535c8f73f525ef9490f326572dda4c1a4f20R235

Please @pedrobaeza can you review it?

@Tecnativa