### PR TITLE
[18.0][FIX] account_financial_report: fix for "group_id" is not searchable accessing account_ids

### DIFF
--- a/account_financial_report/models/account_group.py
+++ b/account_financial_report/models/account_group.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import api, fields, models
+from odoo.tools import SQL
 
 
 class AccountGroup(models.Model):
@@ -12,14 +13,17 @@ class AccountGroup(models.Model):
     )
     level = fields.Integer(compute="_compute_level", recursive=True)
     account_ids = fields.One2many(
-        comodel_name="account.account", inverse_name="group_id", string="Accounts"
+        comodel_name="account.account",
+        compute="_compute_account_ids",
+        string="Accounts",
+        store=False,
     )
     compute_account_ids = fields.Many2many(
         "account.account",
         recursive=True,
         compute="_compute_group_accounts",
         string="Compute accounts",
-        store=True,
+        store=False,
     )
     complete_name = fields.Char(
         "Full Name", compute="_compute_complete_name", recursive=True
@@ -36,6 +40,44 @@ class AccountGroup(models.Model):
                 group.complete_name = f"{group.parent_id.complete_name}/{group.name}"
             else:
                 group.complete_name = group.name
+
+    @api.depends("code_prefix_start", "code_prefix_end")
+    def _compute_account_ids(self):
+        """Retrieves every account from `self`.
+        In Odoo 18 the group_id on account is not stored so it raises
+        an error the one2many account_ids with inverse name group_id."""
+        group_ids = self.ids
+        self.account_ids = self.env["account.account"]
+        if not group_ids:
+            return
+        group_ids = SQL(",".join(map(str, group_ids)))
+        results = self.env.execute_query(
+            SQL(
+                """
+        SELECT
+        agroup.id AS group_id,
+        STRING_AGG(DISTINCT account.id::text, ', ') as account_ids
+        FROM  account_group agroup
+        inner join account_account account
+        ON agroup.code_prefix_start <= LEFT(%(code_store)s->>agroup.company_id::text,
+        char_length(agroup.code_prefix_start))
+        AND agroup.code_prefix_end >= LEFT(%(code_store)s->>agroup.company_id::text,
+        char_length(agroup.code_prefix_end))
+        WHERE agroup.id IN (%(group_ids)s)
+        GROUP BY agroup.id
+            """,
+                code_store=SQL.identifier("account", "code_store"),
+                group_ids=group_ids,
+            )
+        )
+        group_by_code = dict(results)
+        if not group_by_code:
+            return
+        for record in self:
+            if group_by_code.get(record.id, ""):
+                record.account_ids = list(
+                    map(int, group_by_code.get(record.id, "").split(", "))
+                )
 
     @api.depends("code_prefix_start", "parent_id.complete_code")
     def _compute_complete_code(self):
@@ -57,7 +99,6 @@ class AccountGroup(models.Model):
                 group.level = group.parent_id.level + 1
 
     @api.depends(
-        "account_ids",
         "group_child_ids.compute_account_ids",
     )
     def _compute_group_accounts(self):

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -38,12 +38,10 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
             {
                 "code": "001",
                 "name": "Account 001",
-                "group_id": cls.group2.id,
                 "account_type": "income_other",
             },
         )
         cls.account100 = cls.company_data["default_account_receivable"]
-        cls.account100.group_id = cls.group1.id
         cls.account110 = cls.env["account.account"].search(
             [
                 (
@@ -59,7 +57,6 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
             {
                 "code": "200",
                 "name": "Account 200",
-                "group_id": cls.group2.id,
                 "account_type": "income_other",
             },
         )
@@ -76,7 +73,6 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
             {
                 "code": "201",
                 "name": "Account 201",
-                "group_id": cls.group2.id,
                 "account_type": "income_other",
             },
         )
@@ -100,8 +96,6 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
 
     def _create_account_account(self, vals):
         item = self.env["account.account"].create(vals)
-        if "group_id" in vals:
-            item.group_id = vals["group_id"]
         return item
 
     def _add_move(


### PR DESCRIPTION
### Before this PR
The group_id is not stored so it appear "group_id" is not searchable accessing account_ids

Fixes https://github.com/OCA/account-financial-reporting/issues/1306