### PR TITLE
[16.0][IMP] account_financial_report: Add Missing Partner support in trial balance

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -205,7 +205,7 @@ class GeneralLedgerReport(models.AbstractModel):
             for gl in gl_initial_acc_prt:
                 if not gl["partner_id"]:
                     prt_id = 0
-                    prt_name = "Missing Partner"
+                    prt_name = _("Missing Partner")
                 else:
                     prt_id = gl["partner_id"][0]
                     prt_name = gl["partner_id"][1]
@@ -415,7 +415,7 @@ class GeneralLedgerReport(models.AbstractModel):
             item_name = (
                 move_line["partner_id"][1]
                 if move_line["partner_id"]
-                else "Missing Partner"
+                else _("Missing Partner")
             )
             res.append({"id": item_id, "name": item_name})
         elif grouped_by == "taxes":

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -5,7 +5,7 @@
 import operator
 from datetime import date, datetime
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.tools import float_is_zero
 
 
@@ -124,7 +124,7 @@ class OpenItemsReport(models.AbstractModel):
                 prt_name = move_line["partner_id"][1]
             else:
                 prt_id = 0
-                prt_name = "Missing Partner"
+                prt_name = _("Missing Partner")
             if prt_id not in partners_ids:
                 partners_data.update({prt_id: {"id": prt_id, "name": prt_name}})
                 partners_ids.add(prt_id)

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -4,7 +4,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.tools.float_utils import float_is_zero
 
 
@@ -280,31 +280,31 @@ class TrialBalanceReport(models.AbstractModel):
         partners_data = {}
         for tb in tb_period_prt:
             acc_id = tb["account_id"][0]
-            if tb["partner_id"]:
-                prt_id = tb["partner_id"][0]
-                if tb["partner_id"] not in partners_ids:
-                    partners_data.update(
-                        {prt_id: {"id": prt_id, "name": tb["partner_id"][1]}}
-                    )
-                total_amount[acc_id][prt_id] = self._prepare_total_amount(
-                    tb, foreign_currency
+            prt_id = tb["partner_id"][0] if tb["partner_id"] else 0
+            if prt_id not in partners_ids:
+                partner_name = (
+                    tb["partner_id"][1] if tb["partner_id"] else _("Missing Partner")
                 )
-                total_amount[acc_id][prt_id]["credit"] = tb["credit"]
-                total_amount[acc_id][prt_id]["debit"] = tb["debit"]
-                total_amount[acc_id][prt_id]["balance"] = tb["balance"]
-                total_amount[acc_id][prt_id]["initial_balance"] = 0.0
-                partners_ids.add(tb["partner_id"])
+                partners_data.update({prt_id: {"id": prt_id, "name": partner_name}})
+            total_amount[acc_id][prt_id] = self._prepare_total_amount(
+                tb, foreign_currency
+            )
+            total_amount[acc_id][prt_id]["credit"] = tb["credit"]
+            total_amount[acc_id][prt_id]["debit"] = tb["debit"]
+            total_amount[acc_id][prt_id]["balance"] = tb["balance"]
+            total_amount[acc_id][prt_id]["initial_balance"] = 0.0
+            partners_ids.add(prt_id)
         for tb in tb_initial_prt:
             acc_id = tb["account_id"][0]
-            if tb["partner_id"]:
-                prt_id = tb["partner_id"][0]
-                if tb["partner_id"] not in partners_ids:
-                    partners_data.update(
-                        {prt_id: {"id": prt_id, "name": tb["partner_id"][1]}}
-                    )
-                total_amount = self._compute_acc_prt_amount(
-                    total_amount, tb, acc_id, prt_id, foreign_currency
+            prt_id = tb["partner_id"][0] if tb["partner_id"] else 0
+            if prt_id not in partners_ids:
+                partner_name = (
+                    tb["partner_id"][1] if tb["partner_id"] else _("Missing Partner")
                 )
+                partners_data.update({prt_id: {"id": prt_id, "name": partner_name}})
+            total_amount = self._compute_acc_prt_amount(
+                total_amount, tb, acc_id, prt_id, foreign_currency
+            )
         return total_amount, partners_data
 
     def _remove_accounts_at_cero(self, total_amount, show_partner_details, company):


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/account-financial-reporting/pull/1113

Add Missing partner support in trial balance

If there are records without partner_id set and we show the detail of partners we need to take into account those records grouped as "Missing Partner".

Please @pedrobaeza can you review it?

@Tecnativa TT47771