### PR TITLE
[17.0][FIX] partner_statement: context_today() instead of today()

### DIFF
--- a/partner_statement/report/report_statement_common.py
+++ b/partner_statement/report/report_statement_common.py
@@ -352,7 +352,7 @@ class ReportStatementCommon(models.AbstractModel):
         aging_type = data["aging_type"]
         is_activity = data.get("is_activity")
         is_detailed = data.get("is_detailed")
-        today = fields.Date.today()
+        today = fields.Date.context_today(self)
         amount_field = data.get("amount_field", "amount")
 
         # There should be relatively few of these, so to speed performance


### PR DESCRIPTION
The date shown on the report should be based on the client's timezone not UTC. (can be off by a day)

(cherry picked from commit 07b5969a123c87866b76abba146b7378d3b92855)