### PR TITLE
[18.0][FIX] account_financial_report: Remove buggy empty selection value

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -76,8 +76,9 @@ class GeneralLedgerReportWizard(models.TransientModel):
         help="Ending account in a range",
     )
     grouped_by = fields.Selection(
-        selection=[("", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
+        selection=[("none", "None"), ("partners", "Partners"), ("taxes", "Taxes")],
         default="partners",
+        required=True,
     )
     show_cost_center = fields.Boolean(
         string="Show Analytic Account",


### PR DESCRIPTION
Forward-port of #1378 and #1265 

Selecting no value in the "Grouped by" general ledger wizard, but filtering any account, results in an empty display, due to the weird trick of having an empty selection value.

This, joined with the fact of not being able to predefine that empty value with standard tools, makes the switch necessary.

- Set grouped_by as required with non grouped item description.
- Switched selection value from "" (empty) to "none".
- Adapt general_ledger group_by conditionals.

@Tecnativa 