### PR TITLE
[15.0][FIX] account_financial_report: keyError on fin_bal_currency_id

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -347,7 +347,7 @@ class GeneralLedgerXslx(models.AbstractModel):
                             "final_balance": account["fin_bal"]["balance"],
                         }
                     )
-                    if foreign_currency and account["fin_bal_currency_id"]:
+                    if foreign_currency and account.get("fin_bal_currency_id", False):
                         account.update(
                             {
                                 "final_bal_curr": total_bal_curr,

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -313,10 +313,7 @@
                 </div>
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['currency_id'])"
-                        />
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span
@@ -697,10 +694,7 @@
                 <t t-set="misc_grouped_domain" t-value="[]" t-else="" />
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['currency_id'])"
-                        />
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span>

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -313,10 +313,7 @@
                 </div>
                 <t t-if="foreign_currency">
                     <t t-if="account['currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['currency_id'])"
-                        />
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span
@@ -696,11 +693,8 @@
                 />
                 <t t-set="misc_grouped_domain" t-value="[]" t-else="" />
                 <t t-if="foreign_currency">
-                    <t t-if="account['fin_bal_currency_id']">
-                        <t
-                            t-set="account_currency"
-                            t-value="currency_model.browse(account['fin_bal_currency_id'])"
-                        />
+                    <t t-if="account['currency_id']">
+                        <t t-set="account_currency" t-value="account['currency_id']" />
                         <div class="act_as_cell amount" style="width: 3.63%;">
                             <t t-if="type == 'account_type'">
                                 <span>


### PR DESCRIPTION
**keyError: 'fin_bal_currency_id**

So I use **get() method** for skip this error if there is no `fin_bal_currency_id` key on dict object.

```Traceback (most recent call last):
  File "/opt/odoo/auto/addons/report_xlsx/controllers/main.py", line 77, in report_download
    response = self.report_routes(
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/report_xlsx_helper/controllers/main.py", line 50, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File "/opt/odoo/custom/src/odoo/odoo/http.py", line 546, in response_wrap
    response = f(*args, **kw)
  File "/opt/odoo/auto/addons/report_xlsx/controllers/main.py", line 37, in report_routes
    xlsx = report.with_context(**context)._render_xlsx(docids, data=data)[0]
  File "/opt/odoo/auto/addons/account_financial_report/models/ir_actions_report.py", line 25, in _render_xlsx
    return super(IrActionsReport, obj)._render_xlsx(docids, data)
  File "/opt/odoo/auto/addons/report_xlsx_helper/models/ir_actions_report.py", line 19, in _render_xlsx
    return super()._render_xlsx(docids, data)
  File "/opt/odoo/auto/addons/report_xlsx/models/ir_report.py", line 22, in _render_xlsx
    report_model.with_context(active_model=self.model)
  File "/opt/odoo/auto/addons/report_xlsx/report/report_abstract_xlsx.py", line 105, in create_xlsx_report
    self.generate_xlsx_report(workbook, data, objs)
  File "/opt/odoo/auto/addons/account_financial_report/report/abstract_report_xlsx.py", line 40, in generate_xlsx_report
    self._generate_report_content(workbook, objects, data, report_data)
  File "/opt/odoo/auto/addons/account_financial_report/report/general_ledger_xlsx.py", line 350, in _generate_report_content
    if foreign_currency and account["fin_bal_currency_id"]:
KeyError: 'fin_bal_currency_id'```