### PR TITLE
[17][FIX] account_financial_report : fix wizard model names sent to qweb reports for vat and aged balance reports

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -457,8 +457,8 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         )._calculate_percent(aged_partner_data)
         return {
             "doc_ids": [wizard_id],
-            "doc_model": "open.items.report.wizard",
-            "docs": self.env["open.items.report.wizard"].browse(wizard_id),
+            "doc_model": "aged.partner.balance.report.wizard",
+            "docs": self.env["aged.partner.balance.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
             "currency_name": company.currency_id.name,
             "date_at": date_at,

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -218,8 +218,8 @@ class VATReport(models.AbstractModel):
             )
         return {
             "doc_ids": [wizard_id],
-            "doc_model": "open.items.report.wizard",
-            "docs": self.env["open.items.report.wizard"].browse(wizard_id),
+            "doc_model": "vat.report.wizard",
+            "docs": self.env["vat.report.wizard"].browse(wizard_id),
             "company_name": company.display_name,
             "currency_name": company.currency_id.name,
             "date_to": data["date_to"],


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-financial-reporting/pull/1244