### PR TITLE
[16][FIX] account_financial_report : fix wizard model names sent to qweb reports for vat and aged balance reports

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -442,8 +442,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         )._calculate_percent(aged_partner_data)
         return {
             "doc_ids": [wizard_id],
-            "doc_model": "open.items.report.wizard",
-            "docs": self.env["open.items.report.wizard"].browse(wizard_id),
+            "doc_model": "aged.partner.balance.report.wizard",
+            "docs": self.env["aged.partner.balance.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
             "currency_name": company.currency_id.name,
             "date_at": date_at,

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -218,8 +218,8 @@ class VATReport(models.AbstractModel):
             )
         return {
             "doc_ids": [wizard_id],
-            "doc_model": "open.items.report.wizard",
-            "docs": self.env["open.items.report.wizard"].browse(wizard_id),
+            "doc_model": "vat.report.wizard",
+            "docs": self.env["vat.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
             "currency_name": company.currency_id.name,
             "date_from": date_from,


### PR DESCRIPTION
The issue seems obvious, we get a wizard_id related to respectively `aged.partner.balance.report.wizard` and `vat.report.wizard` models but we browse it with another model (`open.items.report.wizard`).

As a result, if you try to read a field from the wizard in the qweb template, it will likely fail with an error like "The record is inexisting or has been deleted"

The problem does only appear in case of override of the qweb template and trying to read of field of the variable `o` which represent the  wizard.

I will forward port-it to 17.

A fast review is very welcome if you could as it is quite an easy one
@pedrobaeza @alexis-via @victoralmau @carlosdauden 