### PR TITLE
[17.0][FIX] account_financial_report: Remove buggy empty selection value

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -181,8 +181,7 @@ class GeneralLedgerReport(models.AbstractModel):
             acc_id = gl["account_id"][0]
             data[acc_id] = self._prepare_gen_ld_data_item(gl)
             data[acc_id]["id"] = acc_id
-            if grouped_by:
-                data[acc_id][grouped_by] = False
+            data[acc_id][grouped_by] = False
         method = "_prepare_gen_ld_data_group_%s" % grouped_by
         if not hasattr(self, method):
             return data
@@ -491,15 +490,13 @@ class GeneralLedgerReport(models.AbstractModel):
                 gen_ld_data[acc_id] = self._initialize_data(foreign_currency)
                 gen_ld_data[acc_id]["id"] = acc_id
                 gen_ld_data[acc_id]["mame"] = move_line["account_id"][1]
-                if grouped_by:
-                    gen_ld_data[acc_id][grouped_by] = False
+                gen_ld_data[acc_id][grouped_by] = False
             if acc_id in acc_prt_account_ids:
                 item_ids = self._prepare_ml_items(move_line, grouped_by)
                 for item in item_ids:
                     item_id = item["id"]
                     if item_id not in gen_ld_data[acc_id]:
-                        if grouped_by:
-                            gen_ld_data[acc_id][grouped_by] = True
+                        gen_ld_data[acc_id][grouped_by] = True
                         gen_ld_data[acc_id][item_id] = self._initialize_data(
                             foreign_currency
                         )
@@ -650,7 +647,7 @@ class GeneralLedgerReport(models.AbstractModel):
                     "grouped_by": grouped_by,
                 }
             )
-            if grouped_by and not gen_led_data[acc_id][grouped_by]:
+            if not gen_led_data[acc_id][grouped_by]:
                 account = self._create_account(
                     account, acc_id, gen_led_data, rec_after_date_to_ids
                 )
@@ -664,37 +661,23 @@ class GeneralLedgerReport(models.AbstractModel):
                 ):
                     continue
             else:
-                if grouped_by:
-                    account, list_grouped = self._get_list_grouped_item(
-                        gen_led_data[acc_id],
-                        account,
-                        rec_after_date_to_ids,
-                        hide_account_at_0,
-                        rounding,
+                account, list_grouped = self._get_list_grouped_item(
+                    gen_led_data[acc_id],
+                    account,
+                    rec_after_date_to_ids,
+                    hide_account_at_0,
+                    rounding,
+                )
+                account.update({"list_grouped": list_grouped})
+                if (
+                    hide_account_at_0
+                    and float_is_zero(
+                        gen_led_data[acc_id]["init_bal"]["balance"],
+                        precision_rounding=rounding,
                     )
-                    account.update({"list_grouped": list_grouped})
-                    if (
-                        hide_account_at_0
-                        and float_is_zero(
-                            gen_led_data[acc_id]["init_bal"]["balance"],
-                            precision_rounding=rounding,
-                        )
-                        and account["list_grouped"] == []
-                    ):
-                        continue
-                else:
-                    account = self._create_account_not_show_item(
-                        account, acc_id, gen_led_data, rec_after_date_to_ids, grouped_by
-                    )
-                    if (
-                        hide_account_at_0
-                        and float_is_zero(
-                            gen_led_data[acc_id]["init_bal"]["balance"],
-                            precision_rounding=rounding,
-                        )
-                        and account["move_lines"] == []
-                    ):
-                        continue
+                    and account["list_grouped"] == []
+                ):
+                    continue
             general_ledger += [account]
         return general_ledger
 
@@ -743,7 +726,7 @@ class GeneralLedgerReport(models.AbstractModel):
         centralized_ml = {}
         if isinstance(date_to, str):
             date_to = datetime.datetime.strptime(date_to, "%Y-%m-%d").date()
-        if grouped_by and account[grouped_by]:
+        if account[grouped_by]:
             for item in account["list_grouped"]:
                 for move_line in item["move_lines"]:
                     centralized_ml = self._calculate_centralization(
@@ -834,7 +817,7 @@ class GeneralLedgerReport(models.AbstractModel):
                         gen_ld_data[account["id"]]["init_bal"]["balance"],
                         rec_after_date_to_ids,
                     )
-                    if grouped_by and account[grouped_by]:
+                    if account[grouped_by]:
                         account[grouped_by] = False
                         del account["list_grouped"]
         general_ledger = sorted(general_ledger, key=lambda k: k["code"])

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -76,8 +76,9 @@ class GeneralLedgerReportWizard(models.TransientModel):
         help="Ending account in a range",
     )
     grouped_by = fields.Selection(
-        selection=[("", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
+        selection=[("none", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
         default="partners",
+        required=True,
     )
     show_cost_center = fields.Boolean(
         string="Show Analytic Account",


### PR DESCRIPTION
Forward-port of #1265 squashing the commits and giving a more comprehensive commit message.

Selecting no value in the "Grouped by" general ledger wizard, but filtering any account, results in an empty display, due to the weird trick of having an empty selection value.

This, joined with the fact of not being able to predefine that empty value with standard tools, makes the switch necessary.

- Set grouped_by as required with non grouped item description.
- Switched selection value from "" (empty) to "none".
- Adapt general_ledger group_by conditionals.

@Tecnativa TT56818