### PR TITLE
[10.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/account_financial_report_qweb/__manifest__.py
+++ b/account_financial_report_qweb/__manifest__.py
@@ -8,7 +8,7 @@
     'version': '10.0.3.1.3',
     'category': 'Reporting',
     'summary': 'OCA Financial Reports',
-    'author': 'Camptocamp SA,'
+    'author': 'Camptocamp,'
               'initOS GmbH,'
               'redCOR AG,'
               'ACSONE SA/NV,'


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 10.0.