### PR TITLE
[16.0][FIX] account_financial_report: Remove inactive analytic account relations

### DIFF
--- a/account_financial_report/models/account_move_line.py
+++ b/account_financial_report/models/account_move_line.py
@@ -27,7 +27,7 @@ class AccountMoveLine(models.Model):
             .ids
         )
         # Store them
-        self.analytic_account_ids = False
+        self.with_context(active_test=False).analytic_account_ids = [(6, 0, [])]
         for account_id, record_ids in batch_by_analytic_account.items():
             if account_id not in existing_account_ids:
                 continue


### PR DESCRIPTION
When an analytic account is set to inactive (active=False), the relation with Journal Item is not automatically removed. This causes inactive analytic accounts to still appear linked to journal items when grouping by Analytic Account.

- **Current behavior before PR**
    - When using the edition mode in tree view from Journal Items, when removing an Analytic Account, the field `analytic_account_ids` is updated.
    - Here is the behavior with active analytic accounts.
[test_with_active_account.webm](https://github.com/user-attachments/assets/e2456308-190b-488f-9701-197ecefa0531)
    - Inactive analytic accounts are not being unlinked from `account.move.line` records.
[test_with_inactive_account.webm](https://github.com/user-attachments/assets/79ce5f08-c3ff-4598-8ac2-15d39da41bb1)

- **Behavior with PR**
    - With this PR, the relation is properly removed and Journal Item is not linked to inactive account
[test_with_pr.webm](https://github.com/user-attachments/assets/b25edbd6-ae5d-42cc-ba20-bf55c37c16b5)


**Changes**
- Remove `self.analytic_account_ids = False`
- Replace with: `self.with_context(active_test=False).analytic_account_ids = [(6, 0, [])]` to consider archived analytic account.
