### PR TITLE
[14.0][FIX] mis_builder_cash_flow: Call the correct method (action_post) to avoid the warning message in tests.

### DIFF
--- a/mis_builder_cash_flow/tests/test_cash_flow.py
+++ b/mis_builder_cash_flow/tests/test_cash_flow.py
@@ -105,7 +105,7 @@ class TestCashFlow(TransactionCase):
                 ],
             }
         )
-        move.post()
+        move.action_post()
         self.check_matrix(
             args=[
                 ("liquidity", "Current", 1500),


### PR DESCRIPTION
Call the correct method (`action_post`) to avoid the warning message in tests.

Please @pedrobaeza can you review it?

@Tecnativa