### PR TITLE
[14.0][FIX] partner_statement: several fixes

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -5,6 +5,8 @@ from collections import defaultdict
 
 from odoo import api, models
 
+from .outstanding_statement import OutstandingStatement
+
 
 class ActivityStatement(models.AbstractModel):
     """Model of Activity Statement"""
@@ -17,40 +19,74 @@ class ActivityStatement(models.AbstractModel):
         return str(
             self._cr.mogrify(
                 """
-            SELECT l.partner_id, l.currency_id, l.company_id,
-            sum(CASE WHEN l.currency_id is not null AND l.amount_currency > 0.0
-                THEN l.amount_currency
-                ELSE l.debit
-            END) as debit,
-            sum(CASE WHEN l.currency_id is not null AND l.amount_currency < 0.0
-                THEN l.amount_currency * (-1)
-                ELSE l.credit
-            END) as credit
+            SELECT l.partner_id, l.currency_id, l.company_id, l.id,
+                CASE WHEN l.balance > 0.0
+                    THEN l.balance - sum(coalesce(pd.amount, 0.0))
+                    ELSE l.balance + sum(coalesce(pc.amount, 0.0))
+                END AS open_amount,
+                CASE WHEN l.balance > 0.0
+                    THEN l.amount_currency - sum(coalesce(pd.debit_amount_currency, 0.0))
+                    ELSE l.amount_currency + sum(coalesce(pc.credit_amount_currency, 0.0))
+                END AS open_amount_currency
             FROM account_move_line l
             JOIN account_account aa ON (aa.id = l.account_id)
             JOIN account_account_type at ON (at.id = aa.user_type_id)
             JOIN account_move m ON (l.move_id = m.id)
+            LEFT JOIN (SELECT pr.*
+                FROM account_partial_reconcile pr
+                INNER JOIN account_move_line l2
+                ON pr.credit_move_id = l2.id
+                WHERE l2.date < %(date_start)s
+            ) as pd ON pd.debit_move_id = l.id
+            LEFT JOIN (SELECT pr.*
+                FROM account_partial_reconcile pr
+                INNER JOIN account_move_line l2
+                ON pr.debit_move_id = l2.id
+                WHERE l2.date < %(date_start)s
+            ) as pc ON pc.credit_move_id = l.id
             WHERE l.partner_id IN %(partners)s
                 AND at.type = %(account_type)s
                 AND l.date < %(date_start)s AND not l.blocked
                 AND m.state IN ('posted')
-            GROUP BY l.partner_id, l.currency_id, l.company_id
+                AND (
+                    (pd.id IS NOT NULL AND
+                        pd.max_date < %(date_start)s) OR
+                    (pc.id IS NOT NULL AND
+                        pc.max_date < %(date_start)s) OR
+                    (pd.id IS NULL AND pc.id IS NULL)
+                )
+            GROUP BY l.partner_id, l.currency_id, l.company_id, l.balance, l.id
         """,
                 locals(),
             ),
             "utf-8",
         )
 
