### PR TITLE
[16.0][FIX] account_financial_report: Multi-company support in test_report_without_aged_report_configuration

### DIFF
--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -21,6 +21,7 @@ class TestAgedPartnerBalance(TransactionCase):
             )
         )
         cls.wizard_model = cls.env["aged.partner.balance.report.wizard"]
+        cls.company = cls.env.company
         # Check that report is produced correctly
         cls.wizard_with_line_details = cls.wizard_model.create(
             {
@@ -98,7 +99,8 @@ class TestAgedPartnerBalance(TransactionCase):
     def test_all_accounts_loaded(self):
         # Tests if all accounts are loaded when the account_code_ fields changed
         all_accounts = self.env["account.account"].search(
-            [("reconcile", "=", True)], order="code"
+            [("reconcile", "=", True), ("company_id", "=", self.company.id)],
+            order="code",
         )
         aged_partner_balance = self.wizard_model.create(
             {


### PR DESCRIPTION
Multi-company support in test_report_without_aged_report_configuration

If we installed `l10n_en` first and then `account_financial_report` the tests would fail because all accounting accounts were taken into account instead of only those of the corresponding company.

Please @pedrobaeza can you review it?

@Tecnativa