### PR TITLE
[17.0][FIX] account_financial_report: Export to XLSX after report preview

### DIFF
--- a/account_financial_report/static/src/js/report_action.esm.js
+++ b/account_financial_report/static/src/js/report_action.esm.js
@@ -31,7 +31,7 @@ patch(ReportAction.prototype, {
      * @returns {String}
      */
     _get_xlsx_name(str) {
-        if (!_.isString(str)) {
+        if (typeof str !== "string") {
             return str;
         }
         const parts = str.split(".");


### PR DESCRIPTION
Before this commit, got an error message when exporting reports after preview. "Error: Fix ReferenceError: _ is not defined when printing report to xlsx after preview"

**Steps to reproduce:**

1. Go to Invoicing > Reporting > OCA accounting reports > General ledger
![image](https://github.com/user-attachments/assets/44e25fbd-78e2-4e01-8c9b-e0bd076affe4)

2. Press View

3. Press Export

![image](https://github.com/user-attachments/assets/73612200-d36c-49a4-a292-f80266f77c52)


@Tecnativa
TT50507
@pedrobaeza @CarlosRoca13 