### PR TITLE
[17.0][FIX] account_financial_report: Correct trial balance domain for anlytic accounts

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -52,12 +52,12 @@
                         <t
                             t-set="aml_domain_extra"
                             t-if="grouped_item['id'] > 0"
-                            t-value="[('analytic_account_id', '=', grouped_item['id'])]"
+                            t-value="[('analytic_account_ids', '=', grouped_item['id'])]"
                         />
                         <t
                             t-set="aml_domain_extra"
                             t-else=""
-                            t-value="[('analytic_account_id', '=', False)]"
+                            t-value="[('analytic_account_ids', '=', False)]"
                         />
                         <div class="act_as_table data_table" style="width: 100%;">
                             <t


### PR DESCRIPTION
Clicking on the QWeb report for a balance grouped by analytic was causing an error because account.move.line does not have account_analytic_id. This has been replaced with account_analytic_ids, which is the correct field.

Error:
Traceback (most recent call last):
  File "/opt/odoo/odoo/http.py", line 1788, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/opt/odoo/odoo/service/model.py", line 152, in retrying
    result = func()
  File "/opt/odoo/odoo/http.py", line 1816, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/opt/odoo/odoo/http.py", line 2020, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/opt/odoo/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
    result = endpoint(**request.params)
  File "/opt/odoo/odoo/http.py", line 757, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 25, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/opt/odoo/addons/web/controllers/dataset.py", line 21, in _call_kw
    return call_kw(Model, method, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 480, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "/opt/odoo/odoo/api.py", line 451, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/addons/web/models/models.py", line 46, in web_search_read
    records = self.search_fetch(domain, specification.keys(), offset=offset, limit=limit, order=order)
  File "/opt/odoo/addons/account/models/account_move_line.py", line 1456, in search_fetch
    return super(AccountMoveLine, contextualized).search_fetch(domain, field_names, offset, limit, order)
  File "/opt/odoo/odoo/models.py", line 1646, in search_fetch
    query = self._search(domain, offset=offset, limit=limit, order=order or self._order)
  File "/opt/odoo/addons/analytic/models/analytic_mixin.py", line 97, in _search
    return super()._search(domain, offset, limit, order, access_rights_uid)
  File "/opt/odoo/odoo/models.py", line 5441, in _search
    query = self._where_calc(domain)
  File "/opt/odoo/odoo/models.py", line 5152, in _where_calc
    return expression.expression(domain, self).query
  File "/opt/odoo/odoo/osv/expression.py", line 788, in __init__
    self.expression = domain_combine_anies(domain, model)
  File "/opt/odoo/odoo/osv/expression.py", line 597, in domain_combine_anies
    domain_any = _anyfy_leaves(domain, model)
  File "/opt/odoo/odoo/osv/expression.py", line 379, in _anyfy_leaves
    raise ValueError(f"Invalid field {model._name}.{path[0]} in leaf {item}")
ValueError: Invalid field account.move.line.analytic_account_id in leaf ('analytic_account_id', '=', 4392)

The above server error caused the following client error:
OwlError: An error occured in the owl lifecycle (see this Error's "cause" property)
    Error: An error occured in the owl lifecycle (see this Error's "cause" property)
        at handleError (https://fdeixalles.prod.aws.apsl.io/web/assets/57e8349/web.assets_web.min.js:925:101)
        at App.handleError (https://fdeixalles.prod.aws.apsl.io/web/assets/57e8349/web.assets_web.min.js:1572:29)
        at ComponentNode.initiateRender (https://fdeixalles.prod.aws.apsl.io/web/assets/57e8349/web.assets_web.min.js:1017:19)

Caused by: RPC_ERROR: Odoo Server Error
    RPC_ERROR
        at makeErrorFromResponse (https://fdeixalles.prod.aws.apsl.io/web/assets/57e8349/web.assets_web.min.js:2925:163)
        at XMLHttpRequest.<anonymous> (https://fdeixalles.prod.aws.apsl.io/web/assets/57e8349/web.assets_web.min.js:2929:13)
       
cc https://github.com/APSL HT01839

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review