-    def _initial_balance_sql_q2(self, company_id):
+    def _initial_balance_sql_q2(self, sub):
         return str(
             self._cr.mogrify(
-                """
-            SELECT Q1.partner_id, debit-credit AS balance,
-            COALESCE(Q1.currency_id, c.currency_id) AS currency_id
-            FROM Q1
-            JOIN res_company c ON (c.id = Q1.company_id)
-            WHERE c.id = %(company_id)s
-        """,
+                f"""
+            SELECT {sub}.partner_id, {sub}.currency_id,
+                sum(CASE WHEN {sub}.currency_id is not null
+                    THEN {sub}.open_amount_currency
+                    ELSE {sub}.open_amount
+                END) as balance, {sub}.company_id
+            FROM {sub}
+            GROUP BY {sub}.partner_id, {sub}.currency_id, {sub}.company_id""",
+                locals(),
+            ),
+            "utf-8",
+        )
+
+    def _initial_balance_sql_q3(self, sub, company_id):
+        return str(
+            self._cr.mogrify(
+                f"""
+            SELECT {sub}.partner_id, {sub}.balance,
+                COALESCE({sub}.currency_id, c.currency_id) AS currency_id
+            FROM {sub}
+            JOIN res_company c ON (c.id = {sub}.company_id)
+            WHERE c.id = %(company_id)s""",
                 locals(),
             ),
             "utf-8",
@@ -63,12 +99,16 @@ class ActivityStatement(models.AbstractModel):
         partners = tuple(partner_ids)
         # pylint: disable=E8103
         self.env.cr.execute(
-            """WITH Q1 AS (%s), Q2 AS (%s)
-        SELECT partner_id, currency_id, balance
-        FROM Q2"""
+            """WITH Q1 AS (%s),
+                    Q2 AS (%s),
+                    Q3 AS (%s)
+        SELECT partner_id, currency_id, sum(balance) as balance
+        FROM Q2
+        GROUP BY partner_id, currency_id"""
             % (
                 self._initial_balance_sql_q1(partners, date_start, account_type),
-                self._initial_balance_sql_q2(company_id),
+                self._initial_balance_sql_q2("Q1"),
+                self._initial_balance_sql_q3("Q2", company_id),
             )
         )
         for row in self.env.cr.dictfetchall():
@@ -155,8 +195,9 @@ class ActivityStatement(models.AbstractModel):
             """
         WITH Q1 AS (%s),
              Q2 AS (%s)
-        SELECT partner_id, move_id, date, date_maturity, name, ref, debit,
-            ids, credit, amount, blocked, currency_id
+        SELECT partner_id, move_id, date, date_maturity, ids,
+            COALESCE(name, '') as name, COALESCE(ref, '') as ref,
+            debit, credit, amount, blocked, currency_id
         FROM Q2
         ORDER BY date, date_maturity, move_id"""
             % (
@@ -170,6 +211,101 @@ class ActivityStatement(models.AbstractModel):
             res[row.pop("partner_id")].append(row)
         return res
 
+    def _display_activity_reconciled_lines_sql_q1(self, sub):
+        return str(
+            self._cr.mogrify(
+                f"""
+            SELECT unnest(ids) as id
+            FROM {sub}
+        """,
+                locals(),
+            ),
+            "utf-8",
+        )
+
+    def _display_activity_reconciled_lines_sql_q2(self, sub, date_end):
+        return str(
+            self._cr.mogrify(
+                f"""
+            SELECT l.id as rel_id, m.name AS move_id, l.partner_id, l.date, l.name,
+                l.blocked, l.currency_id, l.company_id, {sub}.id,
+            CASE WHEN l.ref IS NOT NULL
+                THEN l.ref
+                ELSE m.ref
+            END as ref,
+            CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
+                THEN avg(l.amount_currency)
+                ELSE avg(l.debit)
+            END as debit,
+            CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
+                THEN avg(l.amount_currency * (-1))
+                ELSE avg(l.credit)
+            END as credit,
+            CASE WHEN l.balance > 0.0
+                THEN sum(coalesce(pc.amount, 0.0))
+                ELSE -sum(coalesce(pd.amount, 0.0))
+            END AS open_amount,
+            CASE WHEN l.balance > 0.0
+                THEN sum(coalesce(pc.debit_amount_currency, 0.0))
+                ELSE -sum(coalesce(pd.credit_amount_currency, 0.0))
+            END AS open_amount_currency,
+            CASE WHEN l.date_maturity is null
+                THEN l.date
+                ELSE l.date_maturity
+            END as date_maturity
+            FROM {sub}
+            LEFT JOIN account_partial_reconcile pd ON (
+                pd.debit_move_id = {sub}.id AND pd.max_date <= %(date_end)s)
+            LEFT JOIN account_partial_reconcile pc ON (
+                pc.credit_move_id = {sub}.id AND pc.max_date <= %(date_end)s)
+            LEFT JOIN account_move_line l ON (
+                pd.credit_move_id = l.id OR pc.debit_move_id = l.id)
+            LEFT JOIN account_move m ON (l.move_id = m.id)
+            WHERE l.date <= %(date_end)s AND m.state IN ('posted')
+            GROUP BY l.id, l.partner_id, m.name, l.date, l.date_maturity, l.name,
+                CASE WHEN l.ref IS NOT NULL
+                    THEN l.ref
+                    ELSE m.ref
+                END, {sub}.id,
+                l.blocked, l.currency_id, l.balance, l.amount_currency, l.company_id
+        """,
+                locals(),
+            ),
+            "utf-8",
+        )
+
+    def _get_account_display_reconciled_lines(
+        self, company_id, partner_ids, date_start, date_end, account_type
+    ):
+        partners = tuple(partner_ids)
+
+        # pylint: disable=E8103
+        self.env.cr.execute(
+            """
+        WITH Q1 AS (%s),
+             Q2 AS (%s),
+             Q3 AS (%s),
+             Q4 AS (%s),
+             Q5 AS (%s),
+             Q6 AS (%s)
+        SELECT partner_id, currency_id, move_id, date, date_maturity, debit,
+               credit, amount, open_amount, COALESCE(name, '') as name,
+               COALESCE(ref, '') as ref, blocked, id
+        FROM Q6
+        ORDER BY date, date_maturity, move_id"""
+            % (
+                self._display_activity_lines_sql_q1(
+                    partners, date_start, date_end, account_type
+                ),
+                self._display_activity_lines_sql_q2("Q1", company_id),
+                self._display_activity_reconciled_lines_sql_q1("Q2"),
+                self._display_activity_reconciled_lines_sql_q2("Q3", date_end),
+                self._display_outstanding_lines_sql_q2("Q4"),
+                self._display_outstanding_lines_sql_q3("Q5", company_id),
+            )
+        )
+        return self.env.cr.dictfetchall()
+
     @api.model
     def _get_report_values(self, docids, data=None):
         if not data:
@@ -181,3 +317,11 @@ class ActivityStatement(models.AbstractModel):
             data.update(wiz.create({})._prepare_statement())
         data["amount_field"] = "amount"
         return super()._get_report_values(docids, data)
+
+
+ActivityStatement._display_outstanding_lines_sql_q2 = (
+    OutstandingStatement._display_outstanding_lines_sql_q2
+)
+ActivityStatement._display_outstanding_lines_sql_q3 = (
+    OutstandingStatement._display_outstanding_lines_sql_q3
+)

--- a/partner_statement/report/activity_statement_xlsx.py
+++ b/partner_statement/report/activity_statement_xlsx.py
@@ -56,18 +56,25 @@ class ActivityStatementXslx(models.AbstractModel):
             row_pos,
             2,
             row_pos,
-            4,
+            3,
             _("Description"),
             FORMATS["format_theader_yellow_center"],
         )
-        sheet.write(row_pos, 5, _("Amount"), FORMATS["format_theader_yellow_center"])
-        sheet.write(row_pos, 6, _("Balance"), FORMATS["format_theader_yellow_center"])
+        sheet.write(
+            row_pos, 4, _("Original Amount"), FORMATS["format_theader_yellow_center"]
+        )
+        sheet.write(
+            row_pos, 5, _("Applied Amount"), FORMATS["format_theader_yellow_center"]
+        )
+        sheet.write(
+            row_pos, 6, _("Open Amount"), FORMATS["format_theader_yellow_center"]
+        )
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("prior_day"), FORMATS["format_tcell_date_left"]
         )
         sheet.merge_range(
-            row_pos, 2, row_pos, 4, _("Balance Forward"), FORMATS["format_tcell_left"]
+            row_pos, 2, row_pos, 5, _("Balance Forward"), FORMATS["format_tcell_left"]
         )
         sheet.write(
             row_pos,
@@ -89,7 +96,7 @@ class ActivityStatementXslx(models.AbstractModel):
             name_to_show = (
                 line.get("name", "") == "/" or not line.get("name", "")
             ) and line.get("ref", "")
-            if line.get("name", "") != "/":
+            if line.get("name", "") and line.get("name", "") != "/":
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:
@@ -101,18 +108,24 @@ class ActivityStatementXslx(models.AbstractModel):
                         name_to_show = line.get("ref", "")
             sheet.write(row_pos, 0, line.get("move_id", ""), format_tcell_left)
             sheet.write(row_pos, 1, line.get("date", ""), format_tcell_date_left)
-            sheet.merge_range(row_pos, 2, row_pos, 4, name_to_show, format_distributed)
-            sheet.write(row_pos, 5, line.get("amount", ""), current_money_format)
-            sheet.write(row_pos, 6, line.get("balance", ""), current_money_format)
+            sheet.merge_range(row_pos, 2, row_pos, 3, name_to_show, format_distributed)
+            sheet.write(row_pos, 4, line.get("amount", ""), current_money_format)
+            sheet.write(
+                row_pos, 5, line.get("applied_amount", ""), current_money_format
+            )
+            sheet.write(row_pos, 6, line.get("open_amount", ""), current_money_format)
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("end"), FORMATS["format_tcell_date_left"]
         )
         sheet.merge_range(
-            row_pos, 2, row_pos, 4, _("Ending Balance"), FORMATS["format_tcell_left"]
+            row_pos, 2, row_pos, 5, _("Ending Balance"), FORMATS["format_tcell_left"]
         )
         sheet.write(
-            row_pos, 6, currency_data.get("amount_due"), FORMATS["current_money_format"]
+            row_pos,
+            6,
+            currency_data.get("amount_due"),
+            FORMATS["current_money_format"],
         )
         return row_pos
 

