### PR TITLE
[13.0][FIX] account_financial_report: Allow filtering on any code

### DIFF
--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -1,7 +1,7 @@
 #  Copyright 2021 Simone Rubino - Agile Business Group
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import TransactionCase
+from odoo.tests import Form, TransactionCase
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, test_reports
 
 
@@ -29,3 +29,22 @@ class TestAgedPartnerBalance(TransactionCase):
             data=data,
         )
         self.assertTrue(result)
+
+    def test_account_range_filter(self):
+        account_cex001 = self.env["account.account"].create(
+            {
+                "code": "CEX001",
+                "name": "Account CEX001",
+                "user_type_id": self.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+                "reconcile": True,
+            },
+        )
+        with Form(self.env["aged.partner.balance.report.wizard"]) as wizard_form:
+            wizard_form.account_code_from = account_cex001
+            self.assertEqual([a for a in wizard_form.account_ids], [])
+            wizard_form.account_code_to = account_cex001
+            self.assertEqual(
+                [a.id for a in wizard_form.account_ids], account_cex001.ids
+            )

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -7,7 +7,7 @@ import time
 from datetime import date
 
 from odoo import api, fields
-from odoo.tests import common
+from odoo.tests import Form, common
 
 
 class TestGeneralLedgerReport(common.TransactionCase):
@@ -718,3 +718,21 @@ class TestGeneralLedgerReport(common.TransactionCase):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_account_range_filter(self):
+        account_cex001 = self.env["account.account"].create(
+            {
+                "code": "CEX001",
+                "name": "Account CEX001",
+                "user_type_id": self.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+            },
+        )
+        with Form(self.env["general.ledger.report.wizard"]) as wizard_form:
+            wizard_form.account_code_from = account_cex001
+            self.assertEqual([a for a in wizard_form.account_ids], [])
+            wizard_form.account_code_to = account_cex001
+            self.assertEqual(
+                [a.id for a in wizard_form.account_ids], account_cex001.ids
+            )

--- a/account_financial_report/tests/test_open_items.py
+++ b/account_financial_report/tests/test_open_items.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, TransactionCase
 
 
 class TestOpenItems(TransactionCase):
@@ -22,3 +22,22 @@ class TestOpenItems(TransactionCase):
 
         wizard = self.env["open.items.report.wizard"].with_context(context)
         self.assertEqual(wizard._default_partners(), expected_list)
+
+    def test_account_range_filter(self):
+        account_cex001 = self.env["account.account"].create(
+            {
+                "code": "CEX001",
+                "name": "Account CEX001",
+                "user_type_id": self.env.ref(
+                    "account.data_account_type_other_income"
+                ).id,
+                "reconcile": True,
+            },
+        )
+        with Form(self.env["open.items.report.wizard"]) as wizard_form:
+            wizard_form.account_code_from = account_cex001
+            self.assertEqual([a for a in wizard_form.account_ids], [])
+            wizard_form.account_code_to = account_cex001
+            self.assertEqual(
+                [a.id for a in wizard_form.account_ids], account_cex001.ids
+            )

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -45,25 +45,15 @@ class AgedPartnerBalanceWizard(models.TransientModel):
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
-        if (
-            self.account_code_from
-            and self.account_code_from.code.isdigit()
-            and self.account_code_to
-            and self.account_code_to.code.isdigit()
-        ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [
-                    ("code", ">=", start_range),
-                    ("code", "<=", end_range),
-                    ("reconcile", "=", True),
-                ]
-            )
+        if self.account_code_from and self.account_code_to:
+            domain = [
+                ("code", ">=", self.account_code_from.code),
+                ("code", "<=", self.account_code_to.code),
+                ("reconcile", "=", True),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
-                )
+                domain.append(("company_id", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
         return {
             "domain": {
                 "account_code_from": [("reconcile", "=", True)],

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -98,21 +98,14 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
-        if (
-            self.account_code_from
-            and self.account_code_from.code.isdigit()
-            and self.account_code_to
-            and self.account_code_to.code.isdigit()
-        ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
+        if self.account_code_from and self.account_code_to:
+            domain = [
+                ("code", ">=", self.account_code_from.code),
+                ("code", "<=", self.account_code_to.code),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
-                )
+                domain.append(("company_id", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
 
     def _init_date_from(self):
         """set start date to begin of current year if fiscal year running"""

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -63,25 +63,15 @@ class OpenItemsReportWizard(models.TransientModel):
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
-        if (
-            self.account_code_from
-            and self.account_code_from.code.isdigit()
-            and self.account_code_to
-            and self.account_code_to.code.isdigit()
-        ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [
-                    ("code", ">=", start_range),
-                    ("code", "<=", end_range),
-                    ("reconcile", "=", True),
-                ]
-            )
+        if self.account_code_from and self.account_code_to:
+            domain = [
+                ("code", ">=", self.account_code_from.code),
+                ("code", "<=", self.account_code_to.code),
+                ("reconcile", "=", True),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
-                )
+                domain.append(("company_id", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
         return {
             "domain": {
                 "account_code_from": [("reconcile", "=", True)],

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -84,21 +84,15 @@ class TrialBalanceReportWizard(models.TransientModel):
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
-        if (
-            self.account_code_from
-            and self.account_code_from.code.isdigit()
-            and self.account_code_to
-            and self.account_code_to.code.isdigit()
-        ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
-            if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
-                )
+        if self.account_code_from and self.account_code_to:
+            if self.account_code_from and self.account_code_to:
+                domain = [
+                    ("code", ">=", self.account_code_from.code),
+                    ("code", "<=", self.account_code_to.code),
+                ]
+                if self.company_id:
+                    domain.append(("company_id", "=", self.company_id.id))
+                self.account_ids = self.env["account.account"].search(domain)
 
     @api.constrains("hierarchy_on", "show_hierarchy_level")
     def _check_show_hierarchy_level(self):


### PR DESCRIPTION
Without this change, filtering on non numerical account codes does not work as the code forces the use of integer.

This is a more general fix than #1098 (later completed with #1122) and includes an adaptation of one of its tests.