### PR TITLE
[16.0][FIX] account_financial_report: limit search_read and use of offset on aml based on batches. Use of enclosed environment when processing aml data.

### DIFF
--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -126,9 +126,13 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
             }
         )
         data = general_ledger._prepare_report_general_ledger()
-        res_data = self.env[
-            "report.account_financial_report.general_ledger"
-        ]._get_report_values(general_ledger, data)
+        ctx = self.env.context.copy()
+        ctx.update({"test_enable": True})
+        res_data = (
+            self.env["report.account_financial_report.general_ledger"]
+            .with_context(**ctx)
+            ._get_report_values(general_ledger, data)
+        )
         return res_data
 
     @api.model


### PR DESCRIPTION
Having an environment with > 1million `account.move.line` records, when trying to generate general ledger report, it returns MemoryError:
![image](https://github.com/user-attachments/assets/a360683a-0c40-411f-9438-7b1149431ede)


<details><summary>Traceback in console:</summary>

> --- Logging error ---
> Traceback (most recent call last):
>   File "/mnt/code/common-16.0/reporting-engine/report_xlsx/controllers/main.py", line 76, in report_download
> 2024-09-11 12:30:42,766 2710 ERROR refruiting-537 odoo.http: Exception during request handling. 
> Traceback (most recent call last):
>   File "/mnt/code/common-16.0/reporting-engine/report_xlsx/controllers/main.py", line 76, in report_download
>     response = self.report_routes(
>   File "/mnt/environment/odoo-server/odoo/http.py", line 697, in route_wrapper
>     result = endpoint(self, *args, **params_ok)
>   File "/mnt/code/common-16.0/reporting-engine/report_xlsx/controllers/main.py", line 37, in report_routes
>     xlsx = report.with_context(**context)._render_xlsx(
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/models/ir_actions_report.py", line 27, in _render_xlsx
>     return super(IrActionsReport, obj)._render_xlsx(report_ref, docids, data=data)
>   File "/mnt/code/common-16.0/reporting-engine/report_xlsx/models/ir_report.py", line 27, in _render_xlsx
>     .create_xlsx_report(docids, data)  # noqa
>   File "/mnt/code/common-16.0/reporting-engine/report_xlsx/report/report_abstract_xlsx.py", line 105, in create_xlsx_report
>     self.generate_xlsx_report(workbook, data, objs)
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/report/abstract_report_xlsx.py", line 40, in generate_xlsx_report
>     self._generate_report_content(workbook, objects, data, report_data)
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/report/general_ledger_xlsx.py", line 137, in _generate_report_content
>     ]._get_report_values(report, data)
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/report/general_ledger.py", line 805, in _get_report_values
>     ) = self._get_period_ml_data(
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/report/general_ledger.py", line 509, in _get_period_ml_data
>     gen_ld_data[acc_id][item_id][ml_id] = self._get_move_line_data(
>   File "/mnt/code/development/account-financial-reporting/account_financial_report/report/general_ledger.py", line 312, in _get_move_line_data
>     move_line_data = {
> MemoryError
> 

</details>

With this fix, limiting `search_read` and using `offset` in a enclosed environment, now it's able to process larga amount of data.