### PR TITLE
[14.0][FIX]  account_financial_report: reduce report url

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -776,21 +776,22 @@ class GeneralLedgerReport(models.AbstractModel):
 
     def _get_report_values(self, docids, data):
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        date_to = data["date_to"]
-        date_from = data["date_from"]
-        partner_ids = data["partner_ids"]
-        account_ids = data["account_ids"]
-        analytic_tag_ids = data["analytic_tag_ids"]
-        cost_center_ids = data["cost_center_ids"]
-        grouped_by = data["grouped_by"]
-        hide_account_at_0 = data["hide_account_at_0"]
-        foreign_currency = data["foreign_currency"]
-        only_posted_moves = data["only_posted_moves"]
-        unaffected_earnings_account = data["unaffected_earnings_account"]
-        fy_start_date = data["fy_start_date"]
-        extra_domain = data["domain"]
+        wizard = self.env["general.ledger.report.wizard"].browse(wizard_id)
+        company_id = wizard.company_id.id
+        company = wizard.company_id
+        date_to = wizard.date_to
+        date_from = wizard.date_from
+        partner_ids = wizard.partner_ids.ids
+        account_ids = wizard.account_ids.ids
+        analytic_tag_ids = wizard.analytic_tag_ids.ids
+        cost_center_ids = wizard.cost_center_ids.ids
+        grouped_by = wizard.grouped_by
+        hide_account_at_0 = wizard.hide_account_at_0
+        foreign_currency = wizard.foreign_currency
+        only_posted_moves = wizard.target_move == "posted"
+        unaffected_earnings_account = wizard.unaffected_earnings_account.id
+        fy_start_date = wizard.fy_start_date
+        extra_domain = wizard._get_account_move_lines_domain()
         gen_ld_data = self._get_initial_balance_data(
             account_ids,
             partner_ids,
@@ -805,7 +806,7 @@ class GeneralLedgerReport(models.AbstractModel):
             extra_domain,
             grouped_by,
         )
-        centralize = data["centralize"]
+        centralize = wizard.centralize
         (
             gen_ld_data,
             accounts_data,
@@ -854,17 +855,17 @@ class GeneralLedgerReport(models.AbstractModel):
         return {
             "doc_ids": [wizard_id],
             "doc_model": "general.ledger.report.wizard",
-            "docs": self.env["general.ledger.report.wizard"].browse(wizard_id),
-            "foreign_currency": data["foreign_currency"],
+            "docs": wizard,
+            "foreign_currency": foreign_currency,
             "company_name": company.display_name,
             "company_currency": company.currency_id,
             "currency_name": company.currency_id.name,
-            "date_from": data["date_from"],
-            "date_to": data["date_to"],
-            "only_posted_moves": data["only_posted_moves"],
-            "hide_account_at_0": data["hide_account_at_0"],
-            "show_analytic_tags": data["show_analytic_tags"],
-            "show_cost_center": data["show_cost_center"],
+            "date_from": date_from,
+            "date_to": date_to,
+            "only_posted_moves": only_posted_moves,
+            "hide_account_at_0": hide_account_at_0,
+            "show_analytic_tags": wizard.show_analytic_tags,
+            "show_cost_center": wizard.show_cost_center,
             "general_ledger": general_ledger,
             "accounts_data": accounts_data,
             "journals_data": journals_data,

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -295,28 +295,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     def _prepare_report_general_ledger(self):
         self.ensure_one()
-        return {
-            "wizard_id": self.id,
-            "date_from": self.date_from,
-            "date_to": self.date_to,
-            "only_posted_moves": self.target_move == "posted",
-            "hide_account_at_0": self.hide_account_at_0,
-            "foreign_currency": self.foreign_currency,
-            "show_analytic_tags": self.show_analytic_tags,
-            "company_id": self.company_id.id,
-            "account_ids": self.account_ids.ids,
-            "partner_ids": self.partner_ids.ids,
-            "grouped_by": self.grouped_by,
-            "cost_center_ids": self.cost_center_ids.ids,
-            "show_cost_center": self.show_cost_center,
-            "analytic_tag_ids": self.analytic_tag_ids.ids,
-            "journal_ids": self.account_journal_ids.ids,
-            "centralize": self.centralize,
-            "fy_start_date": self.fy_start_date,
-            "unaffected_earnings_account": self.unaffected_earnings_account.id,
-            "account_financial_report_lang": self.env.lang,
-            "domain": self._get_account_move_lines_domain(),
-        }
+        return {"wizard_id": self.id}
 
     def _export(self, report_type):
         """Default export is PDF."""


### PR DESCRIPTION
When you try to get the report through the "general_ledger_wizard" with too many account created the report url is too long and raise the next error:

![image](https://github.com/OCA/account-financial-reporting/assets/147067396/4bfa6288-298d-43f3-986c-dfe4ef8f94db)

My fix is avoinding to pass all account parameter to the report and instead getting them from the wizard id data.