### PR TITLE
[14.0][IMP] account_financial_report: general ledger account range

### DIFF
--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -742,3 +742,21 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.account_type_ids = False
         wizard._onchange_account_type_ids()
         self.assertEqual(wizard.account_ids, account_model)
+
+    def test_validate_account_range(self):
+        accounts = self.env["account.account"].search([])
+        wizard = self.env["general.ledger.report.wizard"].create(
+            {
+                "company_id": False,
+                "account_code_from": accounts[0].id,
+                "account_code_to": accounts[9].id,
+            }
+        )
+        wizard.on_change_account_range()
+        self.assertEqual(wizard.account_ids, accounts[0:10])
+
+        company_id = self.env.user.company_id
+        company_accounts = accounts[0:10].filtered(lambda a: a.company_id == company_id)
+        wizard.company_id = company_id
+        wizard.on_change_account_range()
+        self.assertEqual(wizard.account_ids, company_accounts)

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -108,17 +108,20 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     @api.onchange("account_code_from", "account_code_to")
     def on_change_account_range(self):
-        if (
-            self.account_code_from
-            and self.account_code_from.code.isdigit()
-            and self.account_code_to
-            and self.account_code_to.code.isdigit()
-        ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
+        if self.account_code_from and self.account_code_to:
+            start_range = self.account_code_from.code
+            end_range = self.account_code_to.code
+
+            accounts = self.env["account.account"].search([])
+            account_codes = [account.code for account in accounts]
+
+            start_index = account_codes.index(start_range)
+            reverse_account_codes = account_codes[::-1]
+            reverse_end_index = reverse_account_codes.index(end_range)
+            end_index = len(account_codes) - 1 - reverse_end_index
+
+            self.account_ids = accounts[start_index : end_index + 1]
+
             if self.company_id:
                 self.account_ids = self.account_ids.filtered(
                     lambda a: a.company_id == self.company_id


### PR DESCRIPTION
This improvement allows filtering accounts by range in the General Ledger for chart of accounts that use a dotted format, such as `1.1.1.01`. Currently, this functionality is not available because accounts with dots fail the `isdigit()` check.

Brazilian Chart of Accounts Example (https://github.com/OCA/l10n-brazil/blob/14.0/l10n_br_coa_simple/data/account.account.template.csv)
![image](https://github.com/OCA/account-financial-reporting/assets/69807420/daf75901-b3d9-4475-9dbc-e74f2206d2e8)

General Ledger with Brazilian Accounts
![image](https://github.com/OCA/account-financial-reporting/assets/69807420/a187417a-a3e8-4bf9-90bd-4631e600b72b)

When attempting to remove dots from accounts and compare them as integers using the `filtered` method, the filter does not apply correctly if the accounts have different numbers of digits (when we use the `search` method, this isn't a problem). So, we implemented a solution where we search for the position of each account in the chart of accounts, finding the position of the `start_range` account and the `end_range` account, and then retrieve the accounts between these positions.

![image](https://github.com/OCA/account-financial-reporting/assets/69807420/c41b3896-51c8-499f-92c9-116ae85414a7)

cc: @marcelsavegnago @kaynnan @Matthwhy 