### PR TITLE
[16.0][FIX] account_financial_report: Fix currency bug on trial balance report

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -559,6 +559,10 @@
                 <t t-if="not show_partner_details">
                     <t t-if="balance['type'] == 'account_type'">
                         <t t-if="balance['currency_id']">
+                            <t
+                                t-set="balance_currency"
+                                t-value="currency_model.browse(balance['currency_id'])"
+                            />
                             <!--## Initial balance cur.-->
                             <div class="act_as_cell amount" t-att-style="style">
                                 <t
@@ -571,7 +575,7 @@
                                 >
                                     <t
                                         t-esc="balance['initial_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': balance_currency}"
                                     />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
@@ -603,8 +607,12 @@
                                     res-model="account.move.line"
                                 >
                                     <t
+                                        t-set="total_amount_item_currency"
+                                        t-value="currency_model.browse(total_amount[account_id]['currency_id'])"
+                                    />
+                                    <t
                                         t-out="total_amount[account_id][partner_id]['initial_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': total_amount[account_id]['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': total_amount_item_currency}"
                                     />
                                 </span>
                             </div>
@@ -626,7 +634,7 @@
                                 >
                                     <t
                                         t-out="balance['ending_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': balance['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': balance_currency}"
                                     />
                                 </span>
                                 <!--                            <t t-if="line.account_group_id">-->
@@ -658,8 +666,12 @@
                                     res-model="account.move.line"
                                 >
                                     <t
+                                        t-set="total_amount_item_currency"
+                                        t-value="currency_model.browse(total_amount[account_id]['currency_id'])"
+                                    />
+                                    <t
                                         t-out="total_amount[account_id][partner_id]['ending_currency_balance']"
-                                        t-options="{'widget': 'monetary', 'display_currency': total_amount[account_id]['currency_id']}"
+                                        t-options="{'widget': 'monetary', 'display_currency': total_amount_item_currency}"
                                     />
                                 </span>
                             </t>

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -216,6 +216,8 @@ class TrialBalanceReport(models.AbstractModel):
             total_amount[acc_id]["debit"] = tb["debit"]
             total_amount[acc_id]["balance"] = tb["balance"]
             total_amount[acc_id]["initial_balance"] = 0.0
+            if foreign_currency:
+                total_amount[acc_id]["initial_currency_balance"] = 0.0
         for tb in tb_initial_acc:
             acc_id = tb["account_id"]
             if acc_id not in total_amount.keys():

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -755,4 +755,5 @@ class TrialBalanceReport(models.AbstractModel):
             "accounts_data": accounts_data,
             "partners_data": partners_data,
             "show_hierarchy_level": show_hierarchy_level,
+            "currency_model": self.env["res.currency"],
         }


### PR DESCRIPTION
Fixes trial balance report so it uses currency record for display_currency option instead record's ID. It was previously throwing the following error:

`Error while render the template`
`AttributeError: 'int' object has no attribute 'decimal_places'`
`Template: account_financial_report.report_trial_balance_line`
`Path: /t/div/t[3]/t[1]/t/t/div/span/t`
`Node: <t t-esc="balance[\'initial_currency_balance\']" t-options="{\'widget\': \'monetary\', \'display_currency\': balance[\'currency_id\']}"/>`

For the error to show up there needs to be a move in a different currency from the company's currency.

Edit: Added another commit which fixed initial balance value when using foreign currency