### PR TITLE
[17.0][FIX] account_financial_report: KeyError rendering report

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -861,6 +861,7 @@ class GeneralLedgerReport(models.AbstractModel):
             fin_bal_currency_ids = []
             fin_bal_currency_id = gl_item["currency_id"]
             if gl_item["currency_id"] or not foreign_currency:
+                gl_item["fin_bal_currency_id"] = fin_bal_currency_id
                 continue
             gl_item["fin_bal"]["bal_curr"] = gl_item["init_bal"]["bal_curr"]
             if "move_lines" in gl_item:


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/account-financial-reporting/pull/1260

Some reports were failing to render without this fix.

Example of use case:
- Define Account Currency (USD) to an account (101401 for example).
- Display the General ledger report

@Tecnativa