### PR TITLE
[14.0][FIX] account_financial_report: Prevent error related to currency from Trial Balance

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -731,6 +731,10 @@
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="balance['currency_id']">
+                            <t
+                                t-set="balance_currency"
+                                t-value="currency_model.browse(balance['currency_id'])"
+                            />
                             <!--## Initial balance cur.-->
                             <div class="act_as_cell amount" t-att-style="style">
                                 <t t-if="only_posted_moves">
@@ -751,7 +755,7 @@
                                 >
                                     <t
                                         t-esc="balance['initial_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': balance_currency}"
                                     />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
@@ -793,8 +797,12 @@
                                     res-model="account.move.line"
                                 >
                                     <t
+                                        t-set="total_amount_item_currency"
+                                        t-value="currency_model.browse(total_amount[account_id]['currency_id'])"
+                                    />
+                                    <t
                                         t-raw="total_amount[account_id][partner_id]['initial_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': total_amount[account_id]['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': total_amount_item_currency}"
                                     />
                                 </span>
                             </div>
@@ -824,7 +832,7 @@
                                 >
                                     <t
                                         t-raw="balance['ending_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': balance_currency}"
                                     />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
@@ -866,8 +874,12 @@
                                     res-model="account.move.line"
                                 >
                                     <t
+                                        t-set="total_amount_item_currency"
+                                        t-value="currency_model.browse(total_amount[account_id]['currency_id'])"
+                                    />
+                                    <t
                                         t-raw="total_amount[account_id][partner_id]['ending_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': total_amount[account_id]['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': total_amount_item_currency}"
                                     />
                                 </span>
                             </t>

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -731,4 +731,5 @@ class TrialBalanceReport(models.AbstractModel):
             "accounts_data": accounts_data,
             "partners_data": partners_data,
             "show_hierarchy_level": show_hierarchy_level,
+            "currency_model": self.env["res.currency"],
         }


### PR DESCRIPTION
Related to https://github.com/OCA/account-financial-reporting/issues/1053

Prevent error related to currency from Trial Balance

Use case: Generate report (showing foreign currency) with accounts with defined currency.

Traceback:

```
Error to render compiling AST
AttributeError: 'int' object has no attribute 'decimal_places' Template: account_financial_report.report_trial_balance_line Path: /t/div/t[3]/t[1]/t/t/div/span/t
Node: <t t-esc="balance['initial_currency_balance']" t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"/>

The error occured while rendering the template account_financial_report.report_trial_balance_line and evaluating the following expression: <t t-esc="balance['initial_currency_balance']" t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"/>
```

Please @pedrobaeza can you review it?