### PR TITLE
[18.0][FIX] account_financial_report:

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -484,7 +484,8 @@ class GeneralLedgerReport(models.AbstractModel):
             for tax_id in move_line["tax_ids"]:
                 taxes_ids.add(tax_id)
             for analytic_account in move_line["analytic_distribution"] or {}:
-                analytic_ids.add(int(analytic_account))
+                for analytic_account_id in analytic_account.split(","):
+                    analytic_ids.add(int(analytic_account_id))
             if move_line["full_reconcile_id"]:
                 rec_id = move_line["full_reconcile_id"][0]
                 if rec_id not in full_reconcile_ids:

--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -195,16 +195,17 @@ class GeneralLedgerXslx(models.AbstractModel):
                             taxes_description += taxes_data[tax_id]["tax_name"] + " "
                         if line["tax_line_id"]:
                             taxes_description += line["tax_line_id"][1]
-                        for account_id, value in line["analytic_distribution"].items():
-                            if value < 100:
-                                analytic_distribution += "%s %d%% " % (
-                                    analytic_data[int(account_id)]["name"],
-                                    value,
-                                )
-                            else:
-                                analytic_distribution += (
-                                    f"{analytic_data[int(account_id)]['name']} "
-                                )
+                        for account_ids, value in line["analytic_distribution"].items():
+                            for account_id in account_ids.split(","):
+                                if value < 100:
+                                    analytic_distribution += "%s %d%% " % (
+                                        analytic_data[int(account_id)]["name"],
+                                        value,
+                                    )
+                                else:
+                                    analytic_distribution += (
+                                        f"{analytic_data[int(account_id)]['name']} "
+                                    )
                         line.update(
                             {
                                 "taxes_description": taxes_description,
@@ -303,18 +304,19 @@ class GeneralLedgerXslx(models.AbstractModel):
                                 taxes_description += (
                                     taxes_data[tax_id]["tax_name"] + " "
                                 )
-                            for account_id, value in line[
+                            for account_ids, value in line[
                                 "analytic_distribution"
                             ].items():
-                                if value < 100:
-                                    analytic_distribution += "%s %d%% " % (
-                                        analytic_data[int(account_id)]["name"],
-                                        value,
-                                    )
-                                else:
-                                    analytic_distribution += (
-                                        f"{analytic_data[int(account_id)]['name']} "
-                                    )
+                                for account_id in account_ids.split(","):
+                                    if value < 100:
+                                        analytic_distribution += "%s %d%% " % (
+                                            analytic_data[int(account_id)]["name"],
+                                            value,
+                                        )
+                                    else:
+                                        analytic_distribution += (
+                                            f"{analytic_data[int(account_id)]['name']} "
+                                        )
                             line.update(
                                 {
                                     "taxes_description": taxes_description,

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -480,22 +480,27 @@
                                 t-as="analytic_id"
                             >
                                 <div>
-                                    <span
-                                        t-att-res-id="analytic_id"
-                                        res-model="account.analytic.account"
-                                        view-type="form"
+                                    <t
+                                        t-foreach="analytic_id.split(',')"
+                                        t-as="analytic_account_id"
                                     >
-                                        <t
-                                            t-out="o._get_atr_from_dict(int(analytic_id), analytic_data, 'name')"
-                                        />
-                                        <t
-                                            t-if="int(line['analytic_distribution'][analytic_id]) &lt; 100"
+                                        <span
+                                            t-att-res-id="analytic_account_id"
+                                            res-model="account.analytic.account"
+                                            view-type="form"
                                         >
                                             <t
-                                            t-out="int(line['analytic_distribution'][analytic_id])"
-                                        />%
-                                        </t>
-                                    </span>
+                                                t-out="o._get_atr_from_dict(int(analytic_account_id), analytic_data, 'name')"
+                                            />
+                                            <t
+                                                t-if="int(line['analytic_distribution'][analytic_id]) &lt; 100"
+                                            >
+                                                <t
+                                                t-out="int(line['analytic_distribution'][analytic_id])"
+                                            />%
+                                            </t>
+                                        </span>
+                                    </t>
                                 </div>
                             </t>
                         </div>


### PR DESCRIPTION
Fix general ledger report print issue when there are multiple analytic accounts on single analytic distribution line.

- Steps to Reproduce:
  - Create journal entry having more than one analytic accounts on single analytic distribution line and post it.
     
      ![image (3)](https://github.com/user-attachments/assets/342bae6d-2f62-4b7a-8054-727581eb00d0)
      
      ![image (4)](https://github.com/user-attachments/assets/db8b835d-911d-4790-b4a2-6df6dbd41a18)
      
  - Try to create general ledger report from "Invoicing > Reporting > OCA accounting reports > General Ledger". Following error occurs
   
    ![image (5)](https://github.com/user-attachments/assets/5a5f5fbe-3c13-4b96-a063-a0c7d2ee1678)


