### PR TITLE
[15.0][FIX] partner_statement: fix test due to last change

### DIFF
--- a/partner_statement/tests/test_activity_statement.py
+++ b/partner_statement/tests/test_activity_statement.py
@@ -125,5 +125,5 @@ class TestActivityStatement(TransactionCase):
 
         wiz_id.aging_type = "days"
         wiz_id.onchange_aging_type()
-        self.assertEqual((wiz_id.date_end - wiz_id.date_start).days, 30)
+        self.assertEqual((wiz_id.date_end - wiz_id.date_start).months, 1)
         self.assertTrue(wiz_id.date_end == self.today)


### PR DESCRIPTION
Supersedes https://github.com/OCA/account-financial-reporting/pull/1181.

In https://github.com/OCA/account-financial-reporting/pull/1164 was done this:
![Selection_3350](https://github.com/OCA/account-financial-reporting/assets/25005517/457121b7-fc36-48f1-997f-423d274e59a9)


