### PR TITLE
[17.0] [FIX] account_financial_report: Replace 'Camptocamp SA' with 'Camptocamp' in authors

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -9,7 +9,7 @@
     "version": "17.0.1.2.0",
     "category": "Reporting",
     "summary": "OCA Financial Reports",
-    "author": "Camptocamp SA,"
+    "author": "Camptocamp,"
     "initOS GmbH,"
     "redCOR AG,"
     "ForgeFlow,"


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 17.0.