### PR TITLE
[18][account_financial_report][FIX] rename call to get method of ir.default model

### DIFF
--- a/account_financial_report/models/res_config_settings.py
+++ b/account_financial_report/models/res_config_settings.py
@@ -27,7 +27,7 @@ class ResConfigSettings(models.TransientModel):
         res.update(
             age_partner_config_id=self.env["ir.default"]
             .sudo()
-            .get(
+            ._get(
                 "aged.partner.balance.report.wizard",
                 "age_partner_config_id",
                 company_id=self.env.company.id,


### PR DESCRIPTION
Fixes https://github.com/OCA/account-financial-reporting/pull/1273

@pedrobaeza Could you merge this one, 18 is broken right now