--- a/partner_statement/report/detailed_activity_statement.py
+++ b/partner_statement/report/detailed_activity_statement.py
@@ -20,103 +20,6 @@ class DetailedActivityStatement(models.AbstractModel):
             company_id, partner_ids, date_start, date_end, account_type
         )
 
-    def _display_activity_reconciled_lines_sql_q1(self, sub):
-        return str(
-            self._cr.mogrify(
-                f"""
-            SELECT unnest(ids) as id
-            FROM {sub}
-        """,
-                locals(),
-            ),
-            "utf-8",
-        )
-
-    def _display_activity_reconciled_lines_sql_q2(self, sub, date_end):
-        return str(
-            self._cr.mogrify(
-                f"""
-            SELECT l.id as rel_id, m.name AS move_id, l.partner_id, l.date, l.name,
-                l.blocked, l.currency_id, l.company_id, {sub}.id,
-            CASE WHEN l.ref IS NOT NULL
-                THEN l.ref
-                ELSE m.ref
-            END as ref,
-            CASE WHEN (l.currency_id is not null AND l.amount_currency > 0.0)
-                THEN avg(l.amount_currency)
-                ELSE avg(l.debit)
-            END as debit,
-            CASE WHEN (l.currency_id is not null AND l.amount_currency < 0.0)
-                THEN avg(l.amount_currency * (-1))
-                ELSE avg(l.credit)
-            END as credit,
-            CASE WHEN l.balance > 0.0
-                THEN sum(coalesce(pc.amount, 0.0))
-                ELSE -sum(coalesce(pd.amount, 0.0))
-            END AS open_amount,
-            CASE WHEN l.balance > 0.0
-                THEN sum(coalesce(pc.debit_amount_currency, 0.0))
-                ELSE -sum(coalesce(pd.credit_amount_currency, 0.0))
-            END AS open_amount_currency,
-            CASE WHEN l.date_maturity is null
-                THEN l.date
-                ELSE l.date_maturity
-            END as date_maturity
-            FROM {sub}
-            LEFT JOIN account_partial_reconcile pd ON (
-                pd.debit_move_id = {sub}.id AND pd.max_date <= %(date_end)s)
-            LEFT JOIN account_partial_reconcile pc ON (
-                pc.credit_move_id = {sub}.id AND pc.max_date <= %(date_end)s)
-            LEFT JOIN account_move_line l ON (
-                pd.credit_move_id = l.id OR pc.debit_move_id = l.id)
-            LEFT JOIN account_move m ON (l.move_id = m.id)
-            WHERE l.date <= %(date_end)s AND m.state IN ('posted')
-            GROUP BY l.id, l.partner_id, m.name, l.date, l.date_maturity, l.name,
-                CASE WHEN l.ref IS NOT NULL
-                    THEN l.ref
-                    ELSE m.ref
-                END, {sub}.id,
-                l.blocked, l.currency_id, l.balance, l.amount_currency, l.company_id
-        """,
-                locals(),
-            ),
-            "utf-8",
-        )
-
-    def _get_account_display_reconciled_lines(
-        self, company_id, partner_ids, date_start, date_end, account_type
-    ):
-        res = dict(map(lambda x: (x, []), partner_ids))
-        partners = tuple(partner_ids)
-
-        # pylint: disable=E8103
-        self.env.cr.execute(
-            """
-        WITH Q1 AS (%s),
-             Q2 AS (%s),
-             Q3 AS (%s),
-             Q4 AS (%s),
-             Q5 AS (%s),
-             Q6 AS (%s)
-        SELECT partner_id, currency_id, move_id, date, date_maturity, debit,
-               credit, amount, open_amount, name, ref, blocked, id
-        FROM Q6
-        ORDER BY date, date_maturity, move_id"""
-            % (
-                self._display_activity_lines_sql_q1(
-                    partners, date_start, date_end, account_type
-                ),
-                self._display_activity_lines_sql_q2("Q1", company_id),
-                self._display_activity_reconciled_lines_sql_q1("Q2"),
-                self._display_activity_reconciled_lines_sql_q2("Q3", date_end),
-                self._display_outstanding_lines_sql_q2("Q4"),
-                self._display_outstanding_lines_sql_q3("Q5", company_id),
-            )
-        )
-        for row in self.env.cr.dictfetchall():
-            res[row.pop("partner_id")].append(row)
-        return res
-
     def _get_account_display_ending_lines(
         self, company_id, partner_ids, date_start, date_end, account_type
     ):
