### PR TITLE
[14.0][FIX] account_financial_report: open_items

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -56,6 +56,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         company_id,
         partner_ids,
         only_posted_moves,
+        debit_amount_currency,
+        credit_amount_currency,
     ):
         debit_ids = set(debit_ids)
         credit_ids = set(credit_ids)
@@ -93,9 +95,29 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         for move_line in move_lines:
             ml_id = move_line["id"]
             if ml_id in debit_ids:
-                move_line["amount_residual"] += debit_amount[ml_id]
+                if move_line.get("amount_residual", False):
+                    move_line["amount_residual"] += debit_amount[ml_id]
+                else:
+                    move_line["amount_residual"] = debit_amount[ml_id]
+                if move_line.get("amount_residual_currency", False):
+                    move_line["amount_residual_currency"] += debit_amount_currency[
+                        ml_id
+                    ]
+                else:
+                    move_line["amount_residual_currency"] = debit_amount_currency[ml_id]
             if ml_id in credit_ids:
-                move_line["amount_residual"] -= credit_amount[ml_id]
+                if move_line.get("amount_residual", False):
+                    move_line["amount_residual"] -= credit_amount[ml_id]
+                else:
+                    move_line["amount_residual"] = -credit_amount[ml_id]
+                if move_line.get("amount_residual_currency", False):
+                    move_line["amount_residual_currency"] -= credit_amount_currency[
+                        ml_id
+                    ]
+                else:
+                    move_line["amount_residual_currency"] = -credit_amount_currency[
+                        ml_id
+                    ]
         return move_lines
 
     def _get_accounts_data(self, accounts_ids):

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -70,25 +70,41 @@ class AgedPartnerBalanceReport(models.AbstractModel):
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
-        fields = ["debit_move_id", "credit_move_id", "amount"]
+        fields = ["debit_move_id", "credit_move_id", "amount", "amount_currency"]
         accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
             domain=domain, fields=fields
         )
         debit_amount = {}
+        debit_amount_currency = {}
         credit_amount = {}
+        credit_amount_currency = {}
         for account_partial_reconcile_data in accounts_partial_reconcile:
             debit_move_id = account_partial_reconcile_data["debit_move_id"][0]
             credit_move_id = account_partial_reconcile_data["credit_move_id"][0]
             if debit_move_id not in debit_amount.keys():
                 debit_amount[debit_move_id] = 0.0
+                debit_amount_currency[debit_move_id] = 0.0
+            debit_amount_currency[debit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             debit_amount[debit_move_id] += account_partial_reconcile_data["amount"]
             if credit_move_id not in credit_amount.keys():
                 credit_amount[credit_move_id] = 0.0
+                credit_amount_currency[credit_move_id] = 0.0
             credit_amount[credit_move_id] += account_partial_reconcile_data["amount"]
+            credit_amount_currency[credit_move_id] += account_partial_reconcile_data[
+                "amount_currency"
+            ]
             account_partial_reconcile_data.update(
                 {"debit_move_id": debit_move_id, "credit_move_id": credit_move_id}
             )
-        return accounts_partial_reconcile, debit_amount, credit_amount
+        return (
+            accounts_partial_reconcile,
+            debit_amount,
+            credit_amount,
+            debit_amount_currency,
+            credit_amount_currency,
+        )
 
     def _get_move_lines_data(
         self,
@@ -127,6 +143,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 acc_partial_rec,
                 debit_amount,
                 credit_amount,
+                debit_amount_currency,
+                credit_amount_currency,
             ) = self._get_account_partial_reconciled(company_id, date_at_object)
             if acc_partial_rec:
                 ml_ids = list(map(operator.itemgetter("id"), move_lines))
@@ -147,6 +165,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                     company_id,
                     partner_ids,
                     only_posted_moves,
+                    debit_amount_currency,
+                    credit_amount_currency,
                 )
         move_lines = [
             move_line

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -16,25 +16,47 @@ class OpenItemsReport(models.AbstractModel):
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
-        fields = ["debit_move_id", "credit_move_id", "amount"]
+        fields = [
+            "debit_move_id",
+            "credit_move_id",
+            "amount",
+            "debit_amount_currency",
+            "credit_amount_currency",
+        ]
         accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
             domain=domain, fields=fields
         )
         debit_amount = {}
+        debit_amount_currency = {}
         credit_amount = {}
+        credit_amount_currency = {}
         for account_partial_reconcile_data in accounts_partial_reconcile:
             debit_move_id = account_partial_reconcile_data["debit_move_id"][0]
             credit_move_id = account_partial_reconcile_data["credit_move_id"][0]
             if debit_move_id not in debit_amount.keys():
                 debit_amount[debit_move_id] = 0.0
+                debit_amount_currency[debit_move_id] = 0.0
             debit_amount[debit_move_id] += account_partial_reconcile_data["amount"]
+            debit_amount_currency[debit_move_id] += account_partial_reconcile_data[
+                "debit_amount_currency"
+            ]
             if credit_move_id not in credit_amount.keys():
                 credit_amount[credit_move_id] = 0.0
+                credit_amount_currency[credit_move_id] = 0.0
             credit_amount[credit_move_id] += account_partial_reconcile_data["amount"]
+            credit_amount_currency[credit_move_id] += account_partial_reconcile_data[
+                "credit_amount_currency"
+            ]
             account_partial_reconcile_data.update(
                 {"debit_move_id": debit_move_id, "credit_move_id": credit_move_id}
             )
-        return accounts_partial_reconcile, debit_amount, credit_amount
+        return (
+            accounts_partial_reconcile,
+            debit_amount,
+            credit_amount,
+            debit_amount_currency,
+            credit_amount_currency,
+        )
 
     def _get_data(
         self,
@@ -77,6 +99,8 @@ class OpenItemsReport(models.AbstractModel):
                 acc_partial_rec,
                 debit_amount,
                 credit_amount,
+                debit_amount_currency,
+                credit_amount_currency,
             ) = self._get_account_partial_reconciled(company_id, date_at_object)
             if acc_partial_rec:
                 ml_ids = list(map(operator.itemgetter("id"), move_lines))
@@ -97,6 +121,8 @@ class OpenItemsReport(models.AbstractModel):
                     company_id,
                     partner_ids,
                     only_posted_moves,
+                    debit_amount_currency,
+                    credit_amount_currency,
                 )
         move_lines = [
             move_line


### PR DESCRIPTION
Fixed the amount_residual_currency on partial reconcile.

This PR is derived from https://github.com/OCA/account-financial-reporting/pull/853, the only differences are in the adaptation to the _accounts_partial_reconcile_ model differences between 13.0 and 14.0.