### PR TITLE
[IMP] partner_statement: Translate statement title

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -15,6 +15,40 @@ class ActivityStatement(models.AbstractModel):
     _name = "report.partner_statement.activity_statement"
     _description = "Partner Activity Statement"
 
+    def _get_title(self, partner, **kwargs):
+        kwargs["context"] = {
+            "lang": partner.lang,
+        }
+        if kwargs.get("is_detailed"):
+            if kwargs.get("account_type") == "receivable":
+                title = _(
+                    "Detailed Statement "
+                    "between %(starting_date)s and %(ending_date)s "
+                    "in %(currency)s",
+                    **kwargs,
+                )
+            else:
+                title = _(
+                    "Detailed Supplier Statement "
+                    "between %(starting_date)s and %(ending_date)s "
+                    "in %(currency)s",
+                    **kwargs,
+                )
+        else:
+            if kwargs.get("account_type") == "receivable":
+                title = _(
+                    "Statement between %(starting_date)s and %(ending_date)s in %(currency)s",
+                    **kwargs,
+                )
+            else:
+                title = _(
+                    "Supplier Statement "
+                    "between %(starting_date)s and %(ending_date)s "
+                    "in %(currency)s",
+                    **kwargs,
+                )
+        return title
+
     def _initial_balance_sql_q1(self, partners, date_start, account_type):
         excluded_accounts_ids = tuple(
             self.env.context.get("excluded_accounts_ids", [])

--- a/partner_statement/report/activity_statement_xlsx.py
+++ b/partner_statement/report/activity_statement_xlsx.py
@@ -38,11 +38,13 @@ class ActivityStatementXslx(models.AbstractModel):
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
         row_pos += 2
-        statement_header = _("%sStatement between %s and %s in %s") % (
-            account_type == "payable" and _("Supplier ") or "",
-            partner_data.get("start"),
-            partner_data.get("end"),
-            currency.display_name,
+        statement_header = data["get_title"](
+            partner,
+            is_detailed=False,
+            account_type=account_type,
+            starting_date=partner_data.get("start"),
+            ending_date=partner_data.get("end"),
+            currency=currency.display_name,
         )
         sheet.merge_range(
             row_pos, 0, row_pos, 6, statement_header, FORMATS["format_left_bold"]

--- a/partner_statement/report/detailed_activity_statement.py
+++ b/partner_statement/report/detailed_activity_statement.py
@@ -1,7 +1,7 @@
 # Copyright 2022 ForgeFlow, S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import models
+from odoo import _, models
 
 from .outstanding_statement import OutstandingStatement
 
@@ -12,6 +12,34 @@ class DetailedActivityStatement(models.AbstractModel):
     _inherit = "report.partner_statement.activity_statement"
     _name = "report.partner_statement.detailed_activity_statement"
     _description = "Partner Detailed Activity Statement"
+
+    def _get_title(self, partner, **kwargs):
+        kwargs["context"] = {
+            "lang": partner.lang,
+        }
+        if kwargs.get("line_type") == "prior_lines":
+            if kwargs.get("account_type") == "receivable":
+                title = _(
+                    "Prior Balance up to %(ending_date)s in %(currency)s", **kwargs
+                )
+            else:
+                title = _(
+                    "Supplier Prior Balance up to %(ending_date)s in %(currency)s",
+                    **kwargs
+                )
+        elif kwargs.get("line_type") == "ending_lines":
+            if kwargs.get("account_type") == "receivable":
+                title = _(
+                    "Ending Balance up to %(ending_date)s in %(currency)s", **kwargs
+                )
+            else:
+                title = _(
+                    "Supplier Ending Balance up to %(ending_date)s in %(currency)s",
+                    **kwargs
+                )
+        else:
+            title = super()._get_title(partner, **kwargs)
+        return title
 
     def _get_account_display_prior_lines(
         self, company_id, partner_ids, date_start, date_end, account_type

--- a/partner_statement/report/detailed_activity_statement_xlsx.py
+++ b/partner_statement/report/detailed_activity_statement_xlsx.py
@@ -38,11 +38,13 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
         row_pos += 2
-        statement_header = _("Detailed %sStatement between %s and %s in %s") % (
-            account_type == "payable" and _("Supplier ") or "",
-            partner_data.get("start"),
-            partner_data.get("end"),
-            currency.display_name,
+        statement_header = data["get_title"](
+            partner,
+            is_detailed=True,
+            account_type=account_type,
+            starting_date=partner_data.get("start"),
+            ending_date=partner_data.get("end"),
+            currency=currency.display_name,
         )
         sheet.merge_range(
             row_pos,
@@ -216,10 +218,13 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
         row_pos += 2
-        statement_header = _("%sStatement up to %s in %s") % (
-            account_type == "payable" and _("Supplier ") or "",
-            partner_data.get("prior_day"),
-            currency.display_name,
+        statement_header = data["get_title"](
+            partner,
+            is_detailed=False,
+            account_type=account_type,
+            starting_date=partner_data.get("start"),
+            ending_date=partner_data.get("end"),
+            currency=currency.display_name,
         )
         sheet.merge_range(
             row_pos,
@@ -321,10 +326,13 @@ class DetailedActivityStatementXslx(models.AbstractModel):
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
         row_pos += 2
-        statement_header = _("%sStatement up to %s in %s") % (
-            account_type == "payable" and _("Supplier ") or "",
-            partner_data.get("end"),
-            currency.display_name,
+        statement_header = data["get_title"](
+            partner,
+            is_detailed=False,
+            account_type=account_type,
+            starting_date=partner_data.get("start"),
+            ending_date=partner_data.get("end"),
+            currency=currency.display_name,
         )
         sheet.merge_range(
             row_pos,

--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -1,7 +1,7 @@
 # Copyright 2018 ForgeFlow, S.L. (https://www.forgeflow.com)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.tools.float_utils import float_is_zero
 
 
@@ -11,6 +11,18 @@ class OutstandingStatement(models.AbstractModel):
     _inherit = "statement.common"
     _name = "report.partner_statement.outstanding_statement"
     _description = "Partner Outstanding Statement"
+
+    def _get_title(self, partner, **kwargs):
+        kwargs["context"] = {
+            "lang": partner.lang,
+        }
+        if kwargs.get("account_type") == "receivable":
+            title = _("Statement up to %(ending_date)s in %(currency)s", **kwargs)
+        else:
+            title = _(
+                "Supplier Statement up to %(ending_date)s in %(currency)s", **kwargs
+            )
+        return title
 
     def _display_outstanding_lines_sql_q1(self, partners, date_end, account_type):
         partners = tuple(partners)

--- a/partner_statement/report/outstanting_statement_xlsx.py
+++ b/partner_statement/report/outstanting_statement_xlsx.py
@@ -156,10 +156,11 @@ class OutstandingStatementXslx(models.AbstractModel):
         currency_data = partner_data.get("currencies", {}).get(currency.id)
         account_type = data.get("account_type", False)
         row_pos += 2
-        statement_header = _("%sStatement up to %s in %s") % (
-            account_type == "payable" and _("Supplier ") or "",
-            partner_data.get("end"),
-            currency.display_name,
+        statement_header = data["get_title"](
+            partner,
+            account_type=account_type,
+            ending_date=partner_data.get("end"),
+            currency=currency.display_name,
         )
         sheet.merge_range(
             row_pos, 0, row_pos, 6, statement_header, FORMATS["format_left_bold"]

--- a/partner_statement/report/report_statement_common.py
+++ b/partner_statement/report/report_statement_common.py
@@ -17,6 +17,15 @@ class ReportStatementCommon(models.AbstractModel):
         inv_addr_id = part.address_get(["invoice"]).get("invoice", part.id)
         return self.env["res.partner"].browse(inv_addr_id)
 
+    def _get_title(self, partner, **kwargs):
+        raise NotImplementedError
+
+    def _get_aging_buckets_title(self, partner, **kwargs):
+        kwargs["context"] = {
+            "lang": partner.lang,
+        }
+        return _("Aging Report at %(ending_date)s in %(currency)s", **kwargs)
+
     def _format_date_to_partner_lang(
         self, date, date_format=DEFAULT_SERVER_DATE_FORMAT
     ):
@@ -599,4 +608,6 @@ class ReportStatementCommon(models.AbstractModel):
             "is_detailed": is_detailed,
             "bucket_labels": bucket_labels,
             "get_inv_addr": self._get_invoice_address,
+            "get_title": self._get_title,
+            "get_aging_buckets_title": self._get_aging_buckets_title,
         }

--- a/partner_statement/views/activity_statement.xml
+++ b/partner_statement/views/activity_statement.xml
@@ -4,12 +4,9 @@
 <odoo>
     <template id="activity_balance">
         <p>
-            <span t-if="is_detailed">Detailed </span>
             <span
-                t-if="account_type == 'payable'"
-            >Supplier </span>Statement between <span t-esc="d['start']" /> and <span
-                t-esc="d['end']"
-            /> in <span t-esc="display_currency.name" />
+                t-esc="get_title(o, is_detailed=is_detailed, account_type=account_type, starting_date=d['start'], ending_date=d['end'], currency=display_currency.name)"
+            />
         </p>
         <table class="table table-condensed table-statement">
             <thead>

--- a/partner_statement/views/aging_buckets.xml
+++ b/partner_statement/views/aging_buckets.xml
@@ -4,9 +4,9 @@
 <odoo>
     <template id="aging_buckets">
         <p>
-            Aging Report at <span t-esc="d['end']" /> in <span
-                t-esc="display_currency.name"
-            />:
+            <span
+                t-esc="get_aging_buckets_title(o, ending_date=d['end'], currency=display_currency.name)"
+            />
         </p>
         <table class="table table-sm table-statement">
             <thead>

--- a/partner_statement/views/detailed_activity_statement.xml
+++ b/partner_statement/views/detailed_activity_statement.xml
@@ -36,7 +36,6 @@
                         <t t-set="display_currency" t-value="Currencies[currency[0]]" />
                         <t t-set="currency" t-value="currency[1]" />
                         <t t-set="line_type" t-value="'prior_lines'" />
-                        <t t-set="title_name" t-value="'Prior Balance'" />
                         <t
                             t-set="ending_amount"
                             t-value="currency['balance_forward']"
@@ -51,7 +50,6 @@
                             name="detailed_activity"
                         />
                         <t t-set="line_type" t-value="'ending_lines'" />
-                        <t t-set="title_name" t-value="'Ending Balance'" />
                         <t t-set="ending_amount" t-value="currency['amount_due']" />
                         <t t-set="ending_date" t-value="d['end']" />
                         <t

--- a/partner_statement/views/outstanding_statement.xml
+++ b/partner_statement/views/outstanding_statement.xml
@@ -4,10 +4,8 @@
 <odoo>
     <template id="outstanding_balance">
         <p>
-            <span t-esc="'' if  account_type == 'receivable' else 'Supplier '" /><span
-                t-esc="title_name"
-            /> up to <span t-esc="ending_date" /> in <span
-                t-esc="display_currency.name"
+            <span
+                t-esc="get_title(o, account_type=account_type, line_type=line_type, ending_date=ending_date, currency=display_currency.name)"
             />
         </p>
         <table class="table table-sm table-statement">
@@ -135,7 +133,6 @@
                         <t t-set="display_currency" t-value="Currencies[currency[0]]" />
                         <t t-set="currency" t-value="currency[1]" />
                         <t t-set="line_type" t-value="'lines'" />
-                        <t t-set="title_name" t-value="'Statement'" />
                         <t t-set="ending_amount" t-value="currency['amount_due']" />
                         <t t-set="ending_date" t-value="d['end']" />
                         <t


### PR DESCRIPTION
Translating the statement titles is difficult, if not impossible in some cases.

For example: in the string "Detailed Supplier Statement ..." right now you can translate "Detailed ", or "Supplier ", but the translation of the whole string might need to change the order of the translated terms.

Another example: the string "Statement" cannot be translated because it is declared in a variable in the template.

After this PR, the whole statement title can be translated properly, for every statement.
Let me know what you think!