### PR TITLE
[13.0][FIX] account_financial_report: Assure the aml order

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -469,7 +469,7 @@ class GeneralLedgerReport(models.AbstractModel):
             domain += extra_domain
         ml_fields = self._get_ml_fields()
         move_lines = self.env["account.move.line"].search_read(
-            domain=domain, fields=ml_fields
+            domain=domain, fields=ml_fields, order="date,move_name"
         )
         journal_ids = set()
         full_reconcile_ids = set()


### PR DESCRIPTION
Backport of #1019

If we don't assure the order for the search, there are chances that several items for the same account and date appear in a incorrect order:

24/02/2023 - BNK1/2023/02/0011 - ...
27/02/2023 - BNK1/2023/02/0013 - ...
27/02/2023 - BNK1/2023/02/0012 - ...
29/02/2023 - BNK1/2023/02/0014 - ...

TT42098