### PR TITLE
[15.0][IMP] account_financial_report: Completes the functionality of hide_parent_hierarchy_level field and fix the level of accounts for trial balance

### DIFF
--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -31,6 +31,8 @@
   * Valentin Vinagre
 
 * Lois Rilo <lois.rilo@forgeflow.com>
+* Saran Lim. <saranl@ecosoft.co.th>
+* Omar Castiñeira <omar@comunitea.com>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -46,15 +46,13 @@
                     <t t-foreach="trial_balance" t-as="balance">
                         <!-- Adapt -->
                         <t t-set="style" t-value="'font-size:12px;'" />
-                        <t t-if="show_hierarchy">
-                            <t t-if="limit_hierarchy_level">
+                        <t t-if="show_hierarchy and limit_hierarchy_level">
+                            <t
+                                t-if="show_hierarchy_level > balance['level'] and (not hide_parent_hierarchy_level or (show_hierarchy_level - 1) == balance['level'])"
+                            >
                                 <t
-                                    t-if="show_hierarchy_level > balance['level'] and (not hide_parent_hierarchy_level or (show_hierarchy_level - 1) == balance['level'])"
-                                >
-                                    <t
-                                        t-call="account_financial_report.report_trial_balance_line"
-                                    />
-                                </t>
+                                    t-call="account_financial_report.report_trial_balance_line"
+                                />
                             </t>
                         </t>
                         <t t-else="">

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -544,7 +544,9 @@ class TrialBalanceReport(models.AbstractModel):
         account_group_relation = {}
         for account in accounts:
             accounts_data[account.id]["complete_code"] = (
-                account.group_id.complete_code if account.group_id.id else ""
+                account.group_id.complete_code + " / " + account.code
+                if account.group_id.id
+                else ""
             )
             if account.group_id.id:
                 if account.group_id.id not in account_group_relation.keys():

--- a/account_financial_report/report/trial_balance_xlsx.py
+++ b/account_financial_report/report/trial_balance_xlsx.py
@@ -188,6 +188,7 @@ class TrialBalanceXslx(models.AbstractModel):
         show_hierarchy_level = res_data["show_hierarchy_level"]
         foreign_currency = res_data["foreign_currency"]
         limit_hierarchy_level = res_data["limit_hierarchy_level"]
+        hide_parent_hierarchy_level = res_data["hide_parent_hierarchy_level"]
         if not show_partner_details:
             # Display array header for account lines
             self.write_array_header(report_data)
@@ -195,12 +196,12 @@ class TrialBalanceXslx(models.AbstractModel):
         # For each account
         if not show_partner_details:
             for balance in trial_balance:
-                if show_hierarchy:
-                    if limit_hierarchy_level:
-                        if show_hierarchy_level > balance["level"]:
-                            # Display account lines
-                            self.write_line_from_dict(balance, report_data)
-                    else:
+                if show_hierarchy and limit_hierarchy_level:
+                    if show_hierarchy_level > balance["level"] and (
+                        not hide_parent_hierarchy_level
+                        or (show_hierarchy_level - 1) == balance["level"]
+                    ):
+                        # Display account lines
                         self.write_line_from_dict(balance, report_data)
                 else:
                     self.write_line_from_dict(balance, report_data)


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/account-financial-reporting/pull/873

Completes the functionality of hide_parent_hierarchy_level field and fix the level of accounts for trial balance

Please @pedrobaeza could you review it?

@Tecnativa
