### PR TITLE
[13.0][FIX] account_financial_report: Default currency

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -95,7 +95,7 @@ class AbstractReportXslx(models.AbstractModel):
             company = self.env["res.company"].browse(company_id)
             currency = company.currency_id
         else:
-            currency = self.env["res.company"]._get_user_currency()
+            currency = self.env.company.currency_id
         self.format_header_amount.set_num_format(
             "#,##0." + "0" * currency.decimal_places
         )


### PR DESCRIPTION
Steps to reproduce the problem:

- Open in one tab one company.
- Open in another tab another company.
- Come back to the first tab, and export there a general ledger.

You will get an access error:

The requested operation ("read" en "Companies" (res.company)) was rejected...

That's because the current code relies on the user's main company, that is changed when you switch the company. Let's put the environment company instead.

@Tecnativa TT49626