### PR TITLE
[17.0][FIX] account_financial_report: Fix error with multiple analytic accounts in distribution

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -195,16 +195,18 @@ class GeneralLedgerXslx(models.AbstractModel):
                             taxes_description += taxes_data[tax_id]["tax_name"] + " "
                         if line["tax_line_id"]:
                             taxes_description += line["tax_line_id"][1]
-                        for account_id, value in line["analytic_distribution"].items():
-                            if value < 100:
-                                analytic_distribution += "%s %d%% " % (
-                                    analytic_data[int(account_id)]["name"],
-                                    value,
-                                )
-                            else:
-                                analytic_distribution += (
-                                    "%s " % analytic_data[int(account_id)]["name"]
-                                )
+                        analytic_list = []
+                        for account_ids, percentage in line[
+                            "analytic_distribution"
+                        ].items():
+                            for account_id in account_ids.split(","):
+                                name = analytic_data[int(account_id)]["name"]
+                                if percentage < 100:
+                                    analytic_list.append(f"{name} {int(percentage)}%")
+                                else:
+                                    analytic_list.append(name)
+                        analytic_distribution = ", ".join(analytic_list)
+
                         line.update(
                             {
                                 "taxes_description": taxes_description,

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -475,29 +475,47 @@
                     <!--## cost_center-->
                     <t t-if="show_cost_center">
                         <div class="act_as_cell left">
-                            <t
-                                t-foreach="line['analytic_distribution']"
-                                t-as="analytic_id"
-                            >
-                                <div>
-                                    <span
-                                        t-att-res-id="analytic_id"
-                                        res-model="account.analytic.account"
-                                        view-type="form"
+                            <ul style="list-style: none; padding: 0; margin: 0;">
+                                <t
+                                    t-foreach="line['analytic_distribution'].items()"
+                                    t-as="analytic_entry"
+                                >
+                                    <t
+                                        t-set="analytic_ids"
+                                        t-value="analytic_entry[0]"
+                                    />
+                                    <t t-set="percentage" t-value="analytic_entry[1]" />
+                                    <t
+                                        t-foreach="analytic_ids.split(',')"
+                                        t-as="analytic_id"
                                     >
-                                        <t
-                                            t-out="o._get_atr_from_dict(int(analytic_id), analytic_data, 'name')"
-                                        />
-                                        <t
-                                            t-if="int(line['analytic_distribution'][analytic_id]) &lt; 100"
-                                        >
-                                            <t
-                                                t-out="int(line['analytic_distribution'][analytic_id])"
-                                            />%
-                                        </t>
-                                    </span>
-                                </div>
-                            </t>
+                                        <li style="padding: 2px 0;">
+                                            <span
+                                                t-att-res-id="analytic_id"
+                                                res-model="account.analytic.account"
+                                                view-type="form"
+                                            >
+                                                <t
+                                                    t-set="analytic_id"
+                                                    t-value="analytic_id.strip()"
+                                                />
+                                                <t
+                                                    t-set="account_name"
+                                                    t-value="o._get_atr_from_dict(int(analytic_id), analytic_data, 'name')"
+                                                />
+                                                <t t-if="percentage &lt; 100">
+                                                    <t
+                                                        t-out="account_name + ' (' + str(percentage) + '%)'"
+                                                    />
+                                                </t>
+                                                <t t-else="">
+                                                    <t t-out="account_name" />
+                                                </t>
+                                            </span>
+                                        </li>
+                                    </t>
+                                </t>
+                            </ul>
                         </div>
                     </t>
                     <t t-if="show_analytic_tags">


### PR DESCRIPTION
Fixed an issue where an error was raised when distributions contained more than one analytic account. The error occurred because the system attempted to convert a comma-separated string (e.g., '516, 986') into an integer.

Error:
![image](https://github.com/user-attachments/assets/4bcaf964-1e0d-4586-a513-f6fa3cb43b47)

cc https://github.com/APSL HT01808

@miquelalzanillas @lbarry-apsl @mpascuall @peluko00 @javierobcn @ppyczko please review