### PR TITLE
14.0 - FIX - Hide general ledger entries, when hide_at_0 flag is set and entries is grouped by partner

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -626,13 +626,9 @@ class GeneralLedgerReport(models.AbstractModel):
                     rec_after_date_to_ids,
                 )
                 group_item.update({"move_lines": move_lines})
-                if (
-                    hide_account_at_0
-                    and float_is_zero(
-                        data[data_id]["init_bal"]["balance"],
-                        precision_rounding=rounding,
-                    )
-                    and group_item["move_lines"] == []
+                if hide_account_at_0 and float_is_zero(
+                    group_item["fin_bal"]["balance"],
+                    precision_rounding=rounding,
                 ):
                     continue
                 list_grouped += [group_item]


### PR DESCRIPTION
Before this fix, when hide_at_0 flag is set and general ledger is grouped by partner, the report show entries even if final balance of grouped `move_lines` is zero

Checking if balance amount of 'fin_bal' is 0, allow to hide that group of move lines
![Fixed general ledger entries](https://github.com/OCA/account-financial-reporting/assets/93334962/9f02bae4-7071-4b63-8a6e-ba08e6531088)

When hide_at_0 flag is set and general ledger entries are grouped by partner, the item outlined in red should not be show on report, because the ending balance is zero, as indicated in help text of hide_at_0 flag
![GEN_LED_WO_FIX](https://github.com/OCA/account-financial-reporting/assets/93334962/947403ef-5ce2-4b52-bc44-a8288272e626)
