### PR TITLE
[18.0][FIX] account_financial_report: replace old field company_id in account.account by company_ids

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -108,7 +108,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
             )
             if self.company_id:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
+                    lambda a: self.company_id in a.company_ids
                 )
 
     def _init_date_from(self):
@@ -177,7 +177,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
+                    lambda a: self.company_id in a.company_ids
                 )
         if self.company_id and self.cost_center_ids:
             self.cost_center_ids = self.cost_center_ids.filtered(
@@ -195,7 +195,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_id", "=", self.company_id.id)]
+            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
             res["domain"]["account_journal_ids"] += [
                 ("company_id", "=", self.company_id.id)
             ]

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -103,13 +103,10 @@ class GeneralLedgerReportWizard(models.TransientModel):
         ):
             start_range = int(self.account_code_from.code)
             end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
+            domain = [("code", ">=", start_range), ("code", "<=", end_range)]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
-                )
+                domain.append(("company_ids", "in", self.company_id.ids))
+            self.account_ids = self.env["account.account"].search(domain)
 
     def _init_date_from(self):
         """set start date to begin of current year if fiscal year running"""

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -79,7 +79,7 @@ class OpenItemsReportWizard(models.TransientModel):
             )
             if self.company_id:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
+                    lambda a: self.company_id in a.company_ids
                 )
         return {
             "domain": {
@@ -103,13 +103,13 @@ class OpenItemsReportWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
+                    lambda a: self.company_id in a.company_ids
                 )
         res = {"domain": {"account_ids": [], "partner_ids": []}}
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_id", "=", self.company_id.id)]
+            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
         return res
 

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -166,7 +166,7 @@ class TrialBalanceReportWizard(models.TransientModel):
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_id", "=", self.company_id.id)]
+            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
             res["domain"]["date_range_id"] += [
                 "|",


### PR DESCRIPTION
In v18 account.account field company_id as been replaced by company_ids