### PR TITLE
[13.0][IMP] account_financial_report: extensibility: ml fields

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -4,9 +4,21 @@
 from odoo import api, models
 
 
-class AgedPartnerBalanceReport(models.AbstractModel):
+class AbstractReport(models.AbstractModel):
     _name = "report.account_financial_report.abstract_report"
     _description = "Abstract Report"
+    COMMON_ML_FIELDS = [
+        "account_id",
+        "ref",
+        "journal_id",
+        "credit",
+        "debit",
+        "date",
+        "partner_id",
+        "id",
+        "move_id",
+        "name",
+    ]
 
     @api.model
     def _get_move_lines_domain_not_reconciled(
@@ -68,24 +80,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         new_domain = self._get_new_move_lines_domain(
             new_ml_ids, account_ids, company_id, partner_ids, only_posted_moves
         )
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "amount_residual",
-            "date_maturity",
-            "ref",
-            "debit",
-            "credit",
-            "reconciled",
-            "currency_id",
-            "amount_currency",
-            "amount_residual_currency",
-        ]
+        ml_fields = self._get_ml_fields()
         new_move_lines = self.env["account.move.line"].search_read(
             domain=new_domain, fields=ml_fields
         )
@@ -124,3 +119,13 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         for journal in journals:
             journals_data.update({journal.id: {"id": journal.id, "code": journal.code}})
         return journals_data
+
+    def _get_ml_fields(self):
+        return self.COMMON_ML_FIELDS + [
+            "reconciled",
+            "currency_id",
+            "amount_residual",
+            "date_maturity",
+            "amount_residual_currency",
+            "amount_currency",
+        ]

--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -282,6 +282,8 @@ class AbstractReportXslx(models.AbstractModel):
                 self.sheet.write_string(
                     self.row_pos, col_pos, value or "", self.format_right
                 )
+            else:
+                self.write_non_standard_column(cell_type, col_pos, value)
         self.row_pos += 1
 
     def write_initial_balance(self, my_object, label):
@@ -611,5 +613,11 @@ class AbstractReportXslx(models.AbstractModel):
     def _get_col_pos_final_balance_label(self):
         """
             :return: the columns position used for final balance label.
+        """
+        raise NotImplementedError()
+
+    def write_non_standard_column(self, cell_type, col_pos, value):
+        """
+            Write columns out of the columns type defined here.
         """
         raise NotImplementedError()

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -103,19 +103,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         domain = self._get_move_lines_domain_not_reconciled(
             company_id, account_ids, partner_ids, only_posted_moves, date_from
         )
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "amount_residual",
-            "date_maturity",
-            "ref",
-            "reconciled",
-        ]
+        ml_fields = self._get_ml_fields()
         line_model = self.env["account.move.line"]
         move_lines = line_model.search_read(domain=domain, fields=ml_fields)
         journals_ids = set()
@@ -376,3 +364,10 @@ class AgedPartnerBalanceReport(models.AbstractModel):
             "aged_partner_balance": aged_partner_data,
             "show_move_lines_details": show_move_line_details,
         }
+
+    def _get_ml_fields(self):
+        return self.COMMON_ML_FIELDS + [
+            "amount_residual",
+            "reconciled",
+            "date_maturity",
+        ]

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -467,27 +467,7 @@ class GeneralLedgerReport(models.AbstractModel):
         )
         if extra_domain:
             domain += extra_domain
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "debit",
-            "credit",
-            "balance",
-            "currency_id",
-            "full_reconcile_id",
-            "tax_ids",
-            "tax_line_id",
-            "analytic_tag_ids",
-            "amount_currency",
-            "ref",
-            "name",
-            "analytic_account_id",
-        ]
+        ml_fields = self._get_ml_fields()
         move_lines = self.env["account.move.line"].search_read(
             domain=domain, fields=ml_fields
         )
@@ -891,3 +871,15 @@ class GeneralLedgerReport(models.AbstractModel):
             "filter_partner_ids": True if partner_ids else False,
             "currency_model": self.env["res.currency"],
         }
+
+    def _get_ml_fields(self):
+        return self.COMMON_ML_FIELDS + [
+            "analytic_account_id",
+            "balance",
+            "full_reconcile_id",
+            "analytic_tag_ids",
+            "tax_line_id",
+            "currency_id",
+            "amount_currency",
+            "tax_ids",
+        ]

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -48,24 +48,7 @@ class OpenItemsReport(models.AbstractModel):
         domain = self._get_move_lines_domain_not_reconciled(
             company_id, account_ids, partner_ids, only_posted_moves, date_from
         )
-        ml_fields = [
-            "id",
-            "name",
-            "date",
-            "move_id",
-            "journal_id",
-            "account_id",
-            "partner_id",
-            "amount_residual",
-            "date_maturity",
-            "ref",
-            "debit",
-            "credit",
-            "reconciled",
-            "currency_id",
-            "amount_currency",
-            "amount_residual_currency",
-        ]
+        ml_fields = self._get_ml_fields()
         move_lines = self.env["account.move.line"].search_read(
             domain=domain, fields=ml_fields
         )
@@ -270,3 +253,13 @@ class OpenItemsReport(models.AbstractModel):
             "total_amount": total_amount,
             "Open_Items": open_items_move_lines_data,
         }
+
+    def _get_ml_fields(self):
+        return self.COMMON_ML_FIELDS + [
+            "reconciled",
+            "currency_id",
+            "amount_residual",
+            "date_maturity",
+            "amount_residual_currency",
+            "amount_currency",
+        ]

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -62,15 +62,7 @@ class VATReport(models.AbstractModel):
         tax_domain = self._get_tax_report_domain(
             company_id, date_from, date_to, only_posted_moves
         )
-        ml_fields = [
-            "id",
-            "tax_base_amount",
-            "balance",
-            "tax_line_id",
-            "tax_ids",
-            "analytic_tag_ids",
-            "tag_ids",
-        ]
+        ml_fields = self._get_ml_fields_vat_report()
         tax_move_lines = self.env["account.move.line"].search_read(
             domain=tax_domain, fields=ml_fields,
         )
@@ -237,3 +229,16 @@ class VATReport(models.AbstractModel):
             "tax_detail": data["tax_detail"],
             "vat_report": vat_report,
         }
+
+    def _get_ml_fields_vat_report(self):
+        return [
+            "id",
+            "tax_base_amount",
+            "credit",
+            "debit",
+            "balance",
+            "tax_line_id",
+            "tax_ids",
+            "analytic_tag_ids",
+            "tag_ids",
+        ]


### PR DESCRIPTION
I think the account move line fields gotten should be available to be extended or modified. Some examples:
- One customer may need the analytic account info in an open items report
- Some other customer may need information about purchase orders that were appearing in an open items report last month

bonus track: Put a proper class name for the abstract report base model

cc @ForgeFlow