### PR TITLE
[15.0][FIX] partner_statement: don't consider reconciled lines outside date range

### DIFF
--- a/partner_statement/report/activity_statement_xlsx.py
+++ b/partner_statement/report/activity_statement_xlsx.py
@@ -310,7 +310,7 @@ class ActivityStatementXslx(models.AbstractModel):
                 FORMATS["current_money_format"] = workbook.add_format(
                     {"align": "right", "num_format": money_string}
                 )
-                bg_grey = "#CCCCCC"
+                bg_grey = "#ADB5BD"
                 FORMATS["format_tcell_left_blocked"] = copy_format(
                     workbook, FORMATS["format_tcell_left"]
                 )

--- a/partner_statement/report/detailed_activity_statement_xlsx.py
+++ b/partner_statement/report/detailed_activity_statement_xlsx.py
@@ -100,12 +100,20 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 format_tcell_date_left = FORMATS["format_tcell_date_left_blocked"]
                 format_distributed = FORMATS["format_distributed_blocked"]
                 current_money_format = FORMATS["current_money_format_blocked"]
-            elif line.get("reconciled_line") and not line.get("blocked"):
+            elif (
+                line.get("reconciled_line")
+                and not line.get("blocked")
+                and not line.get("outside-date-rank")
+            ):
                 format_tcell_left = FORMATS["format_tcell_left_reconciled"]
                 format_tcell_date_left = FORMATS["format_tcell_date_left_reconciled"]
                 format_distributed = FORMATS["format_distributed_reconciled"]
                 current_money_format = FORMATS["current_money_format_reconciled"]
