### PR TITLE
[16.0][FIX] account_financial_report: KeyError rendering report

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -863,6 +863,7 @@ class GeneralLedgerReport(models.AbstractModel):
             fin_bal_currency_ids = []
             fin_bal_currency_id = gl_item["currency_id"]
             if gl_item["currency_id"] or not foreign_currency:
+                gl_item["fin_bal_currency_id"] = fin_bal_currency_id
                 continue
             gl_item["fin_bal"]["bal_curr"] = gl_item["init_bal"]["bal_curr"]
             if "move_lines" in gl_item:


### PR DESCRIPTION
Some reports were failing to render without this fix.

It seems there was a regression introduced in 0a2b2736cdc1a73d6248b91fa79a0f4c6aedc99b.

![image](https://github.com/user-attachments/assets/a21c66fd-4b1e-46e0-95a6-19c9f07de333)

<details>

```
Traceback (most recent call last):
  File "<1582>", line 352, in template_1582
  File "<1582>", line 197, in template_1582_content
KeyError: 'fin_bal_currency_id'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/[http.py](https://http.py/)", line 1653, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/custom/src/odoo/odoo/service/[model.py](https://model.py/)", line 133, in retrying
    result = func()
  File "/opt/odoo/custom/src/odoo/odoo/[http.py](https://http.py/)", line 1680, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/custom/src/odoo/odoo/[http.py](https://http.py/)", line 1794, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/[ir_http.py](https://ir_http.py/)", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/custom/src/odoo/odoo/[http.py](https://http.py/)", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/report_xlsx/controllers/[main.py](https://main.py/)", line 49, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File "/opt/odoo/custom/src/odoo/odoo/[http.py](https://http.py/)", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/auto/addons/web/controllers/[report.py](https://report.py/)", line 39, in report_routes
    html = report.with_context(context)._render_qweb_html(reportname, docids, data=data)[0]
  File "/opt/odoo/auto/addons/account_financial_report/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 19, in _render_qweb_html
    return super(IrActionsReport, obj)._render_qweb_html(
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 971, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/[ir_actions_report.py](https://ir_actions_report.py/)", line 651, in _render_template
    return view_obj._render_template(template, values).encode()
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/[ir_ui_view.py](https://ir_ui_view.py/)", line 2129, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "/opt/odoo/custom/src/odoo/odoo/tools/[profiler.py](https://profiler.py/)", line 294, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/[ir_qweb.py](https://ir_qweb.py/)", line 587, in _render
    result = ''.join(rendering)
  File "<1578>", line 92, in template_1578
  File "<1578>", line 74, in template_1578_content
  File "<1578>", line 56, in template_1578_t_call_0
  File "<1578>", line 21, in template_1578_t_call_1
  File "<1579>", line 326, in template_1579
  File "<1579>", line 216, in template_1579_content
  File "<1582>", line 358, in template_1582
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
KeyError: 'fin_bal_currency_id'
Template: account_financial_report.report_general_ledger_ending_cumul
Path: /t/div/div/t[8]/t[1]/t
Node: <t t-set="account_currency" t-value="currency_model.browse(account[\'fin_bal_currency_id\'])"/>
```

</details>

@moduon MT-8285