### PR TITLE
[13.0][FIX] mis_builder_cash_flow: Change to the value of the corresponding fields to avoid incorrect values in some use cases.

### DIFF
--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -66,16 +66,8 @@ class MisCashFlow(models.Model):
                 'move_line' as line_type,
                 aml.id as move_line_id,
                 aml.account_id as account_id,
-                CASE
-                    WHEN aml.amount_residual > 0
-                    THEN aml.amount_residual
-                    ELSE 0.0
-                END AS debit,
-                CASE
-                    WHEN aml.amount_residual < 0
-                    THEN -aml.amount_residual
-                    ELSE 0.0
-                END AS credit,
+                aml.debit as debit,
+                aml.credit as credit,
                 aml.reconciled as reconciled,
                 aml.full_reconcile_id as full_reconcile_id,
                 aml.partner_id as partner_id,


### PR DESCRIPTION
Change to the value of the corresponding fields to avoid incorrect values in some use cases (https://github.com/odoo/odoo/blob/13.0/addons/account/models/account_move.py#L3344-L3348).

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT40533