### PR TITLE
[15.0][FIX] account_financial_report: Display the values of Amount cur. + Cumul cur. values in general ledger only if necessary

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -150,6 +150,7 @@ class GeneralLedgerXslx(models.AbstractModel):
         tags_data = res_data["tags_data"]
         filter_partner_ids = res_data["filter_partner_ids"]
         foreign_currency = res_data["foreign_currency"]
+        company_currency = res_data["company_currency"]
         # For each account
         for account in general_ledger:
             # Write account title
@@ -171,7 +172,7 @@ class GeneralLedgerXslx(models.AbstractModel):
                         "initial_balance": account["init_bal"]["balance"],
                     }
                 )
-                if foreign_currency:
+                if foreign_currency and account["currency_id"]:
                     account.update(
                         {"initial_bal_curr": account["init_bal"]["bal_curr"]}
                     )
@@ -185,7 +186,10 @@ class GeneralLedgerXslx(models.AbstractModel):
                             "journal": journals_data[line["journal_id"]]["code"],
                         }
                     )
-                    if line["currency_id"]:
+                    line_currency_id = (
+                        line["currency_id"][0] if line["currency_id"] else False
+                    )
+                    if line_currency_id and line_currency_id != company_currency.id:
                         line.update(
                             {
                                 "currency_name": line["currency_id"][1],
@@ -207,7 +211,11 @@ class GeneralLedgerXslx(models.AbstractModel):
                                 "tags": tags,
                             }
                         )
-                    if foreign_currency:
+                    if (
+                        foreign_currency
+                        and line_currency_id
+                        and line_currency_id != company_currency.id
+                    ):
                         total_bal_curr += line["bal_curr"]
                         line.update({"total_bal_curr": total_bal_curr})
                     self.write_line_from_dict(line, report_data)
@@ -219,7 +227,7 @@ class GeneralLedgerXslx(models.AbstractModel):
                         "final_balance": account["fin_bal"]["balance"],
                     }
                 )
-                if foreign_currency:
+                if foreign_currency and account["currency_id"]:
                     account.update(
                         {
                             "final_bal_curr": account["fin_bal"]["bal_curr"],
@@ -262,7 +270,7 @@ class GeneralLedgerXslx(models.AbstractModel):
                             ],
                         }
                     )
-                    if foreign_currency:
+                    if foreign_currency and account["currency_id"]:
                         group_item.update(
                             {
                                 "initial_bal_curr": group_item["init_bal"]["bal_curr"],
@@ -278,7 +286,10 @@ class GeneralLedgerXslx(models.AbstractModel):
                                 "journal": journals_data[line["journal_id"]]["code"],
                             }
                         )
-                        if line["currency_id"]:
+                        line_currency_id = (
+                            line["currency_id"][0] if line["currency_id"] else False
+                        )
+                        if line_currency_id and line_currency_id != company_currency.id:
                             line.update(
                                 {
                                     "currency_name": line["currency_id"][1],
@@ -300,7 +311,11 @@ class GeneralLedgerXslx(models.AbstractModel):
                                     "tags": tags,
                                 }
                             )
-                        if foreign_currency:
+                        if (
+                            foreign_currency
+                            and line_currency_id
+                            and line_currency_id != company_currency.id
+                        ):
                             total_bal_curr += line["bal_curr"]
                             line.update({"total_bal_curr": total_bal_curr})
                         self.write_line_from_dict(line, report_data)


### PR DESCRIPTION
Backport from 16.0: https://github.com/OCA/account-financial-reporting/pull/1232

Display the values of _Amount cur_. + _Cumul cur._ values in general ledger only if necessary

The currency_id field of the lines is always set, so follow the same logic as in report/templates/general_ledger and show the data only if the currency is set in the account.

Please @pedrobaeza and @carlosdauden can you review it?

@Tecnativa TT51204