### PR TITLE
[16][FIX] account_financial_report : make aged report configuration working with multi-company

### DIFF
--- a/account_financial_report/models/res_config_settings.py
+++ b/account_financial_report/models/res_config_settings.py
@@ -1,14 +1,36 @@
 # Copyright 2023 Tecnativa - Carolina Fernandez
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    default_age_partner_config_id = fields.Many2one(
+    age_partner_config_id = fields.Many2one(
         "account.age.report.configuration",
         string="Intervals configuration",
-        default_model="aged.partner.balance.report.wizard",
     )
+
+    def set_values(self):
+        self.env["ir.default"].sudo().set(
+            "aged.partner.balance.report.wizard",
+            "age_partner_config_id",
+            self.age_partner_config_id.id,
+            company_id=self.env.company.id,
+        )
+        return super().set_values()
+
+    @api.model
+    def get_values(self):
+        res = super(ResConfigSettings, self).get_values()
+        res.update(
+            age_partner_config_id=self.env["ir.default"]
+            .sudo()
+            .get(
+                "aged.partner.balance.report.wizard",
+                "age_partner_config_id",
+                company_id=self.env.company.id,
+            )
+        )
+        return res

--- a/account_financial_report/view/res_config_settings_views.xml
+++ b/account_financial_report/view/res_config_settings_views.xml
@@ -28,11 +28,11 @@
                                     <div class="content-group">
                                         <div class="row mt16">
                                             <label
-                                            for="default_age_partner_config_id"
+                                            for="age_partner_config_id"
                                             class="col-lg-3 o_light_label"
                                         />
                                             <field
-                                            name="default_age_partner_config_id"
+                                            name="age_partner_config_id"
                                             options="{'no_create_edit': True, 'no_open': True}"
                                         />
                                         </div>


### PR DESCRIPTION
The field `default_age_partner_config_id` configuration (in `res.config.settings`) does not work in multi-company environment.
Indeed, the default_XXX config create a global (for all companies) `ir.default`, meaning, it is the same setting for all companies.
If you change this configuration for company A, and then go to the settings of company B, you can see it has been update too.

The issue here is that the `account.age.report.configuration` model has a `company_id` field, always filled. And there are multi-company security rule.
So if the `account.age.report.configuration`  belongs to company A, and you try to generate a aged balance report for company B, with this configuration, it will fail because of multi-company access issues.


I changed this config field to use instead the specific config settings (overriding the get_values/set_values). This way, this configuration becomes company dependent instead of beeing global and it solves the multi-company issue when generating aged balance report.

review welcome @metaminux @emiliesoutiras @Kev-Roche 

I will forward port it to 17 when merged