@@ -125,9 +28,6 @@ class DetailedActivityStatement(models.AbstractModel):
         )
 
     def _add_currency_prior_line(self, line, currency):
-        return self._add_currency_line2(line, currency)
-
-    def _add_currency_reconciled_line(self, line, currency):
         return self._add_currency_line2(line, currency)
 
     def _add_currency_ending_line(self, line, currency):
@@ -139,11 +39,5 @@ DetailedActivityStatement._get_account_display_lines2 = (
 )
 DetailedActivityStatement._display_outstanding_lines_sql_q1 = (
     OutstandingStatement._display_outstanding_lines_sql_q1
-)
-DetailedActivityStatement._display_outstanding_lines_sql_q2 = (
-    OutstandingStatement._display_outstanding_lines_sql_q2
-)
-DetailedActivityStatement._display_outstanding_lines_sql_q3 = (
-    OutstandingStatement._display_outstanding_lines_sql_q3
 )
 DetailedActivityStatement._add_currency_line2 = OutstandingStatement._add_currency_line

--- a/partner_statement/report/detailed_activity_statement_xlsx.py
+++ b/partner_statement/report/detailed_activity_statement_xlsx.py
@@ -37,7 +37,6 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         partner_data = data.get("data", {}).get(partner.id, {})
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
-        show_balance = data.get("show_balance", True)
         row_pos += 2
         statement_header = _("Detailed %sStatement between %s and %s in %s") % (
             account_type == "payable" and _("Supplier ") or "",
@@ -49,7 +48,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             0,
             row_pos,
-            7 if show_balance else 6,
+            6,
             statement_header,
             FORMATS["format_left_bold"],
         )