-            elif line.get("blocked") and line.get("reconciled_line"):
+            elif (
+                line.get("blocked")
+                and line.get("reconciled_line")
+                and not line.get("outside-date-rank")
+            ):
                 format_tcell_left = FORMATS["format_tcell_left_blocked_reconciled"]
                 format_tcell_date_left = FORMATS[
                     "format_tcell_date_left_blocked_reconciled"
@@ -113,6 +121,40 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 format_distributed = FORMATS["format_distributed_blocked_reconciled"]
                 current_money_format = FORMATS[
                     "current_money_format_blocked_reconciled"
+                ]
+            elif (
+                line.get("reconciled_line")
+                and not line.get("blocked")
+                and line.get("outside-date-rank")
+            ):
+                format_tcell_left = FORMATS[
+                    "format_tcell_left_reconciled_outside-date-rank"
+                ]
+                format_tcell_date_left = FORMATS[
+                    "format_tcell_date_left_reconciled_outside-date-rank"
+                ]
+                format_distributed = FORMATS[
+                    "format_distributed_reconciled_outside-date-rank"
+                ]
+                current_money_format = FORMATS[
+                    "current_money_format_reconciled_outside-date-rank"
+                ]
+            elif (
+                line.get("blocked")
+                and line.get("reconciled_line")
+                and line.get("outside-date-rank")
+            ):
+                format_tcell_left = FORMATS[
+                    "format_tcell_left_blocked_reconciled_outside-date-rank"
+                ]
+                format_tcell_date_left = FORMATS[
+                    "format_tcell_date_left_blocked_reconciled_outside-date-rank"
+                ]
+                format_distributed = FORMATS[
+                    "format_distributed_blocked_reconciled_outside-date-rank"
+                ]
+                current_money_format = FORMATS[
+                    "current_money_format_blocked_reconciled_outside-date-rank"
                 ]
             else:
                 format_tcell_left = FORMATS["format_tcell_left"]
@@ -491,7 +533,8 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 FORMATS["current_money_format"] = workbook.add_format(
                     {"align": "right", "num_format": money_string}
                 )
-                bg_grey = "#CCCCCC"
+                bg_grey = "#ADB5BD"
+                fc_red = "#DC3545"
                 FORMATS["format_tcell_left_blocked"] = copy_format(
                     workbook, FORMATS["format_tcell_left"]
                 )
@@ -530,32 +573,79 @@ class DetailedActivityStatementXslx(models.AbstractModel):
                 FORMATS["current_money_format_reconciled"].set_italic(True)
                 FORMATS["current_money_format_reconciled"].set_font_size(10)
                 FORMATS["format_tcell_left_blocked_reconciled"] = copy_format(
-                    workbook, FORMATS["format_tcell_left"]
+                    workbook, FORMATS["format_tcell_left_reconciled"]
                 )
                 FORMATS["format_tcell_left_blocked_reconciled"].set_bg_color(bg_grey)
-                FORMATS["format_tcell_left_blocked_reconciled"].set_italic(True)
-                FORMATS["format_tcell_left_blocked_reconciled"].set_font_size(10)
-                FORMATS["format_tcell_left_blocked_reconciled"].set_indent(1)
                 FORMATS["format_tcell_date_left_blocked_reconciled"] = copy_format(
-                    workbook, FORMATS["format_tcell_date_left"]
+                    workbook, FORMATS["format_tcell_date_left_reconciled"]
                 )
                 FORMATS["format_tcell_date_left_blocked_reconciled"].set_bg_color(
                     bg_grey
                 )
-                FORMATS["format_tcell_date_left_blocked_reconciled"].set_italic(True)
-                FORMATS["format_tcell_date_left_blocked_reconciled"].set_font_size(10)
                 FORMATS["format_distributed_blocked_reconciled"] = copy_format(
-                    workbook, FORMATS["format_distributed"]
+                    workbook, FORMATS["format_distributed_reconciled"]
                 )
                 FORMATS["format_distributed_blocked_reconciled"].set_bg_color(bg_grey)
-                FORMATS["format_distributed_blocked_reconciled"].set_italic(True)
-                FORMATS["format_distributed_blocked_reconciled"].set_font_size(10)
                 FORMATS["current_money_format_blocked_reconciled"] = copy_format(
-                    workbook, FORMATS["current_money_format"]
+                    workbook, FORMATS["current_money_format_reconciled"]
                 )
                 FORMATS["current_money_format_blocked_reconciled"].set_bg_color(bg_grey)
-                FORMATS["current_money_format_blocked_reconciled"].set_italic(True)
-                FORMATS["current_money_format_blocked_reconciled"].set_font_size(10)
+                FORMATS["format_tcell_left_reconciled_outside-date-rank"] = copy_format(
+                    workbook, FORMATS["format_tcell_left_reconciled"]
+                )
+                FORMATS[
+                    "format_tcell_left_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "format_tcell_date_left_reconciled_outside-date-rank"
+                ] = copy_format(workbook, FORMATS["format_tcell_date_left_reconciled"])
+                FORMATS[
+                    "format_tcell_date_left_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "format_distributed_reconciled_outside-date-rank"
+                ] = copy_format(workbook, FORMATS["format_distributed_reconciled"])
+                FORMATS[
+                    "format_distributed_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "current_money_format_reconciled_outside-date-rank"
+                ] = copy_format(workbook, FORMATS["current_money_format_reconciled"])
+                FORMATS[
+                    "current_money_format_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "format_tcell_left_blocked_reconciled_outside-date-rank"
+                ] = copy_format(
+                    workbook, FORMATS["format_tcell_left_blocked_reconciled"]
+                )
+                FORMATS[
+                    "format_tcell_left_blocked_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "format_tcell_date_left_blocked_reconciled_outside-date-rank"
+                ] = copy_format(
+                    workbook, FORMATS["format_tcell_date_left_blocked_reconciled"]
+                )
+                FORMATS[
+                    "format_tcell_date_left_blocked_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "format_distributed_blocked_reconciled_outside-date-rank"
+                ] = copy_format(
+                    workbook, FORMATS["format_distributed_blocked_reconciled"]
+                )
+                FORMATS[
+                    "format_distributed_blocked_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
+                FORMATS[
+                    "current_money_format_blocked_reconciled_outside-date-rank"
+                ] = copy_format(
+                    workbook, FORMATS["current_money_format_blocked_reconciled"]
+                )
+                FORMATS[
+                    "current_money_format_blocked_reconciled_outside-date-rank"
+                ].set_font_color(fc_red)
                 row_pos = self._write_currency_prior_lines(
                     row_pos, sheet, partner, currency, data
                 )

--- a/partner_statement/report/outstanting_statement_xlsx.py
+++ b/partner_statement/report/outstanting_statement_xlsx.py
@@ -288,7 +288,7 @@ class OutstandingStatementXslx(models.AbstractModel):
                 FORMATS["current_money_format"] = workbook.add_format(
                     {"align": "right", "num_format": money_string}
                 )
-                bg_grey = "#CCCCCC"
+                bg_grey = "#ADB5BD"
                 FORMATS["format_tcell_left_blocked"] = copy_format(
                     workbook, FORMATS["format_tcell_left"]
                 )

--- a/partner_statement/report/report_statement_common.py
+++ b/partner_statement/report/report_statement_common.py
@@ -475,6 +475,7 @@ class ReportStatementCommon(models.AbstractModel):
                     else:
                         line_currency["ending_balance"] += line[amount_field]
                         line["balance"] = line_currency["ending_balance"]
+                line["outside-date-rank"] = False
                 line["date"] = format_date(
                     line["date"], date_formats.get(partner_id, default_fmt)
                 )
@@ -490,6 +491,14 @@ class ReportStatementCommon(models.AbstractModel):
                 )
                 for line2 in reconciled_lines:
                     if line2["id"] in line["ids"]:
+                        line2["reconciled_line"] = True
+                        line2["applied_amount"] = line2["open_amount"]
+                        if line2["date"] >= date_start and line2["date"] <= date_end:
+                            line2["outside-date-rank"] = False
+                            if not line2["blocked"]:
+                                line["applied_amount"] += line2["open_amount"]
+                        else:
+                            line2["outside-date-rank"] = True
                         line2["date"] = format_date(
                             line2["date"], date_formats.get(partner_id, default_fmt)
                         )
@@ -497,9 +506,6 @@ class ReportStatementCommon(models.AbstractModel):
                             line2["date_maturity"],
                             date_formats.get(partner_id, default_fmt),
                         )
