### PR TITLE
[15.0][FIX] account_financial_report: generate ledger document

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -154,7 +154,7 @@ class GeneralLedgerXslx(models.AbstractModel):
         # For each account
         for account in general_ledger:
             # Write account title
-            total_bal_curr = account["init_bal"]["bal_curr"]
+            total_bal_curr = account["init_bal"].get("bal_curr", 0)
             self.write_array_title(
                 account["code"] + " - " + accounts_data[account["id"]]["name"],
                 report_data,

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -371,7 +371,7 @@
             <!-- Display each lines -->
             <t
                 t-set="total_bal_curr"
-                t-value="account_or_group_item_object['init_bal']['bal_curr'] or 0"
+                t-value="account_or_group_item_object['init_bal'].get('bal_curr', 0)"
             />
             <t t-foreach="account_or_group_item_object['move_lines']" t-as="line">
                 <!-- # lines or centralized lines -->


### PR DESCRIPTION
In general ledger report shows an error due to the fact that the ball_curr varible does not generated

In a runbot I test this:
**view general ledger**
![image](https://user-images.githubusercontent.com/77978942/209518869-7e6329cb-7249-47f0-ab28-fd1a405128db.png)
![image](https://user-images.githubusercontent.com/77978942/209518903-9018f4be-7da2-49eb-872d-ca2c437b1def.png)

**export xlsx**
![image](https://user-images.githubusercontent.com/77978942/209518965-2c61c388-3fc4-4385-8e71-99141c67f618.png)
![image](https://user-images.githubusercontent.com/77978942/209518992-dcf4d115-3260-44e3-b6a3-b7451ec1b9ad.png)