### PR TITLE
[14.0] [FIX] account_financial_report: Fix wrong field `amount_currency` in `account.partial.reconcile`

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -70,7 +70,13 @@ class AgedPartnerBalanceReport(models.AbstractModel):
 
     def _get_account_partial_reconciled(self, company_id, date_at_object):
         domain = [("max_date", ">", date_at_object), ("company_id", "=", company_id)]
-        fields = ["debit_move_id", "credit_move_id", "amount", "amount_currency"]
+        fields = [
+            "debit_move_id",
+            "credit_move_id",
+            "amount",
+            "debit_amount_currency",
+            "credit_amount_currency",
+        ]
         accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
             domain=domain, fields=fields
         )
@@ -85,7 +91,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 debit_amount[debit_move_id] = 0.0
                 debit_amount_currency[debit_move_id] = 0.0
             debit_amount_currency[debit_move_id] += account_partial_reconcile_data[
-                "amount_currency"
+                "debit_amount_currency"
             ]
             debit_amount[debit_move_id] += account_partial_reconcile_data["amount"]
             if credit_move_id not in credit_amount.keys():
@@ -93,7 +99,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 credit_amount_currency[credit_move_id] = 0.0
             credit_amount[credit_move_id] += account_partial_reconcile_data["amount"]
             credit_amount_currency[credit_move_id] += account_partial_reconcile_data[
-                "amount_currency"
+                "credit_amount_currency"
             ]
             account_partial_reconcile_data.update(
                 {"debit_move_id": debit_move_id, "credit_move_id": credit_move_id}


### PR DESCRIPTION
Replace the wrong field `amount_currency` with two fields `debit_amount_currency` and `credit_amount_currency`.

How to reproduce the bug: 
In a database with data **view** the **Aged Partner Balance** (with a date in the past) and you will get this error:

```
 File ".../account/account_financial_report/report/aged_partner_balance.py", line 74, in _get_account_partial_reconciled
    accounts_partial_reconcile = self.env["account.partial.reconcile"].search_read(
  File "/home/rachid/dev/odoo/odoo/models.py", line 4876, in search_read
    result = records.read(fields)
  File "/home/rachid/dev/odoo/odoo/models.py", line 3011, in read
    raise ValueError("Invalid field %r on model %r" % (name, self._name))
ValueError: Invalid field 'amount_currency' on model 'account.partial.reconcile'
```

In odoo 13 there was this field but not in odoo 14

This bug happened after this MR [926](https://github.com/OCA/account-financial-reporting/pull/926)