### PR TITLE
[16.0][IMP] account_financial_report: Journal Items with Analytic Plan

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -15,7 +15,12 @@
     "ForgeFlow,"
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-financial-reporting",
-    "depends": ["account", "date_range", "report_xlsx"],
+    "depends": [
+        "account",
+        "analytic_mixin_analytic_accounts_and_plans",
+        "date_range",
+        "report_xlsx",
+    ],
     "data": [
         "security/ir.model.access.csv",
         "security/security.xml",

--- a/account_financial_report/models/account_move_line.py
+++ b/account_financial_report/models/account_move_line.py
@@ -11,6 +11,9 @@ class AccountMoveLine(models.Model):
     analytic_account_ids = fields.Many2many(
         "account.analytic.account", compute="_compute_analytic_account_ids", store=True
     )
+    analytic_plan_ids = fields.Many2many(
+        "account.analytic.plan", compute="_compute_analytic_account_ids", store=True
+    )
 
     @api.depends("analytic_distribution")
     def _compute_analytic_account_ids(self):
@@ -34,6 +37,8 @@ class AccountMoveLine(models.Model):
             self.browse(record_ids).analytic_account_ids = [
                 fields.Command.link(account_id)
             ]
+            plan_id = self.env["account.analytic.account"].browse(account_id).plan_id.id
+            self.browse(record_ids).analytic_plan_ids = [fields.Command.link(plan_id)]
 
     def init(self):
         """


### PR DESCRIPTION
I need to group JOURNAL ITEMS by **Analytic Plan** and **Analytic Account**. Use cases:
- Pivot view
- MIS Report columns

Since **Analytic Account** is defined in `account_financial_report`, I added **Analytic Plan** here.

Do you think that **Analytic Plan** should be in a different module?
If so, should **Analytic Account** also be in a different module?

EDIT

In a new commit, the module depends on [analytic_mixin_analytic_accounts_and_plans](https://github.com/OCA/account-analytic/pull/673).