### PR TITLE
[15.0][IMP] account_sale_stock_report_non_billed: Take partner from picking

### DIFF
--- a/account_sale_stock_report_non_billed/i18n/account_sale_stock_report_non_billed.pot
+++ b/account_sale_stock_report_non_billed/i18n/account_sale_stock_report_non_billed.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 15.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-08-06 05:44+0000\n"
+"PO-Revision-Date: 2024-08-06 05:44+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -63,6 +65,11 @@ msgstr ""
 msgid ""
 "Date from which stock movements are to be taken into account\n"
 "                            for the non billed movements report."
+msgstr ""
+
+#. module: account_sale_stock_report_non_billed
+#: model:ir.model.fields,field_description:account_sale_stock_report_non_billed.field_stock_move__picking_partner_id
+msgid "Destination Address"
 msgstr ""
 
 #. module: account_sale_stock_report_non_billed

--- a/account_sale_stock_report_non_billed/i18n/es.po
+++ b/account_sale_stock_report_non_billed/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-14 10:03+0000\n"
-"PO-Revision-Date: 2022-11-14 11:04+0100\n"
+"POT-Creation-Date: 2024-08-06 05:44+0000\n"
+"PO-Revision-Date: 2024-08-06 07:45+0200\n"
 "Last-Translator: Sergio Teruel <sergio.teruel@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: account_sale_stock_report_non_billed
 #: model:ir.model.fields,field_description:account_sale_stock_report_non_billed.field_stock_move__price_not_invoiced
@@ -70,6 +70,11 @@ msgid ""
 msgstr ""
 "Fecha a partir de la que se van a tener en cuenta los movimientos\n"
 "\t\t\tpara el informe de movimientos no facturados."
+
+#. module: account_sale_stock_report_non_billed
+#: model:ir.model.fields,field_description:account_sale_stock_report_non_billed.field_stock_move__picking_partner_id
+msgid "Destination Address"
+msgstr "Dirección de destino de la transferencia"
 
 #. module: account_sale_stock_report_non_billed
 #: model:ir.model.fields,field_description:account_sale_stock_report_non_billed.field_account_sale_stock_report_non_billed_wiz__display_name

--- a/account_sale_stock_report_non_billed/models/stock_move.py
+++ b/account_sale_stock_report_non_billed/models/stock_move.py
@@ -25,6 +25,11 @@ class StockMove(models.Model):
     date_done = fields.Date(
         string="Effective Date", compute="_compute_date_done", store=True
     )
+    picking_partner_id = fields.Many2one(
+        comodel_name="res.partner",
+        string="Destination Address",
+        related="picking_id.partner_id",
+    )
 
     @api.depends("picking_id.date_done")
     def _compute_date_done(self):

--- a/account_sale_stock_report_non_billed/views/stock_move_non_billed_views.xml
+++ b/account_sale_stock_report_non_billed/views/stock_move_non_billed_views.xml
@@ -31,7 +31,7 @@
             </xpath>
             <xpath expr="//field[@name='reference']" position="after">
                 <field name="picking_id" string="Picking" />
-                <field name="partner_id" />
+                <field name="picking_partner_id" />
                 <field name="origin" nolabel="1" />
                 <button
                     name="open_origin_document"


### PR DESCRIPTION
With the module account_purchase_stock_report_non_billed, when a purchase is made and it is received, the supplier is not appearing in the report of non-billed movements, as it did in previous versions.

So we retrieved the field picking_partner_id to have the same value as in previous versions.

cc @Tecnativa TT50426

ping @pedrobaeza @pilarvargas-tecnativa 