### PR TITLE
[16.0][FIX] avoid error in aged partner balance report

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -71,20 +71,25 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         else:
             ag_pb_data[acc_id]["older"] += residual
             ag_pb_data[acc_id][prt_id]["older"] += residual
-        days_difference = abs((today - due_date).days)
-        for index, line in enumerate(interval_lines):
-            lower_limit = 0 if not index else interval_lines[index - 1].inferior_limit
-            next_line = interval_lines[index] if index < len(interval_lines) else None
-            interval_range = self._get_values_for_range_intervals(
-                lower_limit, next_line.inferior_limit
-            )
-            if (
-                days_difference in interval_range
-                or days_difference == line.inferior_limit
-            ):
-                ag_pb_data[acc_id][line] += residual
-                ag_pb_data[acc_id][prt_id][line] += residual
-                break
+        if due_date:
+            days_difference = abs((today - due_date).days)
+            for index, line in enumerate(interval_lines):
+                lower_limit = (
+                    0 if not index else interval_lines[index - 1].inferior_limit
+                )
+                next_line = (
+                    interval_lines[index] if index < len(interval_lines) else None
+                )
+                interval_range = self._get_values_for_range_intervals(
+                    lower_limit, next_line.inferior_limit
+                )
+                if (
+                    days_difference in interval_range
+                    or days_difference == line.inferior_limit
+                ):
+                    ag_pb_data[acc_id][line] += residual
+                    ag_pb_data[acc_id][prt_id][line] += residual
+                    break
         return ag_pb_data
 
     def _get_values_for_range_intervals(self, num1, num2):


### PR DESCRIPTION
avoid error in aged partner balance report when processing journal items without a due date (`account.move.line.date_maturity` field is not set).

here is the error that happens without this fix:

```
Traceback (most recent call last):
  File "/home/odoo16/src/odoo/odoo/http.py", line 1638, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo16/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo16/src/odoo/odoo/http.py", line 1665, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo16/src/odoo/odoo/http.py", line 1779, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo16/src/odoo/addons/website/models/ir_http.py", line 237, in _dispatch
    response = super()._dispatch(endpoint)
  File "/home/odoo16/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo16/src/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo16/src/oca/reporting-engine/report_xml/controllers/report.py", line 24, in report_routes
    return super().report_routes(
  File "/home/odoo16/src/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo16/src/oca/reporting-engine/report_xlsx_helper/controllers/main.py", line 52, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File "/home/odoo16/src/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo16/src/oca/reporting-engine/report_xlsx/controllers/main.py", line 49, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File "/home/odoo16/src/odoo/odoo/http.py", line 700, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo16/src/odoo/addons/web/controllers/report.py", line 39, in report_routes
    html = report.with_context(context)._render_qweb_html(reportname, docids, data=data)[0]
  File "/home/odoo16/src/oca/account-financial-reporting/account_financial_report/models/ir_actions_report.py", line 19, in _render_qweb_html
    return super(IrActionsReport, obj)._render_qweb_html(
  File "/home/odoo16/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 913, in _render_qweb_html
    data = self._get_rendering_context(report, docids, data)
  File "/home/odoo16/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 928, in _get_rendering_context
    data.update(report_model._get_report_values(docids, data=data))
  File "/home/odoo16/src/oca/account-financial-reporting/account_financial_report/report/aged_partner_balance.py", line 419, in _get_report_values
    )._get_move_lines_data(
  File "/home/odoo16/src/oca/account-financial-reporting/account_financial_report/report/aged_partner_balance.py", line 240, in _get_move_lines_data
    ag_pb_data = self._calculate_amounts(
  File "/home/odoo16/src/oca/account-financial-reporting/account_financial_report/report/aged_partner_balance.py", line 74, in _calculate_amounts
    days_difference = abs((today - due_date).days)
TypeError: unsupported operand type(s) for -: 'datetime.date' and 'bool'
```

this error did not happen before #1140 was merged.