@@ -66,17 +65,15 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             _("Description"),
             FORMATS["format_theader_yellow_center"],
         )
-        sheet.write(row_pos, 4, _("Original"), FORMATS["format_theader_yellow_center"])
+        sheet.write(
+            row_pos, 4, _("Original Amount"), FORMATS["format_theader_yellow_center"]
+        )
         sheet.write(
             row_pos, 5, _("Applied Amount"), FORMATS["format_theader_yellow_center"]
         )
         sheet.write(
             row_pos, 6, _("Open Amount"), FORMATS["format_theader_yellow_center"]
         )
-        if show_balance:
-            sheet.write(
-                row_pos, 7, _("Balance"), FORMATS["format_theader_yellow_center"]
-            )
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("prior_day"), FORMATS["format_tcell_date_left"]
@@ -85,13 +82,13 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             2,
             row_pos,
-            6 if show_balance else 5,
+            5,
             _("Initial Balance"),
             FORMATS["format_tcell_left"],
         )
         sheet.write(
             row_pos,
-            7 if show_balance else 6,
+            6,
             currency_data.get("balance_forward"),
             FORMATS["current_money_format"],
         )
@@ -124,7 +121,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             name_to_show = (
                 line.get("name", "") == "/" or not line.get("name", "")
             ) and line.get("ref", "")
-            if line.get("name", "") != "/":
+            if line.get("name", "") and line.get("name", "") != "/":
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:
@@ -152,8 +149,6 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 line.get("open_amount", "") if not line.get("reconciled_line") else "",
                 current_money_format,
             )
-            if show_balance:
-                sheet.write(row_pos, 7, line.get("balance", ""), current_money_format)
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("end"), FORMATS["format_tcell_date_left"]
@@ -162,13 +157,13 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             2,
             row_pos,
-            6 if show_balance else 5,
+            5,
             _("Ending Balance"),
             FORMATS["format_tcell_left"],
         )
         sheet.write(
             row_pos,
-            7 if show_balance else 6,
+            6,
             currency_data.get("amount_due"),
             FORMATS["current_money_format"],
         )
@@ -178,7 +173,6 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         partner_data = data.get("data", {}).get(partner.id, {})
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
-        show_balance = data.get("show_balance", True)
         row_pos += 2
         statement_header = _("%sStatement up to %s in %s") % (
             account_type == "payable" and _("Supplier ") or "",
@@ -189,7 +183,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             0,
             row_pos,
-            7 if show_balance else 6,
+            6,
             statement_header,
             FORMATS["format_left_bold"],
         )
