### PR TITLE
[14.0][FIX] account_financial_report: generate ledger document

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -153,7 +153,7 @@ class GeneralLedgerXslx(models.AbstractModel):
         # For each account
         for account in general_ledger:
             # Write account title
-            total_bal_curr = account["init_bal"]["bal_curr"]
+            total_bal_curr = account["init_bal"].get("bal_curr", 0)
             self.write_array_title(
                 account["code"] + " - " + accounts_data[account["id"]]["name"],
                 report_data,

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -371,7 +371,7 @@
             <!-- Display each lines -->
             <t
                 t-set="total_bal_curr"
-                t-value="account_or_group_item_object['init_bal']['bal_curr'] or 0"
+                t-value="account_or_group_item_object['init_bal'].get('bal_curr', 0)"
             />
             <t t-foreach="account_or_group_item_object['move_lines']" t-as="line">
                 <!-- # lines or centralized lines -->


### PR DESCRIPTION
In general ledger report shows an error due to the fact that the ball_curr varible does not generated

In a runbot I test this:
**view general ledger**
![image](https://user-images.githubusercontent.com/77978942/208868925-810057f8-6c65-4c31-859e-3000c44002b1.png)
![image](https://user-images.githubusercontent.com/77978942/208868967-4fd63f2a-eeeb-4025-9fc0-81e756e0d2b8.png)
**export xlsx**
![image](https://user-images.githubusercontent.com/77978942/208869196-39220aaf-04bb-4302-9fec-56e1fa3bd52c.png)
![image](https://user-images.githubusercontent.com/77978942/208869150-eec9c109-05ec-49d1-abfa-102645c373ef.png)
