### PR TITLE
[REF] mis_builder_cash_flow: Allow to override query

### DIFF
--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -55,8 +55,8 @@ class MisCashFlow(models.Model):
             "selection"
         ]
 
-    def init(self):
-        query = """
+    def _init_query(self):
+        return """
             SELECT
                 -- we use negative id to avoid duplicates and we don't use
                 -- ROW_NUMBER() because the performance was very poor
@@ -108,6 +108,9 @@ class MisCashFlow(models.Model):
                 fl.date as date
             FROM mis_cash_flow_forecast_line as fl
         """
+
+    def init(self):
+        query = self._init_query()
         tools.drop_view_if_exists(self.env.cr, self._table)
         self._cr.execute(
             "CREATE OR REPLACE VIEW %s AS (%s)", (AsIs(self._table), AsIs(query))


### PR DESCRIPTION
In another module, we have added a column to `mis.cash_flow.forecast_line` and would like to use it in the MIS reports.

The problem is that the MIS reports do not use directly `mis.cash_flow.forecast_line`: they use the view `mis.cash_flow` that exposes only some selected fields of `mis.cash_flow.forecast_line`.

With this change, it is possible for other modules to change the view generation before it is executed.
This allows us to add the new column of `mis.cash_flow.forecast_line` in the view `mis.cash_flow`.

Any suggestion is appreciated: I admit I don't know MIS builder modules that well, so there may be other solutions for this use-case.
Please let me know what you think.