### PR TITLE
[IMP] account_financial_report: Hide accounts with no end balance

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -45,6 +45,10 @@ currency used in account move lines is properly shown.
 In case that in an account has not been configured a second currency foreign
 currency balances are not available.
 
+In the Trial Balance, the flag *Hide accounts with 0 end balance*
+allows the user to hide accounts that
+have ending balance equal to 0 in the selected period.
+
 **Table of contents**
 
 .. contents::
@@ -143,6 +147,9 @@ Contributors
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Saran Lim. <saranl@ecosoft.co.th>
 * Omar Castiñeira <omar@comunitea.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/readme/CONTRIBUTORS.rst
+++ b/account_financial_report/readme/CONTRIBUTORS.rst
@@ -33,6 +33,9 @@
 * Lois Rilo <lois.rilo@forgeflow.com>
 * Saran Lim. <saranl@ecosoft.co.th>
 * Omar Castiñeira <omar@comunitea.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.

--- a/account_financial_report/readme/DESCRIPTION.rst
+++ b/account_financial_report/readme/DESCRIPTION.rst
@@ -14,3 +14,7 @@ currency used in account move lines is properly shown.
 
 In case that in an account has not been configured a second currency foreign
 currency balances are not available.
+
+In the Trial Balance, the flag *Hide accounts with 0 end balance*
+allows the user to hide accounts that
+have ending balance equal to 0 in the selected period.

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -1,10 +1,11 @@
 # © 2016 Julien Coux (Camptocamp)
 # © 2018 Forest and Biomass Romania SA
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2025 Simone Rubino - PyTech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 
-from odoo import _, api, models
+from odoo import _, api, exceptions, models
 from odoo.tools.float_utils import float_is_zero
 
 
@@ -294,19 +295,55 @@ class TrialBalanceReport(models.AbstractModel):
                 total_amount[acc_id][key] = value
         return total_amount, partners_data
 
-    def _remove_accounts_at_cero(self, total_amount, show_partner_details, company):
-        def is_removable(d):
-            rounding = company.currency_id.rounding
-            return (
-                float_is_zero(d["initial_balance"], precision_rounding=rounding)
-                and float_is_zero(d["credit"], precision_rounding=rounding)
-                and float_is_zero(d["debit"], precision_rounding=rounding)
-                and float_is_zero(d["ending_balance"], precision_rounding=rounding)
-            )
+    def _is_removable(self, company, total_account_data, amounts_at_0):
+        """Return True when all keys in `amounts_at_0` have value 0 in `total_account_data`.
 
+        The precision of `company`'s currency is used to check the values.
+        """
+        rounding = company.currency_id.rounding
+        is_to_remove = False
+        for amount_at_0 in amounts_at_0:
+            if not float_is_zero(
+                total_account_data[amount_at_0],
+                precision_rounding=rounding,
+            ):
+                is_to_remove = False
+                break
+        else:
+            # All amounts are 0
+            is_to_remove = True
+        return is_to_remove
+
+    def _get_amounts_at_0_to_remove_account_data(self, mode):
+        """Return the amounts that must be checked for removing account lines."""
+        mode_to_amounts_at_0 = {
+            "all": [
+                "initial_balance",
+                "credit",
+                "debit",
+                "ending_balance",
+            ],
+            "end": [
+                "ending_balance",
+            ],
+        }
+        amounts_at_0 = mode_to_amounts_at_0.get(mode, [])
+        if not amounts_at_0:
+            raise exceptions.UserError(
+                _(
+                    "Mode %(mode)s for removing account lines at 0 not supported",
+                    mode=mode,
+                )
+            )
+        return amounts_at_0
+
+    def _remove_accounts_at_cero(
+        self, total_amount, show_partner_details, company, mode="all"
+    ):
+        amounts_at_0 = self._get_amounts_at_0_to_remove_account_data(mode=mode)
         accounts_to_remove = []
         for acc_id, ta_data in total_amount.items():
