### PR TITLE
Avoid error on installation with missing analytic account

### DIFF
--- a/account_financial_report/models/account_move_line.py
+++ b/account_financial_report/models/account_move_line.py
@@ -19,7 +19,14 @@ class AccountMoveLine(models.Model):
                 record.update(
                     {
                         "analytic_account_ids": [
-                            (6, 0, [int(k) for k in record.analytic_distribution])
+                            (
+                                6,
+                                0,
+                                self.env["account.analytic.account"]
+                                .browse([int(k) for k in record.analytic_distribution])
+                                .exists()
+                                .ids,
+                            )
                         ]
                     }
                 )


### PR DESCRIPTION
When installing the module account_financial_report, a relational table between account_move_line and account_analytic_account is created and computed.

However, if an analytic account was used only on draft invoices before being deleted, its ID will remain in the JSON column analytic_distibution of account_move_line. In that case we get a ForeignKeyViolation because the ID doesn't exist in account_analytic_account table.

Therefore, we need to check if the ID exists during the computation to avoid inserting it in the relational table and raising the error.

Replaces: #1079 