@@ -199,22 +193,17 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         )
         sheet.write(row_pos, 1, _("Date"), FORMATS["format_theader_yellow_center"])
         sheet.write(row_pos, 2, _("Due Date"), FORMATS["format_theader_yellow_center"])
-        sheet.merge_range(
+        sheet.write(
             row_pos,
             3,
-            row_pos,
-            4,
             _("Description"),
             FORMATS["format_theader_yellow_center"],
         )
-        sheet.write(row_pos, 5, _("Original"), FORMATS["format_theader_yellow_center"])
+        sheet.write(row_pos, 4, _("Original"), FORMATS["format_theader_yellow_center"])
         sheet.write(
-            row_pos, 6, _("Open Amount"), FORMATS["format_theader_yellow_center"]
+            row_pos, 5, _("Open Amount"), FORMATS["format_theader_yellow_center"]
         )
-        if show_balance:
-            sheet.write(
-                row_pos, 7, _("Balance"), FORMATS["format_theader_yellow_center"]
-            )
+        sheet.write(row_pos, 6, _("Balance"), FORMATS["format_theader_yellow_center"])
         format_tcell_left = FORMATS["format_tcell_left"]
         format_tcell_date_left = FORMATS["format_tcell_date_left"]
         format_distributed = FORMATS["format_distributed"]
@@ -243,7 +232,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             name_to_show = (
                 line.get("name", "") == "/" or not line.get("name", "")
             ) and line.get("ref", "")
-            if line.get("name", "") != "/":
+            if line.get("name", "") and line.get("name", "") != "/":
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:
@@ -261,11 +250,10 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 line.get("date_maturity", ""),
                 format_tcell_date_left,
             )
-            sheet.merge_range(row_pos, 3, row_pos, 4, name_to_show, format_distributed)
-            sheet.write(row_pos, 5, line.get("amount", ""), current_money_format)
-            sheet.write(row_pos, 6, line.get("open_amount", ""), current_money_format)
-            if show_balance:
-                sheet.write(row_pos, 7, line.get("balance", ""), current_money_format)
+            sheet.write(row_pos, 3, name_to_show, format_distributed)
+            sheet.write(row_pos, 4, line.get("amount", ""), current_money_format)
+            sheet.write(row_pos, 5, line.get("open_amount", ""), current_money_format)
+            sheet.write(row_pos, 6, line.get("balance", ""), current_money_format)
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("prior_day"), FORMATS["format_tcell_date_left"]
@@ -274,14 +262,14 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             2,
             row_pos,
-            6 if show_balance else 5,
+            5,
             _("Ending Balance"),
             FORMATS["format_tcell_left"],
         )
         sheet.write(
             row_pos,
-            7 if show_balance else 6,
-            currency_data.get("amount_due"),
+            6,
+            currency_data.get("balance_forward"),
             FORMATS["current_money_format"],
         )
         return row_pos
@@ -290,7 +278,6 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         partner_data = data.get("data", {}).get(partner.id, {})
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
-        show_balance = data.get("show_balance", True)
         row_pos += 2
         statement_header = _("%sStatement up to %s in %s") % (
             account_type == "payable" and _("Supplier ") or "",
@@ -301,7 +288,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             0,
             row_pos,
-            7 if show_balance else 6,
+            6,
             statement_header,
             FORMATS["format_left_bold"],
         )
@@ -311,22 +298,17 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         )
         sheet.write(row_pos, 1, _("Date"), FORMATS["format_theader_yellow_center"])
         sheet.write(row_pos, 2, _("Due Date"), FORMATS["format_theader_yellow_center"])