-            if is_removable(ta_data):
+            if self._is_removable(company, ta_data, amounts_at_0):
                 accounts_to_remove.append(acc_id)
             elif show_partner_details:
                 partner_to_remove = []
@@ -314,7 +351,9 @@ class TrialBalanceReport(models.AbstractModel):
                     # If the show_partner_details option is checked,
                     # the partner data is in the same account data dict
                     # but with the partner id as the key
-                    if isinstance(key, int) and is_removable(value):
+                    if isinstance(key, int) and self._is_removable(
+                        company, value, amounts_at_0
+                    ):
                         partner_to_remove.append(key)
                 for partner_id in partner_to_remove:
                     del ta_data[partner_id]
@@ -334,6 +373,7 @@ class TrialBalanceReport(models.AbstractModel):
         only_posted_moves,
         show_partner_details,
         hide_account_at_0,
+        hide_account_at_end_0,
         unaffected_earnings_account,
         fy_start_date,
     ):
@@ -447,6 +487,12 @@ class TrialBalanceReport(models.AbstractModel):
                 total_amount, tb_initial_prt, tb_period_prt, foreign_currency
             )
         # Remove accounts a 0 from collections
+        if hide_account_at_end_0:
+            company = self.env["res.company"].browse(company_id)
+            self._remove_accounts_at_cero(
+                total_amount, show_partner_details, company, mode="end"
+            )
+
         if hide_account_at_0:
             company = self.env["res.company"].browse(company_id)
             self._remove_accounts_at_cero(total_amount, show_partner_details, company)
@@ -657,6 +703,7 @@ class TrialBalanceReport(models.AbstractModel):
         date_to = data["date_to"]
         date_from = data["date_from"]
         hide_account_at_0 = data["hide_account_at_0"]
+        hide_account_at_end_0 = data["hide_account_at_end_0"]
         show_hierarchy = data["show_hierarchy"]
         show_hierarchy_level = data["show_hierarchy_level"]
         foreign_currency = data["foreign_currency"]
@@ -674,6 +721,7 @@ class TrialBalanceReport(models.AbstractModel):
             only_posted_moves,
             show_partner_details,
             hide_account_at_0,
+            hide_account_at_end_0,
             unaffected_earnings_account,
             fy_start_date,
         )
@@ -735,6 +783,7 @@ class TrialBalanceReport(models.AbstractModel):
             "date_to": data["date_to"],
             "only_posted_moves": data["only_posted_moves"],
             "hide_account_at_0": data["hide_account_at_0"],
+            "hide_account_at_end_0": data["hide_account_at_end_0"],
             "show_partner_details": data["show_partner_details"],
             "limit_hierarchy_level": data["limit_hierarchy_level"],
             "show_hierarchy": show_hierarchy,

--- a/account_financial_report/static/description/index.html
+++ b/account_financial_report/static/description/index.html
@@ -385,6 +385,9 @@ currency set up in account in order to display balances. Moreover, any foreign
 currency used in account move lines is properly shown.</p>
 <p>In case that in an account has not been configured a second currency foreign
 currency balances are not available.</p>
+<p>In the Trial Balance, the flag <em>Hide accounts with 0 end balance</em>
+allows the user to hide accounts that
+have ending balance equal to 0 in the selected period.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -498,6 +501,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Lois Rilo &lt;<a class="reference external" href="mailto:lois.rilo&#64;forgeflow.com">lois.rilo&#64;forgeflow.com</a>&gt;</li>
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 <li>Omar Castiñeira &lt;<a class="reference external" href="mailto:omar&#64;comunitea.com">omar&#64;comunitea.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 <p>Much of the work in this module was done at a sprint in Sorrento, Italy in
 April 2016.</p>

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -1,9 +1,10 @@
 # Author: Julien Coux
 # Copyright 2016 Camptocamp SA
 # Copyright 2020 ForgeFlow S.L. (https://www.forgeflow.com)
