### PR TITLE
[15.0][FIX] account_financial_report: Empty format

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -75,9 +75,7 @@ class AbstractReportXslx(models.AbstractModel):
                 {"bold": True, "border": True, "bg_color": "#FFFFCC"}
             ),
             "format_amount": workbook.add_format(),
-            "format_amount_bold": workbook.add_format({"bold": True}).set_num_format(
-                "#,##0." + "0" * currency_id.decimal_places
-            ),
+            "format_amount_bold": workbook.add_format({"bold": True}),
             "format_percent_bold_italic": workbook.add_format(
                 {"bold": True, "italic": True}
             ),
@@ -89,6 +87,9 @@ class AbstractReportXslx(models.AbstractModel):
             "#,##0." + "0" * currency_id.decimal_places
         )
         report_data["formats"]["format_percent_bold_italic"].set_num_format("#,##0.00%")
+        report_data["formats"]["format_amount_bold"].set_num_format(
+            "#,##0." + "0" * currency_id.decimal_places
+        )
 
     def _set_column_width(self, report_data):
         """Set width for all defined columns.


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-financial-reporting/pull/1048 with https://github.com/OCA/oca-port.

As requested in https://github.com/OCA/account-financial-reporting/pull/1073#pullrequestreview-1649264293.
I did not try it because I don't have a `15.0` environment.