### PR TITLE
[15.0][FIX] partner_statement: tests date relativity

### DIFF
--- a/partner_statement/tests/test_activity_statement.py
+++ b/partner_statement/tests/test_activity_statement.py
@@ -3,11 +3,14 @@
 
 from datetime import date
 
+from freezegun import freeze_time
+
 from odoo import fields
 from odoo.tests import new_test_user
 from odoo.tests.common import TransactionCase
 
 
+@freeze_time("2024-05-01", tick=True)
 class TestActivityStatement(TransactionCase):
     """Tests for Activity Statement."""
 


### PR DESCRIPTION
Depending on the day running the test, it will success or not.

@MiquelRForgeFlow I didn't go deep into the causes (I don't know the module), but it looks like the tests aren't resilient enough.

cc @Tecnativa 