### PR TITLE
[FIX] account_financial_report: Empty format

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -75,9 +75,7 @@ class AbstractReportXslx(models.AbstractModel):
                 {"bold": True, "border": True, "bg_color": "#FFFFCC"}
             ),
             "format_amount": workbook.add_format(),
-            "format_amount_bold": workbook.add_format({"bold": True}).set_num_format(
-                "#,##0." + "0" * currency_id.decimal_places
-            ),
+            "format_amount_bold": workbook.add_format({"bold": True}),
             "format_percent_bold_italic": workbook.add_format(
                 {"bold": True, "italic": True}
             ),
@@ -89,6 +87,9 @@ class AbstractReportXslx(models.AbstractModel):
             "#,##0." + "0" * currency_id.decimal_places
         )
         report_data["formats"]["format_percent_bold_italic"].set_num_format("#,##0.00%")
+        report_data["formats"]["format_amount_bold"].set_num_format(
+            "#,##0." + "0" * currency_id.decimal_places
+        )
 
     def _set_column_width(self, report_data):
         """Set width for all defined columns.


### PR DESCRIPTION
**Steps**
1. Create a report that inherits from `report.account_financial_report.abstract_report_xlsx`
2. Use the format in  `report_data["formats"]["format_amount_bold"]`

**Expected**
No error

**Actual**
The following exception is raised:
```
[...]
    report_data["formats"]["format_amount_bold_right"].set_align("right")
AttributeError: 'NoneType' object has no attribute 'set_align'
```
for example see https://github.com/OCA/l10n-italy/actions/runs/5357517683/jobs/9718484779?pr=3343#step:8:1181

**Additional notes**
Method `add_format` returns the format, but `set_num_format` returns `None`, usage is described in https://xlsxwriter.readthedocs.io/format.html.

I cannot easily add a unit test because `report_data` is not available outside the XLSX rendering.