### PR TITLE
[FIX]account_financial_report: missing accounts

### DIFF
--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -20,6 +20,16 @@ class TestAgedPartnerBalance(TransactionCase):
             )
         )
         cls.wizard_model = cls.env["aged.partner.balance.report.wizard"]
+        cls.account001 = cls.env["account.account"].create(
+            {
+                "code": "001",
+                "name": "Account 001",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+                "reconcile": True,
+            }
+        )
 
     def test_report(self):
         """Check that report is produced correctly."""
@@ -43,3 +53,25 @@ class TestAgedPartnerBalance(TransactionCase):
             data=data,
         )
         self.assertTrue(result)
+
+    def test_all_accounts_loaded(self):
+        # Tests if all accounts are loaded when the account_code_ fields changed
+        all_accounts = self.env["account.account"].search(
+            [("reconcile", "=", True)], order="code"
+        )
+        aged_partner_balance = self.wizard_model.create(
+            {
+                "account_code_from": self.account001.id,
+                "account_code_to": all_accounts[-1].id,
+            }
+        )
+        aged_partner_balance.on_change_account_range()
+        all_accounts_code_set = set()
+        aged_partner_balance_code_set = set()
+        [all_accounts_code_set.add(account.code) for account in all_accounts]
+        [
+            aged_partner_balance_code_set.add(account.code)
+            for account in aged_partner_balance.account_ids
+        ]
+        self.assertEqual(len(aged_partner_balance_code_set), len(all_accounts_code_set))
+        self.assertTrue(aged_partner_balance_code_set == all_accounts_code_set)

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -47,6 +47,15 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
             limit=1,
         )
         cls.partner = cls.env.ref("base.res_partner_12")
+        cls.account001 = cls.env["account.account"].create(
+            {
+                "code": "001",
+                "name": "Account 001",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+            }
+        )
 
     def _add_move(
         self,
@@ -731,3 +740,25 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_all_accounts_loaded(self):
+        # Tests if all accounts are loaded when the account_code_ fields changed
+        all_accounts = self.env["account.account"].search([], order="code")
+        general_ledger = self.env["general.ledger.report.wizard"].create(
+            {
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "account_code_from": self.account001.id,
+                "account_code_to": all_accounts[-1].id,
+            }
+        )
+        general_ledger.on_change_account_range()
+        all_accounts_code_set = set()
+        general_ledger_code_set = set()
+        [all_accounts_code_set.add(account.code) for account in all_accounts]
+        [
+            general_ledger_code_set.add(account.code)
+            for account in general_ledger.account_ids
+        ]
+        self.assertEqual(len(general_ledger_code_set), len(all_accounts_code_set))
+        self.assertTrue(general_ledger_code_set == all_accounts_code_set)

--- a/account_financial_report/tests/test_open_items.py
+++ b/account_financial_report/tests/test_open_items.py
@@ -22,6 +22,16 @@ class TestOpenItems(AccountTestInvoicingCommon):
                 tracking_disable=True,
             )
         )
+        cls.account001 = cls.env["account.account"].create(
+            {
+                "code": "001",
+                "name": "Account 001",
+                "user_type_id": cls.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+                "reconcile": True,
+            }
+        )
 
     def test_partner_filter(self):
         partner_1 = self.env.ref("base.res_partner_1")
@@ -39,3 +49,22 @@ class TestOpenItems(AccountTestInvoicingCommon):
 
         wizard = self.env["open.items.report.wizard"].with_context(**context)
         self.assertEqual(wizard._default_partners(), expected_list)
+
+    def test_all_accounts_loaded(self):
+        # Tests if all accounts are loaded when the account_code_ fields changed
+        all_accounts = self.env["account.account"].search(
+            [("reconcile", "=", True)], order="code"
+        )
+        open_items = self.env["open.items.report.wizard"].create(
+            {
+                "account_code_from": self.account001.id,
+                "account_code_to": all_accounts[-1].id,
+            }
+        )
+        open_items.on_change_account_range()
+        all_accounts_code_set = set()
+        open_items_code_set = set()
+        [all_accounts_code_set.add(account.code) for account in all_accounts]
+        [open_items_code_set.add(account.code) for account in open_items.account_ids]
+        self.assertEqual(len(open_items_code_set), len(all_accounts_code_set))
+        self.assertTrue(open_items_code_set == all_accounts_code_set)

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -49,8 +49,8 @@ class AgedPartnerBalanceWizard(models.TransientModel):
             and self.account_code_to
             and self.account_code_to.code.isdigit()
         ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
+            start_range = self.account_code_from.code
+            end_range = self.account_code_to.code
             self.account_ids = self.env["account.account"].search(
                 [
                     ("code", ">=", start_range),

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -103,8 +103,8 @@ class GeneralLedgerReportWizard(models.TransientModel):
             and self.account_code_to
             and self.account_code_to.code.isdigit()
         ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
+            start_range = self.account_code_from.code
+            end_range = self.account_code_to.code
             self.account_ids = self.env["account.account"].search(
                 [("code", ">=", start_range), ("code", "<=", end_range)]
             )

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -68,8 +68,8 @@ class OpenItemsReportWizard(models.TransientModel):
             and self.account_code_to
             and self.account_code_to.code.isdigit()
         ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
+            start_range = self.account_code_from.code
+            end_range = self.account_code_to.code
             self.account_ids = self.env["account.account"].search(
                 [
                     ("code", ">=", start_range),


### PR DESCRIPTION
Same bug fix as described in Pull Request #1098. This time it fixes the remaining 3 wizards that load accounts. See the original Pull Request for further information.
Fixed Wizards:
- aged_partner_balance_wizard (Invoicing -> Reporting -> Aged Partner Balance)
- general_ledger_wizard (Invoicing -> Reporting -> General Ledger)
- open_items_wizard (Invoicing -> Reporting -> Open Items)
