### PR TITLE
[14.0][FIX] account_financial_report: Open Items report now sorted by account code

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -206,11 +206,18 @@ class OpenItemsReport(models.AbstractModel):
 
     @api.model
     def _order_open_items_by_date(
-        self, open_items_move_lines_data, show_partner_details, partners_data
+        self,
+        open_items_move_lines_data,
+        show_partner_details,
+        partners_data,
+        accounts_data,
     ):
+        # We need to order by account code, partner_name and date
+        accounts_data_sorted = sorted(accounts_data.items(), key=lambda x: x[1]["code"])
+        account_ids_sorted = [account[0] for account in accounts_data_sorted]
         new_open_items = {}
         if not show_partner_details:
-            for acc_id in open_items_move_lines_data.keys():
+            for acc_id in account_ids_sorted:
                 new_open_items[acc_id] = {}
                 move_lines = []
                 for prt_id in open_items_move_lines_data[acc_id]:
@@ -219,7 +226,7 @@ class OpenItemsReport(models.AbstractModel):
                 move_lines = sorted(move_lines, key=lambda k: (k["date"]))
                 new_open_items[acc_id] = move_lines
         else:
-            for acc_id in open_items_move_lines_data.keys():
+            for acc_id in account_ids_sorted:
                 new_open_items[acc_id] = {}
                 for prt_id in sorted(
                     open_items_move_lines_data[acc_id],
@@ -262,7 +269,10 @@ class OpenItemsReport(models.AbstractModel):
 
         total_amount = self._calculate_amounts(open_items_move_lines_data)
         open_items_move_lines_data = self._order_open_items_by_date(
-            open_items_move_lines_data, show_partner_details, partners_data
+            open_items_move_lines_data,
+            show_partner_details,
+            partners_data,
+            accounts_data,
         )
         return {
             "doc_ids": [wizard_id],


### PR DESCRIPTION
BEFORE:

![open_items_bug](https://github.com/user-attachments/assets/444b1e72-d579-446d-b299-61d154beb9e5)

AFTER:

![open_items_fixed](https://github.com/user-attachments/assets/81c450de-d03f-463c-8811-eab13c2ed0da)

Explaination of the bug:
When building the Qweb or XLSX report, the module uses open_items_move_lines_data.keys().
In python3, the order of a dict is the order of insertion of the keys. In the code of report/open_items.py, the keys of open_items_move_lines_data were inserted by the order of the first move line of the account.
This PR make sure that the keys in open_items_move_lines_data are inserted in the order of the account codes.