### PR TITLE
[FIX] Rename wizard AbstractModel

### DIFF
--- a/account_financial_report/wizard/abstract_wizard.py
+++ b/account_financial_report/wizard/abstract_wizard.py
@@ -5,7 +5,7 @@ from odoo import fields, models
 
 
 class AbstractWizard(models.AbstractModel):
-    _name = "account_financial_report_abstract_wizard"
+    _name = "report.account_financial_report.abstract_wizard"
     _description = "Abstract Wizard"
 
     def _get_partner_ids_domain(self):

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -11,7 +11,7 @@ class AgedPartnerBalanceWizard(models.TransientModel):
 
     _name = "aged.partner.balance.report.wizard"
     _description = "Aged Partner Balance Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_at = fields.Date(required=True, default=fields.Date.context_today)
     date_from = fields.Date()

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -20,7 +20,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
 
     _name = "general.ledger.report.wizard"
     _description = "General Ledger Report Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_range_id = fields.Many2one(comodel_name="date.range", string="Date range")
     date_from = fields.Date(required=True, default=lambda self: self._init_date_from())

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -9,7 +9,7 @@ class JournalLedgerReportWizard(models.TransientModel):
 
     _name = "journal.ledger.report.wizard"
     _description = "Journal Ledger Report Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_range_id = fields.Many2one(comodel_name="date.range", string="Date range")
     date_from = fields.Date(string="Start date", required=True)

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -11,7 +11,7 @@ class OpenItemsReportWizard(models.TransientModel):
 
     _name = "open.items.report.wizard"
     _description = "Open Items Report Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_at = fields.Date(required=True, default=fields.Date.context_today)
     date_from = fields.Date()

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -14,7 +14,7 @@ class TrialBalanceReportWizard(models.TransientModel):
 
     _name = "trial.balance.report.wizard"
     _description = "Trial Balance Report Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_range_id = fields.Many2one(comodel_name="date.range", string="Date range")
     date_from = fields.Date(required=True)

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -8,7 +8,7 @@ from odoo.exceptions import ValidationError
 class VATReportWizard(models.TransientModel):
     _name = "vat.report.wizard"
     _description = "VAT Report Wizard"
-    _inherit = "account_financial_report_abstract_wizard"
+    _inherit = "report.account_financial_report.abstract_wizard"
 
     date_range_id = fields.Many2one(comodel_name="date.range", string="Date range")
     date_from = fields.Date("Start Date", required=True)


### PR DESCRIPTION
The original name existing with only underscores is giving errors when upgrading to v17.

File "/tmp/tmpeyhz1_ak/migrations/util/helpers.py", line 140, in _validate_model
raise SleepyDeveloperError("`{}` seems to be a table name instead of model name".format(model))
odoo.upgrade.util.exceptions.SleepyDeveloperError: `account_financial_report_abstract_wizard` seems to be a table name instead of model name

This change has been discussed in https://github.com/OCA/account-financial-reporting/pull/1101

Upgrades to v17 should work. I created a support ticket for this and Odoo should have fixed this one for all customers.
But it's better to be safe then sorry for next version migrations to fix this problem in front.