### PR TITLE
[18.0][FIX] account_financial_report: Refact search and company_id field

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -103,13 +103,13 @@ class GeneralLedgerReportWizard(models.TransientModel):
         ):
             start_range = int(self.account_code_from.code)
             end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
+            domain = [
+                ("code", ">=", start_range),
+                ("code", "<=", end_range),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: a.company_id == self.company_id
-                )
+                domain.append(("company_ids", "in", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
 
     def _init_date_from(self):
         """set start date to begin of current year if fiscal year running"""


### PR DESCRIPTION
**Error al filtrar por misma cuenta en libro mayor**
Al introducir la misma cuenta para hacer el filtro de cuentas da el siguiente error ya que el campo company_id en las cuentas ahora se llama company_ids. 

![image](https://github.com/user-attachments/assets/73ee4b18-f672-4697-b096-3bf25714a7e6)

![image](https://github.com/user-attachments/assets/8a066332-62e9-489b-a817-dbcfcfde45bf)

De esta forma conseguimos que sólo haga la ejecución del search y nos quitamos el filtered.

Este PR sigue abierto:  https://github.com/OCA/account-financial-reporting/pull/1293


**ERROR**
RPC_ERROR
Odoo Server Error

Traceback (most recent call last):
File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 1976, in _transactioning
return service_model.retrying(func, env=self.env)
File "/opt/odoo/src/odoo/odoo/odoo/service/model.py", line 156, in retrying
result = func()
File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 1943, in _serve_ir_http
response = self.dispatcher.dispatch(rule.endpoint, args)
File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 2191, in dispatch
result = self.request.registry['ir.http']._dispatch(endpoint)
File "/opt/odoo/src/odoo/odoo/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
result = endpoint(**request.params)
File "/opt/odoo/src/odoo/odoo/odoo/http.py", line 740, in route_wrapper
result = endpoint(self, *args, **params_ok)
File "/opt/odoo/src/odoo/odoo/addons/web/controllers/dataset.py", line 36, in call_kw
return call_kw(request.env[model], method, args, kwargs)
File "/opt/odoo/src/odoo/odoo/odoo/api.py", line 533, in call_kw
result = getattr(recs, name)(*args, **kwargs)
File "/opt/odoo/src/odoo/odoo/addons/web/models/models.py", line 1005, in onchange
record._apply_onchange_methods(field_name, result)
File "/opt/odoo/src/odoo/odoo/odoo/models.py", line 7364, in _apply_onchange_methods
res = method(self)
File "/opt/odoo/src/oca/account-financial-reporting/account_financial_report/wizard/general_ledger_wizard.py", line 110, in on_change_account_range
self.account_ids = self.account_ids.filtered(
File "/opt/odoo/src/odoo/odoo/odoo/models.py", line 6523, in filtered
return self.browse(rec.id for rec in self if func(rec))
File "/opt/odoo/src/odoo/odoo/odoo/models.py", line 6222, in browse
ids = tuple(ids)
File "/opt/odoo/src/odoo/odoo/odoo/models.py", line 6523, in <genexpr>
return self.browse(rec.id for rec in self if func(rec))
File "/opt/odoo/src/oca/account-financial-reporting/account_financial_report/wizard/general_ledger_wizard.py", line 111, in <lambda>
lambda a: a.company_id == self.company_id
AttributeError: 'account.account' object has no attribute 'company_id'