-        sheet.merge_range(
+        sheet.write(
             row_pos,
             3,
-            row_pos,
-            4,
             _("Description"),
             FORMATS["format_theader_yellow_center"],
         )
-        sheet.write(row_pos, 5, _("Original"), FORMATS["format_theader_yellow_center"])
+        sheet.write(row_pos, 4, _("Original"), FORMATS["format_theader_yellow_center"])
         sheet.write(
-            row_pos, 6, _("Open Amount"), FORMATS["format_theader_yellow_center"]
+            row_pos, 5, _("Open Amount"), FORMATS["format_theader_yellow_center"]
         )
-        if show_balance:
-            sheet.write(
-                row_pos, 7, _("Balance"), FORMATS["format_theader_yellow_center"]
-            )
+        sheet.write(row_pos, 6, _("Balance"), FORMATS["format_theader_yellow_center"])
         format_tcell_left = FORMATS["format_tcell_left"]
         format_tcell_date_left = FORMATS["format_tcell_date_left"]
         format_distributed = FORMATS["format_distributed"]
@@ -355,7 +337,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             name_to_show = (
                 line.get("name", "") == "/" or not line.get("name", "")
             ) and line.get("ref", "")
-            if line.get("name", "") != "/":
+            if line.get("name", "") and line.get("name", "") != "/":
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:
@@ -373,11 +355,10 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 line.get("date_maturity", ""),
                 format_tcell_date_left,
             )
-            sheet.merge_range(row_pos, 3, row_pos, 4, name_to_show, format_distributed)
-            sheet.write(row_pos, 5, line.get("amount", ""), current_money_format)
-            sheet.write(row_pos, 6, line.get("open_amount", ""), current_money_format)
-            if show_balance:
-                sheet.write(row_pos, 7, line.get("balance", ""), current_money_format)
+            sheet.write(row_pos, 3, name_to_show, format_distributed)
+            sheet.write(row_pos, 4, line.get("amount", ""), current_money_format)
+            sheet.write(row_pos, 5, line.get("open_amount", ""), current_money_format)
+            sheet.write(row_pos, 6, line.get("balance", ""), current_money_format)
         row_pos += 1
         sheet.write(
             row_pos, 1, partner_data.get("end"), FORMATS["format_tcell_date_left"]
@@ -386,21 +367,20 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             2,
             row_pos,
-            6 if show_balance else 5,
+            5,
             _("Ending Balance"),
             FORMATS["format_tcell_left"],
         )
         sheet.write(
             row_pos,
-            7 if show_balance else 6,
+            6,
             currency_data.get("amount_due"),
             FORMATS["current_money_format"],
         )
         return row_pos
 
     def _size_columns(self, sheet, data):
-        show_balance = data.get("show_balance", True)
-        for i in range(8 if show_balance else 7):
+        for i in range(7):
             sheet.set_column(0, i, 20)
 
     def generate_xlsx_report(self, workbook, data, objects):
@@ -413,7 +393,6 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         else:
             company = self.env.user.company_id
         data.update(report_model._get_report_values(data.get("partner_ids"), data))
-        show_balance = data.get("show_balance", True)
         partners = self.env["res.partner"].browse(data.get("partner_ids"))
         sheet = workbook.add_worksheet(_("Detailed Activity Statement"))
         sheet.set_landscape()
@@ -422,7 +401,7 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             row_pos,
             0,
             row_pos,
-            7 if show_balance else 6,
+            6,
             _("Statement of Account from %s") % (company.display_name,),
             FORMATS["format_ws_title"],
         )

--- a/partner_statement/report/outstanting_statement_xlsx.py
+++ b/partner_statement/report/outstanting_statement_xlsx.py
@@ -74,7 +74,7 @@ class OutstandingStatementXslx(models.AbstractModel):
             name_to_show = (
                 line.get("name", "") == "/" or not line.get("name", "")
             ) and line.get("ref", "")
-            if line.get("name", "") != "/":
+            if line.get("name", "") and line.get("name", "") != "/":
                 if not line.get("ref", ""):
                     name_to_show = line.get("name", "")
                 else:

--- a/partner_statement/views/activity_statement.xml
+++ b/partner_statement/views/activity_statement.xml
@@ -17,12 +17,9 @@
                     <th>Reference number</th>
                     <th>Date</th>
                     <th>Description</th>
-                    <th class="amount"><span t-if="is_detailed">Original</span><span
-                            t-if="not is_detailed"
-                        >Amount</span></th>
-                    <th t-if="is_detailed">Applied Amount</th>
-                    <th t-if="is_detailed">Open Amount</th>
-                    <th class="amount" t-if="show_balance">Balance</th>
+                    <th class="amount">Original Amount</th>
+                    <th class="amount">Applied Amount</th>
+                    <th class="amount">Open Amount</th>
                 </tr>
             </thead>
             <tbody>
@@ -33,9 +30,8 @@
                     </td>
                     <td t-if="is_detailed">Initial Balance</td>
                     <td t-else="">Balance Forward</td>
