### PR TITLE
[15.0][FIX] account_purchase_stock_report_non_billed: Fix cache miss error on currency_id computed field

### DIFF
--- a/account_purchase_stock_report_non_billed/models/stock_move.py
+++ b/account_purchase_stock_report_non_billed/models/stock_move.py
@@ -9,11 +9,14 @@ class StockMove(models.Model):
 
     @api.depends("purchase_line_id")
     def _compute_currency_id(self):
+        non_purchase_move = self.env["stock.move"]
         for move in self:
             if move.purchase_line_id:
                 move.currency_id = move.purchase_line_id.currency_id
             else:
-                return super(StockMove, move)._compute_currency_id()
+                non_purchase_move |= move
+        if non_purchase_move:
+            return super(StockMove, non_purchase_move)._compute_currency_id()
 
     def get_quantity_invoiced(self, invoice_lines):
         if self.purchase_line_id:

--- a/account_purchase_stock_report_non_billed/tests/test_account_purchase_stock_report_non_billed.py
+++ b/account_purchase_stock_report_non_billed/tests/test_account_purchase_stock_report_non_billed.py
@@ -37,6 +37,7 @@ class TestAccountPurchaseStockReportNonBilled(common.TransactionCase):
         domain_ids = action["domain"][0][2]
         for move in picking.move_lines:
             self.assertIn(move.id, domain_ids)
+            self.assertEqual(move.currency_id, move.purchase_line_id.currency_id)
 
     def test_02_report_move_full_invoiced(self):
         picking = self.get_picking_done_po()


### PR DESCRIPTION

Fix CacheMiss error on stock.move currency_id non store computed field.

