### PR TITLE
[15.0][FIX]account_financial_report: missing accounts

### DIFF
--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -31,6 +31,16 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         )
         cls.group2 = group_obj.create({"code_prefix_start": "2", "name": "Group 2"})
         # Set accounts
+        cls.account001 = cls._create_account_account(
+            cls,
+            {
+                "code": "001",
+                "name": "Account 001",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+            },
+        )
         cls.account100 = cls.company_data["default_account_receivable"]
         cls.account100.group_id = cls.group1.id
         cls.account110 = cls.env["account.account"].search(
@@ -681,3 +691,33 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         self.assertEqual(total_initial_balance, 0)
         self.assertEqual(total_final_balance, 0)
         self.assertEqual(total_debit, total_credit)
+
+    def test_05_all_accounts_loaded(self):
+        # Tests if all accounts are loaded when the account_code_ fields changed
+        all_accounts = self.env["account.account"].search([], order="code")
+        company = self.env.user.company_id
+        trial_balance = self.env["trial.balance.report.wizard"].create(
+            {
+                "date_from": self.date_start,
+                "date_to": self.date_end,
+                "target_move": "posted",
+                "hide_account_at_0": False,
+                "show_hierarchy": False,
+                "company_id": company.id,
+                "fy_start_date": self.fy_date_start,
+                "account_code_from": self.account001.id,
+                "account_code_to": all_accounts[-1].id,
+            }
+        )
+        trial_balance.on_change_account_range()
+        # sets are needed because some codes are duplicated and
+        # thus the length of all_accounts would be higher
+        all_accounts_code_set = set()
+        trial_balance_code_set = set()
+        [all_accounts_code_set.add(account.code) for account in all_accounts]
+        [
+            trial_balance_code_set.add(account.code)
+            for account in trial_balance.account_ids
+        ]
+        self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
+        self.assertTrue(trial_balance_code_set == all_accounts_code_set)

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -76,8 +76,8 @@ class TrialBalanceReportWizard(models.TransientModel):
             and self.account_code_to
             and self.account_code_to.code.isdigit()
         ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
+            start_range = self.account_code_from.code
+            end_range = self.account_code_to.code
             self.account_ids = self.env["account.account"].search(
                 [("code", ">=", start_range), ("code", "<=", end_range)]
             )


### PR DESCRIPTION
Accounts with leading 0s break the search that loads the accounts for trial balance reports.

Steps to reproduce:
1. Login
2. Go to 'Invoicing' -> 'Configuration' -> 'Chart of Accounts' ([Chart of Accounts](http://oca-account-financial-reporting-15-0-e8fb133409fc.runboat.odoo-community.org/web#cids=1&menu_id=119&action=241&model=account.account&view_type=list))
3. Create Button -> Field 'Code' has to start with at least a 0. E.g: 000123
Values for fields 'Account Name' and 'Type' don't matter
4. Go to 'Reporting' -> 'Trial Balance' (A wizard should open)
5. Select for the field 'From Code' an account with leading 0s in the code. E.g. 000123
6. Select for the 'to' field any account with code that starts with 2 or higher. E.g. 999999

In the list of accounts the first account code is 131000. In the view 'Chart of Accounts' can be seen that there are some accounts not loaded. This is because of the broken search. Those codes are stored as chars in the database. In the wizard they will be converted to integers. That casting removes the leading 0s. E.g. 000123 will be 123. In the search that integer will be casted to a char again. As a result, any account with code that is lexicographically smaller will not be loaded. Eg. codes that are 012345 or 100000 will not be loaded if the start code is 000123

![chart_of_accounts](https://github.com/OCA/account-financial-reporting/assets/132348854/4a862083-4718-4334-b275-a20ba5730cf1)
![trial_balance_loaded_accounts](https://github.com/OCA/account-financial-reporting/assets/132348854/9c14e8d3-3eb4-4f59-bbee-c1bc1c742f4d)


