### PR TITLE
[15.0][FIX] account_financial_report: Prevent error related to currency from General ledger

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -531,7 +531,10 @@ class AbstractReportXslx(models.AbstractModel):
             format_amt = report_data["formats"]["format_amount"]
             field_prefix = "format_amount"
         if "currency_id" in line_object and line_object.get("currency_id", False):
-            currency = line_object["currency_id"]
+            if isinstance(line_object["currency_id"], int):
+                currency = self.env["res.currency"].browse(line_object["currency_id"])
+            else:
+                currency = line_object["currency_id"]
             field_name = "{}_{}".format(field_prefix, currency.name)
             if hasattr(self, field_name):
                 format_amt = getattr(self, field_name)

--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -237,6 +237,15 @@ class GeneralLedgerXslx(models.AbstractModel):
                     # Display array header for move lines
                     self.write_array_header(report_data)
 
+                    account.update(
+                        {
+                            "currency_id": accounts_data[account["id"]]["currency_id"],
+                            "currency_name": accounts_data[account["id"]][
+                                "currency_name"
+                            ],
+                        }
+                    )
+
                     # Display initial balance line for partner
                     group_item.update(
                         {
@@ -248,6 +257,9 @@ class GeneralLedgerXslx(models.AbstractModel):
                             if "grouped_by" in account
                             else "",
                             "currency_id": accounts_data[account["id"]]["currency_id"],
+                            "currency_name": accounts_data[account["id"]][
+                                "currency_name"
+                            ],
                         }
                     )
                     if foreign_currency:
@@ -305,8 +317,6 @@ class GeneralLedgerXslx(models.AbstractModel):
                         group_item.update(
                             {
                                 "final_bal_curr": group_item["fin_bal"]["bal_curr"],
-                                "currency_name": group_item["currency_id"].name,
-                                "currency_id": group_item["currency_id"].id,
                             }
                         )
                     self.write_ending_balance_from_dict(group_item, report_data)
@@ -326,8 +336,6 @@ class GeneralLedgerXslx(models.AbstractModel):
                         account.update(
                             {
                                 "final_bal_curr": account["fin_bal"]["bal_curr"],
-                                "currency_name": account["currency_id"].name,
-                                "currency_id": account["currency_id"].id,
                             }
                         )
                     self.write_ending_balance_from_dict(account, report_data)

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -313,6 +313,10 @@
                 </div>
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
+                        <t
+                            t-set="account_currency"
+                            t-value="currency_model.browse(account['currency_id'])"
+                        />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span
@@ -321,7 +325,7 @@
                                 >
                                     <t
                                         t-raw="account_or_group_item_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
                             </t>
@@ -332,7 +336,7 @@
                                 >
                                     <t
                                         t-raw="account_or_group_item_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
                             </t>
@@ -345,7 +349,7 @@
                                 >
                                     <t
                                         t-raw="account_or_group_item_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
                             </t>
@@ -356,7 +360,7 @@
                                 >
                                     <t
                                         t-raw="account_or_group_item_object['init_bal']['bal_curr']"
-                                        t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
                             </t>
@@ -693,6 +697,10 @@
                 <t t-set="misc_grouped_domain" t-value="[]" t-else="" />
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
+                        <t
+                            t-set="account_currency"
+                            t-value="currency_model.browse(account['currency_id'])"
+                        />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span>
@@ -704,7 +712,7 @@
                                     >
                                         <t
                                             t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                            t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
                                 </span>
@@ -719,7 +727,7 @@
                                     >
                                         <t
                                             t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                            t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
                                 </span>
@@ -736,7 +744,7 @@
                                     >
                                         <t
                                             t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                            t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
                                 </span>
@@ -751,7 +759,7 @@
                                     >
                                         <t
                                             t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
-                                            t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"
+                                            t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
                                 </span>


### PR DESCRIPTION
FWP from 14.0: https://github.com/OCA/account-financial-reporting/pull/1033

Related to: https://github.com/OCA/account-financial-reporting/issues/1039

Prevent error related to currency from General ledger

Use case: Generate report (showing foreign currency) with accounts with defined currency.

Traceback:

```
File "/odoo/odoo-server/odoo/addons/base/models/ir_qweb_fields.py", line 448, in value_to_html
fmt = "%.{0}f".format(display_currency.decimal_places)
AttributeError: 'int' object has no attribute 'decimal_places'

The above exception was the direct cause of the following exception:

Error to render compiling AST
AttributeError: 'int' object has no attribute 'decimal_places'
Template: account_financial_report.report_general_ledger_lines
Path: /t/div/div[2]/t[6]/t[1]/div[1]/t[1]/span/t
Node: <t t-raw="account_or_group_item_object['init_bal']['bal_curr']" t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"/>

```
Please @pedrobaeza can you review it?

@Tecnativa TT42804