### PR TITLE
[16.0][FIX] account_financial_report: aged partner compute due date

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -270,6 +270,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         today = date_at_object
         if not due_date or today <= due_date:
             ml["current"] += amount
+            due_date = today
         elif today <= due_date + timedelta(days=30):
             ml["30_days"] += amount
         elif today <= due_date + timedelta(days=60):


### PR DESCRIPTION
Step to test same as https://github.com/OCA/account-financial-reporting/pull/1149 :
1. Go to menu Invoicing > Accounting > Journal Entries
2. Create new JE > Save
3. Run report Aged Partner Balance by filter account payable and `Show Move Line Details`. it can't run report

![Selection_014](https://github.com/OCA/account-financial-reporting/assets/20896369/f2367845-ca11-4ecb-9602-ccde9bea95b1)
![Selection_015](https://github.com/OCA/account-financial-reporting/assets/20896369/47ada726-ee03-4721-9bf3-2bc7ddf99173)
