### PR TITLE
[15.0][IMP] account_tax_balance: optional hide for financial_type in tree view

### DIFF
--- a/account_tax_balance/views/account_move_view.xml
+++ b/account_tax_balance/views/account_move_view.xml
@@ -8,7 +8,7 @@
         <field name="inherit_id" ref="account.view_move_tree" />
         <field name="arch" type="xml">
             <field name="state" position="after">
-                <field name="financial_type" />
+                <field name="financial_type" optional="hide" />
             </field>
         </field>
     </record>
@@ -30,7 +30,7 @@
             <group expand="0" position="inside">
                 <filter
                     name="financial_type"
-                    string="Move type"
+                    string="Financial type"
                     domain="[]"
                     context="{'group_by':'financial_type'}"
                 />


### PR DESCRIPTION
This PR makes the `financial_type` field optional in tree view. While the field makes sense from a technical perspective, it can be confusing from an accounting point of view. We are introducing the option to hide it when it's not relevant.

Additionally, we rename the filter title from "Move Type" to "Financial Type". This is the label shown in both the tree and form views. The previous label was misleading, as "Move Type" could be confused with the standard Odoo field `move_type`.
