### PR TITLE
[14.0][FIX] account_financial_report: foregin_currency check in general_ledger_xlsx

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -234,7 +234,8 @@ class GeneralLedgerXslx(models.AbstractModel):
 
             else:
                 # For each partner
-                total_bal_curr = account["init_bal"]["bal_curr"]
+                if foreign_currency:
+                    total_bal_curr = account["init_bal"]["bal_curr"]
                 for group_item in account["list_grouped"]:
                     # Write partner title
                     self.write_array_title(group_item["name"], report_data)


### PR DESCRIPTION
Change done:
- [x] Added a missing if in line 237. It was causing the Excel report to fail if "Show foreign currency" was not selected on the Wizard.

Please, @pedrobaeza could you review it? Thank you for your time.