### PR TITLE
[13.0][FIX] account_financial_report: Show records in general ledger when not grouped.

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -436,6 +436,8 @@ class GeneralLedgerReport(models.AbstractModel):
                     res.append({"id": tax_item.id, "name": tax_item.name})
             else:
                 res.append({"id": 0, "name": "Missing Tax"})
+        else:
+            res.append({"id": 0, "name": ""})
         return res
 
     def _get_period_ml_data(
@@ -519,13 +521,15 @@ class GeneralLedgerReport(models.AbstractModel):
                 gen_ld_data[acc_id] = self._initialize_data(foreign_currency)
                 gen_ld_data[acc_id]["id"] = acc_id
                 gen_ld_data[acc_id]["mame"] = move_line["account_id"][1]
-                gen_ld_data[acc_id][grouped_by] = False
+                if grouped_by:
+                    gen_ld_data[acc_id][grouped_by] = False
             if acc_id in acc_prt_account_ids:
                 item_ids = self._prepare_ml_items(move_line, grouped_by)
                 for item in item_ids:
                     item_id = item["id"]
                     if item_id not in gen_ld_data[acc_id]:
-                        gen_ld_data[acc_id][grouped_by] = True
+                        if grouped_by:
+                            gen_ld_data[acc_id][grouped_by] = True
                         gen_ld_data[acc_id][item_id] = self._initialize_data(
                             foreign_currency
                         )

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -81,7 +81,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
         help="Ending account in a range",
     )
     grouped_by = fields.Selection(
-        selection=[("none", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
+        selection=[("", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
         default="partners",
         string="Grouped by",
     )


### PR DESCRIPTION
Backport from 14.0: https://github.com/OCA/account-financial-reporting/pull/955

Related to: https://github.com/OCA/account-financial-reporting/issues/944

Show records in general ledger when not grouped.

Please @pedrobaeza and @sergio-teruel can you review it?

@Tecnativa