### PR TITLE
[16.0][FIX] account_financial_report: fix error false due_date

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -56,6 +56,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         if not due_date or today <= due_date:
             ag_pb_data[acc_id]["current"] += residual
             ag_pb_data[acc_id][prt_id]["current"] += residual
+            due_date = today
         elif today <= due_date + timedelta(days=30):
             ag_pb_data[acc_id]["30_days"] += residual
             ag_pb_data[acc_id][prt_id]["30_days"] += residual


### PR DESCRIPTION
This PR fixed error can't run report aged partner balance when create JE directly.

Step to test
1. Go to menu Invoicing > Accounting > Journal Entries
2. Create new JE > Save
3. Run report `Aged Partner Balance` by filter account payable. it can't run report

Error Code: 
![image](https://github.com/OCA/account-financial-reporting/assets/20896369/4f255469-e15b-4e59-b23e-d965ccea0d1f)

`TypeError: unsupported operand type(s) for -: 'datetime.date' and 'bool'`