-                        line2["reconciled_line"] = True
-                        line2["applied_amount"] = line2["open_amount"]
-                        line["applied_amount"] += line2["open_amount"]
                         if is_detailed:
                             line_currency["lines"].extend(
                                 self._add_currency_line(
@@ -508,7 +514,8 @@ class ReportStatementCommon(models.AbstractModel):
                             )
                 if is_activity:
                     line["open_amount"] = line["amount"] + line["applied_amount"]
-                    line_currency["amount_due"] += line["open_amount"]
+                    if not line["blocked"]:
+                        line_currency["amount_due"] += line["open_amount"]
 
             if is_detailed:
                 for line_currency in currency_dict.values():

--- a/partner_statement/static/src/scss/layout_statement.scss
+++ b/partner_statement/static/src/scss/layout_statement.scss
@@ -28,3 +28,10 @@
         font-style: italic !important;
     }
 }
+
+.statement-outside-date-rank {
+    color: $red !important;
+    td:last-child {
+        color: $red !important;
+    }
+}

--- a/partner_statement/views/activity_statement.xml
+++ b/partner_statement/views/activity_statement.xml
@@ -42,7 +42,7 @@
                 <tr
                     t-foreach="currency['lines']"
                     t-as="line"
-                    t-att-class="('statement-blocked ' if line['blocked'] else '') + ('statement-reconciled' if line['reconciled_line'] else '')"
+                    t-att-class="('statement-blocked ' if line['blocked'] else '') + ('statement-reconciled ' if line['reconciled_line'] else '') + ('statement-outside-date-rank' if line['outside-date-rank'] else '')"
                 >
                     <td>
                         <span

--- a/partner_statement/wizard/activity_statement_wizard.py
+++ b/partner_statement/wizard/activity_statement_wizard.py
@@ -27,7 +27,7 @@ class ActivityStatementWizard(models.TransientModel):
         if self.aging_type == "months":
             self.date_start = self.date_end.replace(day=1)
         else:
-            self.date_start = self.date_end - relativedelta(days=30)
+            self.date_start = self.date_end - relativedelta(months=1)
         return res
 
     def _prepare_statement(self):
@@ -47,7 +47,7 @@ class ActivityStatementWizard(models.TransientModel):
             report_name = "p_s.report_activity_statement_xlsx"
         else:
             report_name = "partner_statement.activity_statement"
-        partners = self.env["res.partner"].browse(self._context["active_ids"])
+        partners = self.env["res.partner"].browse(data["partner_ids"])
         return (
             self.env["ir.actions.report"]
             .search(

--- a/partner_statement/wizard/detailed_activity_statement_wizard.py
+++ b/partner_statement/wizard/detailed_activity_statement_wizard.py
@@ -30,7 +30,7 @@ class DetailedActivityStatementWizard(models.TransientModel):
             report_name = "p_s.report_detailed_activity_statement_xlsx"
         else:
             report_name = "partner_statement.detailed_activity_statement"
-        partners = self.env["res.partner"].browse(self._context["active_ids"])
+        partners = self.env["res.partner"].browse(data["partner_ids"])
         return (
             self.env["ir.actions.report"]
             .search(

--- a/partner_statement/wizard/outstanding_statement_wizard.py
+++ b/partner_statement/wizard/outstanding_statement_wizard.py
@@ -27,7 +27,7 @@ class OutstandingStatementWizard(models.TransientModel):
             report_name = "p_s.report_outstanding_statement_xlsx"
         else:
             report_name = "partner_statement.outstanding_statement"
-        partners = self.env["res.partner"].browse(self._context["active_ids"])
+        partners = self.env["res.partner"].browse(data["partner_ids"])
         return (
             self.env["ir.actions.report"]
             .search(


### PR DESCRIPTION
Supersedes https://github.com/OCA/account-financial-reporting/pull/1104 and fixes https://github.com/OCA/account-financial-reporting/issues/1103.

If the reconciled sublines are outside the date range of the report, then mark them as red and don't consider them in the applied_amount of the above line (as they are already included in the prior balance).

Before this fix:
![300367597-567851f2-44c7-4314-8a2b-bb5ca7defe92](https://github.com/OCA/account-financial-reporting/assets/25005517/9c9d307e-43db-417e-a0da-225ba7f914c9)



After this fix, in the above image, the sublines (which are outside date range) should be in red color, and the applied amount of the Payment should be 0.