### PR TITLE
[14.0][FIX] account_financial_report: in XLSX report, display null ending balance

### DIFF
--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -496,7 +496,7 @@ class AbstractReportXslx(models.AbstractModel):
                         report_data["formats"]["format_header_amount"],
                     )
                 elif cell_type == "amount_currency":
-                    if my_object["currency_id"] and value:
+                    if my_object["currency_id"]:
                         format_amt = self._get_currency_amt_format_dict(
                             my_object, report_data
                         )


### PR DESCRIPTION
In an XLSX general ledger, the ending balance in foreign currency is not displayed when the amount is 0. This bug is present on the ending balance, but not on the initial balance. It's pretty obvious bug when you compare:

1) the code of the method write_initial_balance_from_dict()
https://github.com/OCA/account-financial-reporting/blob/14.0/account_financial_report/report/abstract_report_xlsx.py#L365

2) the code of the method write_ending_balance_from_dict()
https://github.com/OCA/account-financial-reporting/blob/14.0/account_financial_report/report/abstract_report_xlsx.py#L499

The code is almost the same, but in the method write_ending_balance_from_dict, the line with the "if my_object["currency_id"]" and "and value", which means that the value is not displayed when the balance is foreign currency is 0.

BEFORE :

![gl_bug_null_value](https://github.com/user-attachments/assets/ad2e2d9f-e892-4b63-b2df-d980cf712fa4)


AFTER:

![gl_bug_fixed](https://github.com/user-attachments/assets/48966b6d-013f-4daf-a152-cbb1ea59a22d)
