### PR TITLE
[16.0][FIX] account_financial_report: take multiple account tags per tax into account

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -87,10 +87,6 @@ you can set default interval configuration per company in:
 Known issues / Roadmap
 ======================
 
-* 'VAT Report' is valid only for cases where it's met that for each
-  Tax defined: all the "Account tags" of all the
-  'Repartition for Invoices' or 'Repartition for Credit Notes'
-  are different.
 * It would be nice to have in reports a column indicating the
   state of the entries when the option "All Entries" is selected
   in "Target Moves" field in a wizard

--- a/account_financial_report/readme/ROADMAP.rst
+++ b/account_financial_report/readme/ROADMAP.rst
@@ -1,7 +1,3 @@
-* 'VAT Report' is valid only for cases where it's met that for each
-  Tax defined: all the "Account tags" of all the
-  'Repartition for Invoices' or 'Repartition for Credit Notes'
-  are different.
 * It would be nice to have in reports a column indicating the
   state of the entries when the option "All Entries" is selected
   in "Target Moves" field in a wizard

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -80,6 +80,7 @@ class VATReport(models.AbstractModel):
                     "net": 0.0,
                     "tax": tax_move_line["balance"],
                     "tax_line_id": tax_move_line["tax_line_id"][0],
+                    "tax_tag_ids": tax_move_line["tax_tag_ids"],
                 }
             )
         for taxed_move_line in taxed_move_lines:
@@ -89,6 +90,7 @@ class VATReport(models.AbstractModel):
                         "net": taxed_move_line["balance"],
                         "tax": 0.0,
                         "tax_line_id": tax_id,
+                        "tax_tag_ids": taxed_move_line["tax_tag_ids"],
                     }
                 )
         tax_ids = list(map(operator.itemgetter("tax_line_id"), vat_data))
@@ -161,12 +163,11 @@ class VATReport(models.AbstractModel):
         vat_report = {}
         for tax_move_line in vat_report_data:
             tax_id = tax_move_line["tax_line_id"]
-            tags_ids = tax_data[tax_id]["tags_ids"]
             if tax_data[tax_id]["amount_type"] == "group":
                 continue
             else:
-                if tags_ids:
-                    for tag_id in tags_ids:
+                if tax_move_line["tax_tag_ids"]:
+                    for tag_id in tax_move_line["tax_tag_ids"]:
                         if tag_id not in vat_report.keys():
                             vat_report[tag_id] = {}
                             vat_report[tag_id]["net"] = 0.0
@@ -240,4 +241,5 @@ class VATReport(models.AbstractModel):
             "balance",
             "tax_line_id",
             "tax_ids",
+            "tax_tag_ids",
         ]

--- a/account_financial_report/tests/test_vat_report.py
+++ b/account_financial_report/tests/test_vat_report.py
@@ -296,15 +296,15 @@ class TestVATReport(AccountTestInvoicingCommon):
         tax_10_net, tax_10_tax = self._get_tax_line(self.tax_10.name, vat_report)
         tax_20_net, tax_20_tax = self._get_tax_line(self.tax_20.name, vat_report)
 
-        self.assertEqual(tag_01_net, -100)
+        self.assertEqual(tag_01_net, 0)
         self.assertEqual(tag_01_tax, -10)
-        self.assertEqual(tag_02_net, -350)
+        self.assertEqual(tag_02_net, 0)
         self.assertEqual(tag_02_tax, -60)
-        self.assertEqual(tag_03_net, -250)
+        self.assertEqual(tag_03_net, 0)
         self.assertEqual(tag_03_tax, -50)
-        self.assertEqual(tax_10_net, -100)
+        self.assertEqual(tax_10_net, 0)
         self.assertEqual(tax_10_tax, -10)
-        self.assertEqual(tax_20_net, -250)
+        self.assertEqual(tax_20_net, 0)
         self.assertEqual(tax_20_tax, -50)
 
         # Check report based on taxgroups


### PR DESCRIPTION
- When there are multiple repartition lines having different tax tags the VAT report will take all the tax lines for all tags into consideration leading to wrong results (e.g.: l10n_at.account_tax_template_sales_rev_charge_0_code021_1e)
- This patch will fix this by only using the balance of account move lines for the linked tax tags.
- As this change leads to the account move line balance being only taken into account for the tags being explicitly set in the repartition line the net sum will not be affected when the tag is not associated to the base repartition line (leading to changes in the expected behaviour in test_01_compute).