### PR TITLE
[16.0][FIX] account_financial_report: error when currency_id is int

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -589,6 +589,10 @@ class AbstractReportXslx(models.AbstractModel):
         """Return amount header format for each currency."""
         format_amt = report_data["formats"]["format_header_amount"]
         if line_object["currency_id"]:
+            if isinstance(line_object["currency_id"], int):
+                currency = self.env["res.currency"].browse(line_object["currency_id"])
+            else:
+                currency = line_object["currency_id"]
             field_name = "format_header_amount_%s" % line_object["currency_name"]
             if hasattr(self, field_name):
                 format_amt = getattr(self, field_name)


### PR DESCRIPTION
- When exporting trial balance xlsx, this error occurs, it seems in accounts_data, currency_id is integer instead of object.

  File "/opt/odoo/addons/report_xlsx/report/report_abstract_xlsx.py", line 105, in create_xlsx_report
    self.generate_xlsx_report(workbook, data, objs)
  File "/opt/odoo/addons/account_financial_report/report/abstract_report_xlsx.py", line 40, in generate_xlsx_report
    self._generate_report_content(workbook, objects, data, report_data)
  File "/opt/odoo/addons/account_financial_report/report/trial_balance_xlsx.py", line 237, in _generate_report_content
    self.write_account_footer(
  File "/opt/odoo/addons/account_financial_report/report/trial_balance_xlsx.py", line 264, in write_account_footer
    format_amt = self._get_currency_amt_header_format_dict(account, report_data)
  File "/opt/odoo/addons/account_financial_report/report/abstract_report_xlsx.py", line 601, in _get_currency_amt_header_format_dict
    "0" * line_object["currency_id"].decimal_places
AttributeError: 'int' object has no attribute 'decimal_places'