### PR TITLE
[13.0][FIX] account_financial_report: show currency name instead of dictionary

### DIFF
--- a/account_financial_report/report/templates/journal_ledger.xml
+++ b/account_financial_report/report/templates/journal_ledger.xml
@@ -300,7 +300,9 @@
         <t t-if="display_currency">
             <div class="act_as_cell" name="currency_name">
                 <t t-if="move_line['currency_id']">
-                    <span t-esc="currency_ids_data.get(move_line['currency_id'], '')" />
+                    <span
+                        t-esc="currency_ids_data.get(move_line['currency_id'], '').get('name', '')"
+                    />
                 </t>
             </div>
             <div class="act_as_cell amount" name="amount_currency">


### PR DESCRIPTION
Steps:

 - Accounting > Reporting > OCA accounting reports > Journal Ledger
 - Select Date range and activate Foreign Currency

Get "{'name': 'EUR'} " in currency field

Desired: get EUR

Backport of #1117 