### PR TITLE
[17.0][IMP] account_financial_report: Change font size

### DIFF
--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="aged_partner_balance">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="general_ledger">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t t-call="account_financial_report.report_general_ledger_base" />

--- a/account_financial_report/report/templates/journal_ledger.xml
+++ b/account_financial_report/report/templates/journal_ledger.xml
@@ -3,7 +3,7 @@
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <template id="journal_ledger">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t t-call="account_financial_report.report_journal_ledger_base" />

--- a/account_financial_report/report/templates/layouts.xml
+++ b/account_financial_report/report/templates/layouts.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <template id="account_financial_report.html_container">
+        <link
+            href="/account_financial_report/static/src/css/report_html.css"
+            rel="stylesheet"
+        />
+        <t t-set="body_classname" t-value="'container'" />
+        <t t-call="web.report_layout">
+            <t t-out="0" />
+        </t>
+    </template>
     <template id="account_financial_report.internal_layout">
         <div class="article o_account_financial_reports_page">
             <link

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="open_items">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t t-call="account_financial_report.report_open_items_base" />

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="trial_balance">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t t-call="account_financial_report.report_trial_balance_base" />

--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="vat_report">
-        <t t-call="web.html_container">
+        <t t-call="account_financial_report.html_container">
             <t t-foreach="docs" t-as="o">
                 <t t-call="account_financial_report.internal_layout">
                     <t t-call="account_financial_report.report_vat_report_base" />

--- a/account_financial_report/static/src/css/report_html.css
+++ b/account_financial_report/static/src/css/report_html.css
@@ -1,0 +1,7 @@
+/* Styles of html report */
+.account_title span {
+    font-size: 1rem !important;
+}
+.act_as_cell {
+    font-size: 0.9rem !important;
+}


### PR DESCRIPTION
fw-port of #1148 

Set a larger font style for the html report with a relative font size to make it responsive. For this, a new html_container is defined so that this does
not affect the other reports and the font style is customised only for the report in html view.

cc @Tecnativa TT48995

@pedrobaeza @victoralmau please review