### PR TITLE
[16.0][IMP] partner_statement: Allow installation of partner_statement on 16.0 - Issue 1299

### DIFF
--- a/partner_statement/wizard/statement_common.py
+++ b/partner_statement/wizard/statement_common.py
@@ -21,7 +21,7 @@ class StatementCommon(models.AbstractModel):
     date_end = fields.Date(required=True, default=fields.Date.context_today)
     show_aging_buckets = fields.Boolean(default=True)
     number_partner_ids = fields.Integer(
-        default=lambda self: len(self._context["active_ids"])
+        default=lambda self: self._context.get("active_ids") and len(self._context.get("active_ids"))
     )
     filter_partners_non_due = fields.Boolean(
         string="Don't show partners with no due entries", default=True

--- a/partner_statement/wizard/statement_common.py
+++ b/partner_statement/wizard/statement_common.py
@@ -21,7 +21,7 @@ class StatementCommon(models.AbstractModel):
     date_end = fields.Date(required=True, default=fields.Date.context_today)
     show_aging_buckets = fields.Boolean(default=True)
     number_partner_ids = fields.Integer(
-        default=lambda self: self._context.get("active_ids") and len(self._context.get("active_ids"))
+        default=lambda self: len(self._context.get("active_ids", []))
     )
     filter_partners_non_due = fields.Boolean(
         string="Don't show partners with no due entries", default=True


### PR DESCRIPTION
When attempting to install the partner_statement module, the installation fails with a KeyError: 'active_ids'. The error occurs when the module tries to access "active_ids" from the context, but it is missing.