### PR TITLE
[15.0][IMP] account_financial_report: Fix VAT tax tag report

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -53,10 +53,6 @@ currency balances are not available.
 Known issues / Roadmap
 ======================
 
-* 'VAT Report' is valid only for cases where it's met that for each
-  Tax defined: all the "Account tags" of all the
-  'Repartition for Invoices' or 'Repartition for Credit Notes'
-  are different.
 * It would be nice to have in reports a column indicating the
   state of the entries when the option "All Entries" is selected
   in "Target Moves" field in a wizard

--- a/account_financial_report/readme/ROADMAP.rst
+++ b/account_financial_report/readme/ROADMAP.rst
@@ -1,7 +1,3 @@
-* 'VAT Report' is valid only for cases where it's met that for each
-  Tax defined: all the "Account tags" of all the
-  'Repartition for Invoices' or 'Repartition for Credit Notes'
-  are different.
 * It would be nice to have in reports a column indicating the
   state of the entries when the option "All Entries" is selected
   in "Target Moves" field in a wizard

--- a/account_financial_report/tests/test_vat_report.py
+++ b/account_financial_report/tests/test_vat_report.py
@@ -83,6 +83,7 @@ class TestVATReport(AccountTestInvoicingCommon):
             {
                 "name": "Tag 01",
                 "applicability": "taxes",
+                "tax_negate": False,
                 "country_id": cls.company.country_id.id,
             }
         )
@@ -90,6 +91,7 @@ class TestVATReport(AccountTestInvoicingCommon):
             {
                 "name": "Tag 02",
                 "applicability": "taxes",
+                "tax_negate": True,
                 "country_id": cls.company.country_id.id,
             }
         )
@@ -97,6 +99,7 @@ class TestVATReport(AccountTestInvoicingCommon):
             {
                 "name": "Tag 03",
                 "applicability": "taxes",
+                "tax_negate": False,
                 "country_id": cls.company.country_id.id,
             }
         )
@@ -297,15 +300,15 @@ class TestVATReport(AccountTestInvoicingCommon):
         tax_10_net, tax_10_tax = self._get_tax_line(self.tax_10.name, vat_report)
         tax_20_net, tax_20_tax = self._get_tax_line(self.tax_20.name, vat_report)
 
-        self.assertEqual(tag_01_net, -100)
+        self.assertEqual(tag_01_net, 0)
         self.assertEqual(tag_01_tax, -10)
-        self.assertEqual(tag_02_net, -350)
-        self.assertEqual(tag_02_tax, -60)
-        self.assertEqual(tag_03_net, -250)
+        self.assertEqual(tag_02_net, 0)
+        self.assertEqual(tag_02_tax, 60)
+        self.assertEqual(tag_03_net, 0)
         self.assertEqual(tag_03_tax, -50)
-        self.assertEqual(tax_10_net, -100)
+        self.assertEqual(tax_10_net, 0)
         self.assertEqual(tax_10_tax, -10)
-        self.assertEqual(tax_20_net, -250)
+        self.assertEqual(tax_20_net, 0)
         self.assertEqual(tax_20_tax, -50)
 
         # Check report based on taxgroups


### PR DESCRIPTION
Currently the VAT report does not work when a tax has multiple account tags in the distribution as the account move line balance will end up in ALL tags (e.g. for the Reverse Charge Tax in Austria this leads to a zero balance in the tax column of the tags "+KZ 057" and "+KZ 066" / as the entries will cancel each other).

This fixes this issue by only using the balance of account move lines for linked tax tags also taking the tax_tag_invert flag into account.