### PR TITLE
[16.0][IMP] account_financial_report: Show move_name in entry column from general ledger report

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -312,7 +312,7 @@ class GeneralLedgerReport(models.AbstractModel):
         move_line_data = {
             "id": move_line["id"],
             "date": move_line["date"],
-            "entry": move_line["move_id"][1],
+            "entry": move_line["move_name"],
             "entry_id": move_line["move_id"][0],
             "journal_id": move_line["journal_id"][0],
             "account_id": move_line["account_id"][0],
@@ -873,4 +873,5 @@ class GeneralLedgerReport(models.AbstractModel):
             "amount_currency",
             "balance",
             "tax_ids",
+            "move_name",
         ]


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/account-financial-reporting/pull/1036

Show `move_name` in entry column from general ledger report

It is not necessary to repeat part of the text shown in _Ref - Label_ column.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT42731