### PR TITLE
[14.0] [FIX] account_financial_report: General ledger multilanguage

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -295,7 +295,10 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     def _prepare_report_general_ledger(self):
         self.ensure_one()
-        return {"wizard_id": self.id}
+        return {
+            "wizard_id": self.id,
+            "account_financial_report_lang": self.env.lang,
+        }
 
     def _export(self, report_type):
         """Default export is PDF."""


### PR DESCRIPTION
Before this fix, the general ledger report was always printed in English.

This PR https://github.com/OCA/account-financial-reporting/commit/6f5d0e9d27413db8553a029e5e2544470b6beac4 removed multiple elements in _prepare_report_general_ledger method. One of them was account_financial_report_lang, which is necessary in order to print the report in the current user's language.