### PR TITLE
[16.0][IMP] account_financial_report: Set grouped_by as required with non grouped item description. Fixes display of report when no agroupation is wanted

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -180,8 +180,7 @@ class GeneralLedgerReport(models.AbstractModel):
             acc_id = gl["account_id"][0]
             data[acc_id] = self._prepare_gen_ld_data_item(gl)
             data[acc_id]["id"] = acc_id
-            if grouped_by:
-                data[acc_id][grouped_by] = False
+            data[acc_id][grouped_by] = False
         method = "_prepare_gen_ld_data_group_%s" % grouped_by
         if not hasattr(self, method):
             return data
@@ -492,15 +491,13 @@ class GeneralLedgerReport(models.AbstractModel):
                 gen_ld_data[acc_id] = self._initialize_data(foreign_currency)
                 gen_ld_data[acc_id]["id"] = acc_id
                 gen_ld_data[acc_id]["mame"] = move_line["account_id"][1]
-                if grouped_by:
-                    gen_ld_data[acc_id][grouped_by] = False
+                gen_ld_data[acc_id][grouped_by] = False
             if acc_id in acc_prt_account_ids:
                 item_ids = self._prepare_ml_items(move_line, grouped_by)
                 for item in item_ids:
                     item_id = item["id"]
                     if item_id not in gen_ld_data[acc_id]:
-                        if grouped_by:
-                            gen_ld_data[acc_id][grouped_by] = True
+                        gen_ld_data[acc_id][grouped_by] = True
                         gen_ld_data[acc_id][item_id] = self._initialize_data(
                             foreign_currency
                         )
@@ -651,7 +648,7 @@ class GeneralLedgerReport(models.AbstractModel):
                     "grouped_by": grouped_by,
                 }
             )
-            if grouped_by and not gen_led_data[acc_id][grouped_by]:
+            if not gen_led_data[acc_id][grouped_by]:
                 account = self._create_account(
                     account, acc_id, gen_led_data, rec_after_date_to_ids
                 )
@@ -665,37 +662,23 @@ class GeneralLedgerReport(models.AbstractModel):
                 ):
                     continue
             else:
-                if grouped_by:
-                    account, list_grouped = self._get_list_grouped_item(
-                        gen_led_data[acc_id],
-                        account,
-                        rec_after_date_to_ids,
-                        hide_account_at_0,
-                        rounding,
+                account, list_grouped = self._get_list_grouped_item(
+                    gen_led_data[acc_id],
+                    account,
+                    rec_after_date_to_ids,
+                    hide_account_at_0,
+                    rounding,
+                )
+                account.update({"list_grouped": list_grouped})
+                if (
+                    hide_account_at_0
+                    and float_is_zero(
+                        gen_led_data[acc_id]["init_bal"]["balance"],
+                        precision_rounding=rounding,
                     )
-                    account.update({"list_grouped": list_grouped})
-                    if (
-                        hide_account_at_0
-                        and float_is_zero(
-                            gen_led_data[acc_id]["init_bal"]["balance"],
-                            precision_rounding=rounding,
-                        )
-                        and account["list_grouped"] == []
-                    ):
-                        continue
-                else:
-                    account = self._create_account_not_show_item(
-                        account, acc_id, gen_led_data, rec_after_date_to_ids, grouped_by
-                    )
-                    if (
-                        hide_account_at_0
-                        and float_is_zero(
-                            gen_led_data[acc_id]["init_bal"]["balance"],
-                            precision_rounding=rounding,
-                        )
-                        and account["move_lines"] == []
-                    ):
-                        continue
+                    and account["list_grouped"] == []
+                ):
+                    continue
             general_ledger += [account]
         return general_ledger
 
@@ -744,7 +727,7 @@ class GeneralLedgerReport(models.AbstractModel):
         centralized_ml = {}
         if isinstance(date_to, str):
             date_to = datetime.datetime.strptime(date_to, "%Y-%m-%d").date()
-        if grouped_by and account[grouped_by]:
+        if account[grouped_by]:
             for item in account["list_grouped"]:
                 for move_line in item["move_lines"]:
                     centralized_ml = self._calculate_centralization(
@@ -835,7 +818,7 @@ class GeneralLedgerReport(models.AbstractModel):
                         gen_ld_data[account["id"]]["init_bal"]["balance"],
                         rec_after_date_to_ids,
                     )
-                    if grouped_by and account[grouped_by]:
+                    if account[grouped_by]:
                         account[grouped_by] = False
                         del account["list_grouped"]
         general_ledger = sorted(general_ledger, key=lambda k: k["code"])

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -74,8 +74,9 @@ class GeneralLedgerReportWizard(models.TransientModel):
         help="Ending account in a range",
     )
     grouped_by = fields.Selection(
-        selection=[("", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
+        selection=[("none", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
         default="partners",
+        required=True,
     )
     show_cost_center = fields.Boolean(
         string="Show Analytic Account",


### PR DESCRIPTION
This PR fixes two items.

In first place, the Grouped By field has two options that returns same result:
![image](https://github.com/user-attachments/assets/22c8fc32-b197-4d65-9530-405a3904b96d)

And with any of the two options, the result is not correct, as is not displaying all the data available for the accounts.

https://github.com/user-attachments/assets/6d943d4c-03ab-41b8-a9ee-71239ba487bc


With this PR we have the option limited to correct options:
![image](https://github.com/user-attachments/assets/f3737e47-1196-4111-8772-778e55afa7cc)


And the result is displayed with all the info:

https://github.com/user-attachments/assets/1cb92ad8-933f-4150-b7e7-b70f4cd7b469