-                    <td t-if="show_balance" />
-                    <td t-if="is_detailed" />
-                    <td t-if="is_detailed" />
+                    <td />
+                    <td />
                     <td class="amount">
                         <span
                             t-esc="currency['balance_forward']"
@@ -87,22 +83,15 @@
                             t-if="not line['reconciled_line']"
                         />
                     </td>
-                    <td class="amount" t-if="is_detailed">
+                    <td class="amount">
                         <span
                             t-esc="line['applied_amount']"
                             t-options="{'widget': 'monetary', 'display_currency': display_currency}"
                         />
                     </td>
-                    <td class="amount" t-if="is_detailed">
+                    <td class="amount">
                         <span
                             t-esc="line['open_amount']"
-                            t-options="{'widget': 'monetary', 'display_currency': display_currency}"
-                            t-if="not line['reconciled_line']"
-                        />
-                    </td>
-                    <td class="amount" t-if="show_balance">
-                        <span
-                            t-esc="line['balance']"
                             t-options="{'widget': 'monetary', 'display_currency': display_currency}"
                             t-if="not line['reconciled_line']"
                         />
@@ -114,9 +103,8 @@
                         <span t-esc="d['end']" />
                     </td>
                     <td>Ending Balance</td>
-                    <td t-if="show_balance" />
-                    <td t-if="is_detailed" />
-                    <td t-if="is_detailed" />
+                    <td />
+                    <td />
                     <td class="amount">
                         <span
                             t-esc="currency['amount_due']"

--- a/partner_statement/views/outstanding_statement.xml
+++ b/partner_statement/views/outstanding_statement.xml
@@ -19,7 +19,7 @@
                     <th>Description</th>
                     <th class="amount">Original</th>
                     <th class="amount">Open Amount</th>
-                    <th class="amount" t-if="show_balance">Balance</th>
+                    <th class="amount">Balance</th>
                 </tr>
             </thead>
             <tbody>
@@ -72,7 +72,7 @@
                             t-options="{'widget': 'monetary', 'display_currency': display_currency}"
                         />
                     </td>
-                    <td class="amount" t-if="show_balance">
+                    <td class="amount">
                         <span
                             t-esc="line['balance']"
                             t-options="{'widget': 'monetary', 'display_currency': display_currency}"
@@ -89,7 +89,7 @@
                         </td>
                     <td />
                     <td />
-                    <td t-if="show_balance" />
+                    <td />
                     <td class="amount">
                         <span
                             t-esc="ending_amount"

--- a/partner_statement/wizard/detailed_activity_statement_wizard.py
+++ b/partner_statement/wizard/detailed_activity_statement_wizard.py
@@ -18,7 +18,6 @@ class DetailedActivityStatementWizard(models.TransientModel):
         res = super()._prepare_statement()
         res.update(
             {
-                "show_balance": self.show_balance,
                 "is_detailed": True,
             }
         )

--- a/partner_statement/wizard/statement_wizard.xml
+++ b/partner_statement/wizard/statement_wizard.xml
@@ -155,15 +155,21 @@
     <record id="detailed_activity_statement_wizard_view" model="ir.ui.view">
         <field name="name">Detailed Activity Statement Wizard</field>
         <field name="model">detailed.activity.statement.wizard</field>
-        <field
-            name="inherit_id"
-            ref="partner_statement.activity_statement_wizard_view"
-        />
+        <field name="inherit_id" ref="partner_statement.statement_common_view" />
         <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <group name="aging_report" position="inside">
-                <field name="show_balance" />
-            </group>
+            <xpath expr="//div[@name='info']/span" position="before">
+                <span
+                    class="o_form_label"
+                >The detailed activity statement is an extension of the activity statement, and intends to explain the transactions
+that have happened during the period, also providing with a Prior Balance section and an Ending Balance section.
+                </span>
+                <br />
+                <br />
+            </xpath>
+            <xpath expr="//field[@name='date_end']" position="before">
+                <field name="date_start" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Fixes:

 - Initial balance for Activity Statement: Consider moves reconciled with moves that have different partner (use open amounts)
 - Reconciled moves for Detailed Activity Statement: Consider moves reconciled with moves that have different partner (they should appear).
 - Ending amounts should be correct in all cases.
 - Other minor fixes.

Improvements:

 - Refactor of Activity Statement: include columns of "Applied Amount" and "Open Amount", and removed "Balance" column.
 - Removed option "Show Balance column" for Detailed Activity Statement.