### PR TITLE
[FIX] account_financial_report: general ledger: sort by list_grouped name

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -853,6 +853,12 @@ class GeneralLedgerReport(models.AbstractModel):
                         account[grouped_by] = False
                         del account["list_grouped"]
         general_ledger = sorted(general_ledger, key=lambda k: k["code"])
+        for account in general_ledger:
+            if "list_grouped" in account.keys():
+                account["list_grouped"] = sorted(
+                    account["list_grouped"], key=lambda x: x["name"]
+                )
+
         return {
             "doc_ids": [wizard_id],
             "doc_model": "general.ledger.report.wizard",


### PR DESCRIPTION
Actually the general ledger is some times not sorted by partner name when we grouped by partner (it seems random).
With this PR we force the sort by list_grouped name.