+# Copyright 2025 Simone Rubino - PyTech
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -671,3 +672,62 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         self.assertEqual(total_initial_balance, 0)
         self.assertEqual(total_final_balance, 0)
         self.assertEqual(total_debit, total_credit)
+
+    def _move_amount(self, amount, from_account, to_account, move_date):
+        """Move `amount` from account `from_account` to account `to_account` on `move_date`."""
+        entry_form = Form(self.env["account.move"])
+        entry_form.partner_id = self.env.ref("base.res_partner_12")
+        entry_form.date = move_date
+        with entry_form.line_ids.new() as line:
+            line.name = "Test"
+            line.account_id = from_account
+            line.credit = 100
+        with entry_form.line_ids.new() as line:
+            line.name = "Test"
+            line.account_id = to_account
+            line.debit = 100
+        entry = entry_form.save()
+        entry.action_post()
+        return entry
+
+    def test_hide_account_at_end_0(self):
+        """When "Hide accounts with 0 end balance" is enabled,
+        accounts that have 0 end balance are hidden.
+        """
+        # Arrange
+        trial_balance = self.env["trial.balance.report.wizard"].create(
+            {
+                "date_from": self.date_start,
+                "date_to": self.date_end,
+                "hide_account_at_end_0": True,
+            }
+        )
+        start_date = trial_balance.date_from
+        end_date = trial_balance.date_to
+        report_interval = end_date - start_date
+        before_date = start_date - report_interval
+        in_date = start_date + report_interval / 2
+        # One account has initial balance > 0
+        # but end balance = 0
+        only_initial_account = self.account100.copy()
+        self._move_amount(100, self.account100, only_initial_account, before_date)
+        self._move_amount(100, only_initial_account, self.account100, in_date)
+        # Another account has initial balance = 0
+        # but end balance > 0
+        only_end_account = self.account100.copy()
+        self._move_amount(100, self.account100, only_end_account, in_date)
+
+        # Act
+        prepared_data = trial_balance._prepare_report_trial_balance()
+        report_values = self.env[
+            "report.account_financial_report.trial_balance"
+        ]._get_report_values(trial_balance, prepared_data)
+        trial_balance = report_values["trial_balance"]
+
+        # Assert
+        self.assertFalse(
+            self.check_account_in_report(only_initial_account.id, trial_balance)
+        )
+        self.assertTrue(
+            self.check_account_in_report(only_end_account.id, trial_balance)
+        )

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -45,6 +45,11 @@ class TrialBalanceReportWizard(models.TransientModel):
         "not display accounts that have initial balance = "
         "debit = credit = end balance = 0",
     )
+    hide_account_at_end_0 = fields.Boolean(
+        string="Hide accounts with 0 end balance",
+        help="When this option is enabled, the trial balance will "
+        "not display accounts that have end balance = 0",
+    )
     receivable_accounts_only = fields.Boolean()
     payable_accounts_only = fields.Boolean()
     show_partner_details = fields.Boolean()
@@ -249,6 +254,7 @@ class TrialBalanceReportWizard(models.TransientModel):
             "date_to": self.date_to,
             "only_posted_moves": self.target_move == "posted",
             "hide_account_at_0": self.hide_account_at_0,
+            "hide_account_at_end_0": self.hide_account_at_end_0,
             "foreign_currency": self.foreign_currency,
             "company_id": self.company_id.id,
             "account_ids": self.account_ids.ids or [],

--- a/account_financial_report/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report/wizard/trial_balance_wizard_view.xml
@@ -26,6 +26,7 @@
                         <group name="other_filters">
                             <field name="target_move" widget="radio" />
                             <field name="hide_account_at_0" />
+                            <field name="hide_account_at_end_0" />
                             <field name="show_partner_details" />
                             <field
                                 name="show_hierarchy"


### PR DESCRIPTION
Add a new flag in the wizard that allows the user to hide from the report the accounts that have 0 ending balance.