### PR TITLE
[14.0][IMP] account_financial_report: general ledger filter by account types

### DIFF
--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -721,3 +721,24 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_account_type_filter(self):
+        company_id = self.env.user.company_id
+        account_model = self.env["account.account"]
+        account = account_model.search([], limit=1)
+        account_type = account.user_type_id
+        accounts = account_model.search(
+            [
+                ("company_id", "=", company_id.id),
+                ("user_type_id", "in", account_type.ids),
+            ]
+        )
+        wizard = self.env["general.ledger.report.wizard"].create(
+            {"account_type_ids": account_type, "company_id": company_id.id}
+        )
+        wizard.onchange_company_id()
+        self.assertEqual(wizard.account_ids, accounts)
+
+        wizard.account_type_ids = False
+        wizard._onchange_account_type_ids()
+        self.assertEqual(wizard.account_ids, account_model)

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -56,6 +56,11 @@
                                     </div>
                                 </div>
                                 <field
+                                    name="account_type_ids"
+                                    widget="many2many_tags"
+                                    options="{'no_create': True}"
+                                />
+                                <field
                                     name="account_ids"
                                     nolabel="1"
                                     widget="many2many_tags"


### PR DESCRIPTION
This improvement reintroduces the functionality of filtering accounts by the `user_type_id` field, which was present in version 12 and was essential for filtering accounts in the general ledger report.

![image](https://github.com/OCA/account-financial-reporting/assets/69807420/7e213ddd-eb47-4c2a-818c-968be3bacaa8)

cc: @marcelsavegnago @kaynnan @Matthwhy 