### PR TITLE
[15.0][FIX] account_financial_report: error currency object

### DIFF
--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -313,10 +313,7 @@
                 </div>
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['currency_id'])"
-                        />
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span
@@ -697,10 +694,7 @@
                 <t t-set="misc_grouped_domain" t-value="[]" t-else="" />
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['currency_id'])"
-                        />
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span>


### PR DESCRIPTION
This PR fixed error run GL in view it error because object currency browse with `account['currency_id']` (object currency)
![Selection_008](https://github.com/OCA/account-financial-reporting/assets/20896369/0ab3cade-9cb1-42ba-9a09-a1be8a50839c)
