### PR TITLE
[15.0][FIX] account_financial_report: show current owed in xlsx report

### DIFF
--- a/account_financial_report/report/aged_partner_balance_xlsx.py
+++ b/account_financial_report/report/aged_partner_balance_xlsx.py
@@ -44,6 +44,14 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
             report_columns.update(
                 {
                     3: {
+                        "header": _("Current"),
+                        "field": "current",
+                        "field_footer_total": "current",
+                        "field_footer_percent": "percent_current",
+                        "type": "amount",
+                        "width": 14,
+                    },
+                    4: {
                         "header": _("Age ≤ 30 d."),
                         "field": "30_days",
                         "field_footer_total": "30_days",
@@ -51,7 +59,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    4: {
+                    5: {
                         "header": _("Age ≤ 60 d."),
                         "field": "60_days",
                         "field_footer_total": "60_days",
@@ -59,7 +67,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    5: {
+                    6: {
                         "header": _("Age ≤ 90 d."),
                         "field": "90_days",
                         "field_footer_total": "90_days",
@@ -67,7 +75,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    6: {
+                    7: {
                         "header": _("Age ≤ 120 d."),
                         "field": "120_days",
                         "field_footer_total": "120_days",
@@ -75,7 +83,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    7: {
+                    8: {
                         "header": _("Older"),
                         "field": "older",
                         "field_footer_total": "older",
@@ -132,7 +140,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
         if not report.age_partner_config_id:
             report_columns.update(
                 {
-                    9: {
+                    10: {
                         "header": _("Age ≤ 30 d."),
                         "field": "30_days",
                         "field_footer_total": "30_days",
@@ -141,7 +149,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    10: {
+                    11: {
                         "header": _("Age ≤ 60 d."),
                         "field": "60_days",
                         "field_footer_total": "60_days",
@@ -150,7 +158,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    11: {
+                    12: {
                         "header": _("Age ≤ 90 d."),
                         "field": "90_days",
                         "field_footer_total": "90_days",
@@ -159,7 +167,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    12: {
+                    13: {
                         "header": _("Age ≤ 120 d."),
                         "field": "120_days",
                         "field_footer_total": "120_days",
@@ -168,7 +176,7 @@ class AgedPartnerBalanceXslx(models.AbstractModel):
                         "type": "amount",
                         "width": 14,
                     },
-                    13: {
+                    14: {
                         "header": _("Older"),
                         "field": "older",
                         "field_footer_total": "older",


### PR DESCRIPTION
Current column not showing in XLSX report. Currently in runboat:

- in the normal view:

![2025-02-08_07-47](https://github.com/user-attachments/assets/f05ec2d8-9adc-4f0b-b3c3-584f13916158)

- in the xlsx report:

![2025-02-08_07-49](https://github.com/user-attachments/assets/3417fcf8-f825-4319-9ea9-f0b875ad07af)

- This PR adds the column current like this:

![2025-02-08_08-12](https://github.com/user-attachments/assets/21ada824-4787-45e3-bd96-2448acee67f2)

cc @ForgeFlow
