### PR TITLE
[16.0] [FIX] account_financial_report: Prevent error related to currency from General Ledger

### DIFF
--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -318,7 +318,7 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-out="account_or_group_item_object['init_bal']['bal_curr']"
+                                        t-raw="account_or_group_item_object['init_bal']['bal_curr']"
                                         t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
@@ -329,7 +329,7 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-out="account_or_group_item_object['init_bal']['bal_curr']"
+                                        t-raw="account_or_group_item_object['init_bal']['bal_curr']"
                                         t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
@@ -342,7 +342,7 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-out="account_or_group_item_object['init_bal']['bal_curr']"
+                                        t-raw="account_or_group_item_object['init_bal']['bal_curr']"
                                         t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
@@ -353,7 +353,7 @@
                                     res-model="account.move.line"
                                 >
                                     <t
-                                        t-out="account_or_group_item_object['init_bal']['bal_curr']"
+                                        t-raw="account_or_group_item_object['init_bal']['bal_curr']"
                                         t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                     />
                                 </span>
@@ -717,7 +717,7 @@
                                         style="color: black;"
                                     >
                                         <t
-                                            t-out="account_or_group_item_object['fin_bal']['bal_curr']"
+                                            t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
                                             t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
@@ -732,7 +732,7 @@
                                         style="color: black;"
                                     >
                                         <t
-                                            t-out="account_or_group_item_object['fin_bal']['bal_curr']"
+                                            t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
                                             t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
@@ -749,7 +749,7 @@
                                         style="color: black;"
                                     >
                                         <t
-                                            t-out="account_or_group_item_object['fin_bal']['bal_curr']"
+                                            t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
                                             t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>
@@ -764,7 +764,7 @@
                                         style="color: black;"
                                     >
                                         <t
-                                            t-out="account_or_group_item_object['fin_bal']['bal_curr']"
+                                            t-raw="account_or_group_item_object['fin_bal']['bal_curr']"
                                             t-options="{'widget': 'monetary', 'display_currency': account_currency}"
                                         />
                                     </a>


### PR DESCRIPTION
Use case: Generate report (showing foreign currency) with accounts with defined currency.

Traceback:

File "/odoo/odoo-server/odoo/addons/base/models/ir_qweb_fields.py", line 448, in value_to_html fmt = "%.{0}f".format(display_currency.decimal_places) AttributeError: 'int' object has no attribute 'decimal_places'

The above exception was the direct cause of the following exception:

Error to render compiling AST
AttributeError: 'int' object has no attribute 'decimal_places' Template: account_financial_report.report_general_ledger_lines Path: /t/div/div[2]/t[6]/t[1]/div[1]/t[1]/span/t
Node: <t t-raw="account_or_group_item_object['init_bal']['bal_curr']" t-options="{'widget': 'monetary', 'display_currency': account['currency_id']}"/>

Port of #1042 to 16.0