### PR TITLE
[14.0][IMP] add field account_internal_group to account_financial_report for l10n-italy report

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -347,7 +347,12 @@ class TrialBalanceReport(models.AbstractModel):
         tb_initial_acc = []
         for account in accounts:
             tb_initial_acc.append(
-                {"account_id": account.id, "balance": 0.0, "amount_currency": 0.0}
+                {
+                    "account_id": account.id,
+                    "balance": 0.0,
+                    "amount_currency": 0.0,
+                    "account_internal_group": account.internal_group,
+                }
             )
         initial_domain_bs = self._get_initial_balances_bs_ml_domain(
             account_ids,


### PR DESCRIPTION
Add field `account_internal_group` to initial balance data to filter out expense/revenue account on initial balance value for Italian account financial report.

I set Ready for review to use this PR for test in Italian localization, but please wait until Italian localization approve the logic on the local PR.