### PR TITLE
[15.0][IMP] account_financial_report: analytic info + filters

### DIFF
--- a/account_financial_report/report/aged_partner_balance_xlsx.py
+++ b/account_financial_report/report/aged_partner_balance_xlsx.py
@@ -104,9 +104,14 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
             2: {"header": _("Journal"), "field": "journal", "width": 8},
             3: {"header": _("Account"), "field": "account", "width": 9},
             4: {"header": _("Partner"), "field": "partner", "width": 25},
-            5: {"header": _("Ref - Label"), "field": "ref_label", "width": 40},
-            6: {"header": _("Due date"), "field": "due_date", "width": 11},
-            7: {
+            5: {
+                "header": _("Analytic Account"),
+                "field": "analytic_account_id",
+                "width": 25,
+            },
+            6: {"header": _("Ref - Label"), "field": "ref_label", "width": 40},
+            7: {"header": _("Due date"), "field": "due_date", "width": 11},
+            8: {
                 "header": _("Residual"),
                 "field": "residual",
                 "field_footer_total": "residual",
@@ -114,7 +119,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                 "type": "amount",
                 "width": 14,
             },
-            8: {
+            9: {
                 "header": _("Current"),
                 "field": "current",
                 "field_footer_total": "current",

--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -27,15 +27,20 @@ class OpenItemsXslx(models.AbstractModel):
             2: {"header": _("Journal"), "field": "journal", "width": 8},
             3: {"header": _("Account"), "field": "account", "width": 9},
             4: {"header": _("Partner"), "field": "partner_name", "width": 25},
-            5: {"header": _("Ref - Label"), "field": "ref_label", "width": 40},
-            6: {"header": _("Due date"), "field": "date_maturity", "width": 11},
-            7: {
+            5: {
+                "header": _("Analytic Account"),
+                "field": "analytic_account_id",
+                "width": 25,
+            },
+            6: {"header": _("Ref - Label"), "field": "ref_label", "width": 40},
+            7: {"header": _("Due date"), "field": "date_maturity", "width": 11},
+            8: {
                 "header": _("Original"),
                 "field": "original",
                 "type": "amount",
                 "width": 14,
             },
-            8: {
+            9: {
                 "header": _("Residual"),
                 "field": "amount_residual",
                 "field_final_balance": "residual",
@@ -45,21 +50,21 @@ class OpenItemsXslx(models.AbstractModel):
         }
         if report.foreign_currency:
             foreign_currency = {
-                9: {
+                10: {
                     "header": _("Cur."),
                     "field": "currency_name",
                     "field_currency_balance": "currency_name",
                     "type": "currency_name",
                     "width": 7,
                 },
-                10: {
+                11: {
                     "header": _("Cur. Original"),
                     "field": "amount_currency",
                     "field_final_balance": "amount_currency",
                     "type": "amount_currency",
                     "width": 14,
                 },
-                11: {
+                12: {
                     "header": _("Cur. Residual"),
                     "field": "amount_residual_currency",
                     "field_final_balance": "amount_currency",

--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -218,13 +218,29 @@
                     <div class="act_as_cell" style="width: 5.00%;">Journal</div>
                     <!--## account code-->
                     <div class="act_as_cell" style="width: 6.00%;">Account</div>
-                    <!--## partner-->
-                    <div class="act_as_cell" style="width: 10.50%;">Partner</div>
-                    <!--## ref - label-->
-                    <div class="act_as_cell" style="width: 18.00%;">
-                        Ref -
-                        Label
-                    </div>
+                    <t t-if="analytic_account_ids">
+                        <!--## partner-->
+                        <div class="act_as_cell" style="width: 9.50%;">Partner</div>
+                        <!--## analytic account -->
+                        <div
+                            class="act_as_cell"
+                            style="width: 9.50%;"
+                        >Analytic Account</div>
+                        <!--## ref - label-->
+                        <div class="act_as_cell" style="width: 9.50%;">
+                            Ref -
+                            Label
+                        </div>
+                    </t>
+                    <t t-else="">
+                        <!--## partner-->
+                        <div class="act_as_cell" style="width: 10.50%;">Partner</div>
+                        <!--## ref - label-->
+                        <div class="act_as_cell" style="width: 18.00%;">
+                            Ref -
+                            Label
+                        </div>
+                    </t>
                     <!--## date_due-->
                     <div class="act_as_cell" style="width: 6.00%;">
                         Due
@@ -311,26 +327,60 @@
                             <t t-out="line['account']" />
                         </span>
                     </div>
-                    <!--## partner-->
-                    <div class="act_as_cell left">
-                        <span
-                            t-att-res-id="line['line_rec'].partner_id.id"
-                            res-model="res.partner"
-                            view-type="form"
-                        >
-                            <t t-out="line['partner']" />
-                        </span>
-                    </div>
-                    <!--## ref - label-->
-                    <div class="act_as_cell left">
-                        <span
-                            t-att-res-id="line['line_rec'].id"
-                            res-model="account.move.line"
-                            view-type="form"
-                        >
-                            <t t-out="line['ref_label']" />
-                        </span>
-                    </div>
+                    <t t-if="analytic_account_ids">
+                        <!--## partner-->
+                        <div class="act_as_cell left">
+                            <span
+                                t-att-res-id="line['line_rec'].partner_id.id"
+                                res-model="res.partner"
+                                view-type="form"
+                            >
+                                <t t-out="line['partner']" />
+                            </span>
+                        </div>
+                        <!-- ANAL -->
+                        <div class="act_as_cell left">
+                            <span
+                                t-att-res-id="line['line_rec'].analytic_account_id.id"
+                                res-model="analytic_account_id"
+                                view-type="form"
+                            >
+                                <t t-out="line['analytic_account_id']" />
+                            </span>
+                        </div>
+                        <!--## ref - label-->
+                        <div class="act_as_cell left">
+                            <span
+                                t-att-res-id="line['line_rec'].id"
+                                res-model="account.move.line"
+                                view-type="form"
+                            >
+                                <t t-out="line['ref_label']" />
+                            </span>
+                        </div>
+                    </t>
+                    <t t-else="">
+                        <!--## partner-->
+                        <div class="act_as_cell left">
+                            <span
+                                t-att-res-id="line['line_rec'].partner_id.id"
+                                res-model="res.partner"
+                                view-type="form"
+                            >
+                                <t t-out="line['partner']" />
+                            </span>
+                        </div>
+                        <!--## ref - label-->
+                        <div class="act_as_cell left">
+                            <span
+                                t-att-res-id="line['line_rec'].id"
+                                res-model="account.move.line"
+                                view-type="form"
+                            >
+                                <t t-out="line['ref_label']" />
+                            </span>
+                        </div>
+                    </t>
                     <!--## date_due-->
                     <div class="act_as_cell left">
                         <span

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -245,13 +245,30 @@
                 <div class="act_as_cell" style="width: 4.78%;">Journal</div>
                 <!--## account code-->
                 <div class="act_as_cell" style="width: 5.38%;">Account</div>
-                <!--## partner-->
-                <div class="act_as_cell" style="width: 15.07%;">Partner</div>
-                <!--## ref - label-->
-                <div class="act_as_cell" style="width: 24.5%;">
-                    Ref -
-                    Label
-                </div>
+
+                <t t-if="analytic_account_ids">
+                    <!--## partner-->
+                    <div class="act_as_cell" style="width: 13.19%;">Partner</div>
+                    <!--## analytic_account-->
+                    <div
+                        class="act_as_cell"
+                        style="width: 13.19%;"
+                    >Analytic Account</div>
+                    <!--## ref - label-->
+                    <div class="act_as_cell" style="width: 13.19%;">
+                        Ref -
+                        Label
+                    </div>
+                </t>
+                <t t-else="">
+                    <!--## partner-->
+                    <div class="act_as_cell" style="width: 15.07%;">Partner</div>
+                    <!--## ref - label-->
+                    <div class="act_as_cell" style="width: 24.5%;">
+                        Ref -
+                        Label
+                    </div>
+                </t>
                 <!--## date_due-->
                 <div class="act_as_cell" style="width: 6.47%;">
                     Due
@@ -324,6 +341,20 @@
                     <t t-esc="line['partner_name']" />
                 </span>
             </div>
+            <!--## cost_center-->
+            <t t-if="analytic_account_ids">
+                <div class="act_as_cell left">
+                    <t t-if="line['analytic_account_id']">
+                        <span
+                            t-att-res-id="line['analytic_account_id']"
+                            res-model="account.analytic.account"
+                            view-type="form"
+                        >
+                            <t t-raw="line['analytic_account_id']" />
+                        </span>
+                    </t>
+                </div>
+            </t>
             <!--## ref - label-->
             <div class="act_as_cell left">
                 <span t-esc="line['ref_label']" />

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -47,6 +47,16 @@ class AgedPartnerBalanceWizard(models.TransientModel):
         comodel_name="account.analytic.account", string="Filter analytic accounts"
     )
     no_analytic = fields.Boolean("Only no analytic items")
+    all_analytic = fields.Boolean("All analytic items")
+
+    @api.onchange("all_analytic", "no_analytic")
+    def on_change_all_analytic(self):
+        if self.all_analytic:
+            all_aa = self.env["account.analytic.account"].search([])
+            self.analytic_account_ids = all_aa
+            self.no_analytic = False
+        else:
+            self.analytic_account_ids = False
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -43,6 +43,10 @@ class AgedPartnerBalanceWizard(models.TransientModel):
     age_partner_config_id = fields.Many2one(
         "account.age.report.configuration", string="Intervals configuration"
     )
+    analytic_account_ids = fields.Many2many(
+        comodel_name="account.analytic.account", string="Filter analytic accounts"
+    )
+    no_analytic = fields.Boolean("Only no analytic items")
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
@@ -86,17 +90,27 @@ class AgedPartnerBalanceWizard(models.TransientModel):
                 self.account_ids = self.account_ids.filtered(
                     lambda a: a.company_id == self.company_id
                 )
-        res = {"domain": {"account_ids": [], "partner_ids": []}}
+        res = {
+            "domain": {"account_ids": [], "partner_ids": [], "analytic_account_ids": []}
+        }
         if not self.company_id:
             return res
         else:
             res["domain"]["account_ids"] += [("company_id", "=", self.company_id.id)]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
+            res["domain"]["analytic_account_ids"] += [
+                ("company_id", "=", self.company_id.id)
+            ]
         return res
 
     @api.onchange("account_ids")
     def onchange_account_ids(self):
-        return {"domain": {"account_ids": [("reconcile", "=", True)]}}
+        return {
+            "domain": {
+                "account_ids": [("reconcile", "=", True)],
+                "analytic_account_ids": [],
+            }
+        }
 
     @api.onchange("receivable_accounts_only", "payable_accounts_only")
     def onchange_type_accounts_only(self):
@@ -142,6 +156,8 @@ class AgedPartnerBalanceWizard(models.TransientModel):
             "show_move_line_details": self.show_move_line_details,
             "account_financial_report_lang": self.env.lang,
             "age_partner_config_id": self.age_partner_config_id.id,
+            "analytic_account_ids": self.analytic_account_ids.ids or [],
+            "no_analytic": self.no_analytic,
         }
 
     def _export(self, report_type):

--- a/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
@@ -62,6 +62,17 @@
                         colspan="4"
                     />
                 </group>
+                <group
+                    name="Filter analytic accounts"
+                    groups="analytic.group_analytic_accounting"
+                >
+                    <field
+                        name="analytic_account_ids"
+                        widget="many2many_tags"
+                        options="{'no_create': True}"
+                    />
+                    <field name="no_analytic" />
+                </group>
                 <footer>
                     <button
                         name="button_export_html"

--- a/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
@@ -72,6 +72,7 @@
                         options="{'no_create': True}"
                     />
                     <field name="no_analytic" />
+                    <field name="all_analytic" />
                 </group>
                 <footer>
                     <button

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -67,6 +67,17 @@ class OpenItemsReportWizard(models.TransientModel):
         comodel_name="account.analytic.account", string="Filter analytic accounts"
     )
     no_analytic = fields.Boolean("Only no analytic items")
+    only_analytic = fields.Boolean("Only analytic items")
+    all_analytic = fields.Boolean("All analytic items")
+
+    @api.onchange("all_analytic", "no_analytic")
+    def on_change_all_analytic(self):
+        if self.all_analytic:
+            all_aa = self.env["account.analytic.account"].search([])
+            self.analytic_account_ids = all_aa
+            self.no_analytic = False
+        else:
+            self.analytic_account_ids = False
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -62,6 +62,17 @@
                         colspan="4"
                     />
                 </group>
+                <group
+                    name="Filter analytic accounts"
+                    groups="analytic.group_analytic_accounting"
+                >
+                    <field
+                        name="analytic_account_ids"
+                        widget="many2many_tags"
+                        options="{'no_create': True}"
+                    />
+                    <field name="no_analytic" />
+                </group>
                 <footer>
                     <button
                         name="button_export_html"

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -72,6 +72,7 @@
                         options="{'no_create': True}"
                     />
                     <field name="no_analytic" />
+                    <field name="all_analytic" />
                 </group>
                 <footer>
                     <button


### PR DESCRIPTION
open items and aged partner balance reports.

This is useful in project based companies where it is important the assets & liabilities by projects. Long term projects my have outstanding invoices and payments for months.

Similar filter is already in the general ledger so I think this can be included in the base module.

cc @ForgeFlow

Edit: added also a filter for all analytic accounts only, so only analytic items are shown. This is useful when a company have several divisions, one of them managed by projects and other that is not project based division.

Edit: this is an example from runboat. You can see the Outstanding payments by analytic account:

![image](https://github.com/OCA/account-financial-reporting/assets/19620251/98a6ffed-d7b4-455c-a507-0886eb7bae64)
