### PR TITLE
[15.0][FIX] account_financial_report: Don't show cancelled items when clicking on interactive cells

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -230,6 +230,16 @@
         </div>
     </template>
     <template id="account_financial_report.report_trial_balance_line">
+        <t
+            t-set="aml_domain_common"
+            t-if="only_posted_moves"
+            t-value="[('parent_state', '=', 'posted')]"
+        />
+        <t
+            t-set="aml_domain_common"
+            t-else=""
+            t-value="[('parent_state', 'in', ('posted', 'draft'))]"
+        />
         <!-- # line -->
         <div class="act_as_row lines">
             <t t-if="not show_partner_details">
@@ -302,7 +312,10 @@
                             t-value="[('account_id', '=', balance['id']),
                                ('date', '&lt;', date_from)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-esc="balance['initial_balance']"
@@ -316,7 +329,10 @@
                             t-value="[('account_id', 'in', balance['account_ids']),
                                     ('date', '&lt;', date_from)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-raw="balance['initial_balance']"
@@ -332,7 +348,10 @@
                                  ('partner_id', '=', int(partner_id)),
                                  ('date', '&lt;', date_from)]"
                     />
-                    <span t-att-domain="domain" res-model="account.move.line">
+                    <span
+                        t-att-domain="domain+aml_domain_common"
+                        res-model="account.move.line"
+                    >
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['initial_balance']"
@@ -352,7 +371,10 @@
                                          ('date', '&lt;=', date_to),
                                          ('debit', '&lt;&gt;', 0)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-esc="balance['debit']"
@@ -368,7 +390,10 @@
                                     ('date', '&lt;=', date_to),
                                     ('debit', '&lt;&gt;', 0)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-raw="balance['debit']"
@@ -386,7 +411,10 @@
                                  ('date', '&lt;=', date_to),
                                  ('debit', '&lt;&gt;', 0)]"
                     />
-                    <span t-att-domain="domain" res-model="account.move.line">
+                    <span
+                        t-att-domain="domain+aml_domain_common"
+                        res-model="account.move.line"
+                    >
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['debit']"
@@ -406,7 +434,10 @@
                                          ('date', '&lt;=', date_to),
                                          ('credit', '&lt;&gt;', 0)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-esc="balance['credit']"
@@ -422,7 +453,10 @@
                                     ('date', '&lt;=', date_to),
                                     ('credit', '&lt;&gt;', 0)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-raw="balance['credit']"
@@ -440,7 +474,10 @@
                                  ('date', '&lt;=', date_to),
                                  ('credit', '&lt;&gt;', 0)]"
                     />
-                    <span t-att-domain="domain" res-model="account.move.line">
+                    <span
+                        t-att-domain="domain+aml_domain_common"
+                        res-model="account.move.line"
+                    >
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['credit']"
@@ -460,7 +497,10 @@
                                     ('date', '&lt;=', date_to),
                                     ('balance', '&lt;&gt;', 0)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-esc="balance['balance']"
@@ -475,7 +515,10 @@
                                     ('date', '&gt;=', date_from),
                                     ('date', '&lt;=', date_to)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-raw="balance['balance']"
@@ -493,7 +536,10 @@
                                  ('date', '&lt;=', date_to),
                                  ('balance', '&lt;&gt;', 0)]"
                     />
-                    <span t-att-domain="domain" res-model="account.move.line">
+                    <span
+                        t-att-domain="domain+aml_domain_common"
+                        res-model="account.move.line"
+                    >
                         <t
                             t-att-style="style"
                             t-raw="total_amount[account_id][partner_id]['balance']"
@@ -511,7 +557,10 @@
                             t-value="[('account_id', '=', balance['id']),
                                          ('date', '&lt;=', date_to)]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-esc="balance['ending_balance']"
@@ -524,7 +573,10 @@
                             t-set="domain"
                             t-value="[('account_id', 'in', balance['account_ids'])]"
                         />
-                        <span t-att-domain="domain" res-model="account.move.line">
+                        <span
+                            t-att-domain="domain+aml_domain_common"
+                            res-model="account.move.line"
+                        >
                             <t
                                 t-att-style="style"
                                 t-raw="balance['ending_balance']"
@@ -540,7 +592,10 @@
                                  ('partner_id', '=', int(partner_id)),
                                  ('date', '&lt;=', date_to)]"
                     />
-                    <span t-att-domain="domain" res-model="account.move.line">
+                    <span
+                        t-att-domain="domain+aml_domain_common"
+                        res-model="account.move.line"
+                    >
                         <t
                             t-att-style="style"
                             t-esc="total_amount[account_id][partner_id]['ending_balance']"
@@ -564,7 +619,7 @@
                                     t-value="[('account_id', '=', balance['id'])]"
                                 />
                                 <span
-                                    t-att-domain="domain"
+                                    t-att-domain="domain+aml_domain_common"
                                     res-model="account.move.line"
                                 >
                                     <t
@@ -603,7 +658,7 @@
                                             ('partner_id', '=', partner_id)]"
                                 />
                                 <span
-                                    t-att-domain="domain"
+                                    t-att-domain="domain+aml_domain_common"
                                     res-model="account.move.line"
                                 >
                                     <t
@@ -625,7 +680,7 @@
                                     t-value="[('account_id', '=', balance['id'])]"
                                 />
                                 <span
-                                    t-att-domain="domain"
+                                    t-att-domain="domain+aml_domain_common"
                                     res-model="account.move.line"
                                 >
                                     <t
@@ -658,7 +713,7 @@
                                             ('partner_id', '=', partner_id)]"
                                 />
                                 <span
-                                    t-att-domain="domain"
+                                    t-att-domain="domain+aml_domain_common"
                                     res-model="account.move.line"
                                 >
                                     <t


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/account-financial-reporting/pull/934

Don't show cancelled items when clicking on interactive cells.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT39954