### PR TITLE
[18.0][IMP] mis_template_financial_report: unallocated earnings

### DIFF
--- a/mis_template_financial_report/data/mis_report_kpi.xml
+++ b/mis_template_financial_report/data/mis_report_kpi.xml
@@ -1,17 +1,5 @@
 <odoo>
-    <record id="kpi_loss" model="mis.report.kpi">
-        <field name="name">loss</field>
-        <field name="description">Loss</field>
-        <field name="expression">balp[('account_type', 'like', 'expense%')][]</field>
-        <field name="auto_expand_accounts">true</field>
-        <field name="auto_expand_accounts_style_id" ref="style_details" />
-        <field name="style_id" ref="style_header" />
-        <field name="type">num</field>
-        <field name="compare_method">diff</field>
-        <field name="accumulation_method">sum</field>
-        <field name="sequence">100</field>
-        <field name="report_id" ref="report_pl" />
-    </record>
+    <!-- profit & loss -->
     <record id="kpi_profit" model="mis.report.kpi">
         <field name="name">profit</field>
         <field name="description">Profit</field>
@@ -28,8 +16,20 @@
         <field name="report_id" ref="report_pl" />
         <field name="split_after" eval="True" />
     </record>
+    <record id="kpi_loss" model="mis.report.kpi">
+        <field name="name">loss</field>
+        <field name="description">Loss</field>
+        <field name="expression">balp[('account_type', 'like', 'expense%')][]</field>
+        <field name="auto_expand_accounts">true</field>
+        <field name="auto_expand_accounts_style_id" ref="style_details" />
+        <field name="style_id" ref="style_header" />
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="sequence">100</field>
+        <field name="report_id" ref="report_pl" />
+    </record>
     <record id="kpi_pl_to_report" model="mis.report.kpi">
-        <field name="id">3</field>
         <field name="name">pl_to_report</field>
         <field name="description">Profit or loss to report</field>
         <field name="expression">profit - loss</field>
@@ -41,8 +41,22 @@
         <field name="sequence">101</field>
         <field name="report_id" ref="report_pl" />
     </record>
+    <!-- balance sheet -->
+    <record id="kpi_assets" model="mis.report.kpi">
+        <field name="name">assets</field>
+        <field name="description">Assets</field>
+        <field name="expression">bale[('account_type', 'like', 'asset%')][]</field>
+        <field name="auto_expand_accounts">true</field>
+        <field name="auto_expand_accounts_style_id" ref="style_details" />
+        <field name="style_id" ref="style_header" />
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="sequence">0</field>
+        <field name="report_id" ref="report_bs" />
+        <field name="split_after" eval="True" />
+    </record>
     <record id="kpi_liability_total" model="mis.report.kpi">
-        <field name="id">8</field>
         <field name="name">liability_header</field>
         <field name="description">Liability</field>
         <field name="expression">liability + subreport_pl.pl_to_report</field>
@@ -54,21 +68,7 @@
         <field name="sequence">100</field>
         <field name="report_id" ref="report_bs" />
     </record>
-    <record id="kpi_liability_pl_subreport" model="mis.report.kpi">
-        <field name="id">7</field>
-        <field name="name">pl</field>
-        <field name="description">Profit / Loss</field>
-        <field name="expression">subreport_pl.pl_to_report</field>
-        <field name="auto_expand_accounts">false</field>
-        <field name="style_id" ref="style_header_indent" />
-        <field name="type">num</field>
-        <field name="compare_method">pct</field>
-        <field name="accumulation_method">sum</field>
-        <field name="sequence">102</field>
-        <field name="report_id" ref="report_bs" />
-    </record>
     <record id="kpi_liability" model="mis.report.kpi">
-        <field name="id">5</field>
         <field name="name">liability</field>
         <field name="description">Liabilities</field>
         <field
@@ -83,19 +83,16 @@
         <field name="sequence">101</field>
         <field name="report_id" ref="report_bs" />
     </record>
-    <record id="kpi_assets" model="mis.report.kpi">
-        <field name="id">4</field>
-        <field name="name">assets</field>
-        <field name="description">Assets</field>
-        <field name="expression">bale[('account_type', 'like', 'asset%')][]</field>
-        <field name="auto_expand_accounts">true</field>
-        <field name="auto_expand_accounts_style_id" ref="style_details" />
-        <field name="style_id" ref="style_header" />
+    <record id="kpi_liability_pl_subreport" model="mis.report.kpi">
+        <field name="name">pl</field>
+        <field name="description">Profit / Loss</field>
+        <field name="expression">subreport_pl.pl_to_report</field>
+        <field name="auto_expand_accounts">false</field>
+        <field name="style_id" ref="style_header_indent" />
         <field name="type">num</field>
-        <field name="compare_method">diff</field>
+        <field name="compare_method">pct</field>
         <field name="accumulation_method">sum</field>
-        <field name="sequence">0</field>
+        <field name="sequence">102</field>
         <field name="report_id" ref="report_bs" />
-        <field name="split_after" eval="True" />
     </record>
 </odoo>

--- a/mis_template_financial_report/data/mis_report_kpi.xml
+++ b/mis_template_financial_report/data/mis_report_kpi.xml
@@ -3,9 +3,7 @@
     <record id="kpi_profit" model="mis.report.kpi">
         <field name="name">profit</field>
         <field name="description">Profit</field>
-        <field
-            name="expression"
-        >-balp['|', ('account_type', 'like', 'income%'), ('account_type', 'like', 'equity_unaffected')][]</field>
+        <field name="expression">-balp[('account_type', 'like', 'income%')][]</field>
         <field name="auto_expand_accounts">true</field>
         <field name="auto_expand_accounts_style_id" ref="style_details" />
         <field name="style_id" ref="style_header" />
@@ -58,8 +56,8 @@
     </record>
     <record id="kpi_liability_total" model="mis.report.kpi">
         <field name="name">liability_header</field>
-        <field name="description">Liability</field>
-        <field name="expression">liability + subreport_pl.pl_to_report</field>
+        <field name="description">Liability + Equity</field>
+        <field name="expression">liability + equity + current_ue + previous_ue</field>
         <field name="auto_expand_accounts">false</field>
         <field name="style_id" ref="style_header" />
         <field name="type">num</field>
@@ -71,9 +69,7 @@
     <record id="kpi_liability" model="mis.report.kpi">
         <field name="name">liability</field>
         <field name="description">Liabilities</field>
-        <field
-            name="expression"
-        >-bale['|', ('account_type', 'like', 'liability%'), ('account_type', '=', 'equity')][]</field>
+        <field name="expression">-bale[('account_type', 'like', 'liability%')][]</field>
         <field name="auto_expand_accounts">true</field>
         <field name="auto_expand_accounts_style_id" ref="style_details_double_indent" />
         <field name="style_id" ref="style_header_indent" />
@@ -83,16 +79,69 @@
         <field name="sequence">101</field>
         <field name="report_id" ref="report_bs" />
     </record>
+    <record id="kpi_equity" model="mis.report.kpi">
+        <field name="name">equity</field>
+        <field name="description">Equity</field>
+        <field name="expression">-bale[('account_type', '=', 'equity')][]</field>
+        <field name="auto_expand_accounts">true</field>
+        <field name="auto_expand_accounts_style_id" ref="style_details_double_indent" />
+        <field name="style_id" ref="style_header_indent" />
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="sequence">102</field>
+        <field name="report_id" ref="report_bs" />
+    </record>
+    <record id="kpi_unallocated_total" model="mis.report.kpi">
+        <field name="name">unallocated_header</field>
+        <field name="description">Unallocated Earnings</field>
+        <field name="expression">current_ue + previous_ue</field>
+        <field name="auto_expand_accounts">false</field>
+        <field name="style_id" ref="style_header_indent" />
+        <field name="type">num</field>
+        <field name="compare_method">none</field>
+        <field name="accumulation_method">none</field>
+        <field name="sequence">103</field>
+        <field name="report_id" ref="report_bs" />
+    </record>
+    <record id="kpi_current_unallocated" model="mis.report.kpi">
+        <field name="name">current_ue</field>
+        <field name="description">Current Year Unallocated Earnings</field>
+        <field
+            name="expression"
+        >subreport_pl.pl_to_report -balp[('account_type', 'like', 'equity_unaffected')]</field>
+        <field name="auto_expand_accounts">false</field>
+        <field name="style_id" ref="style_details_double_indent" />
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="sequence">104</field>
+        <field name="report_id" ref="report_bs" />
+    </record>
+    <record id="kpi_previous_unallocated" model="mis.report.kpi">
+        <field name="name">previous_ue</field>
+        <field name="description">Previous Year Unallocated Earnings</field>
+        <field
+            name="expression"
+        >-balu[] -bale[('account_type', 'like', 'equity_unaffected')] +balp[('account_type', 'like', 'equity_unaffected')]</field>
+        <field name="auto_expand_accounts">false</field>
+        <field name="style_id" ref="style_details_double_indent" />
+        <field name="type">num</field>
+        <field name="compare_method">diff</field>
+        <field name="accumulation_method">sum</field>
+        <field name="sequence">105</field>
+        <field name="report_id" ref="report_bs" />
+    </record>
     <record id="kpi_liability_pl_subreport" model="mis.report.kpi">
         <field name="name">pl</field>
         <field name="description">Profit / Loss</field>
         <field name="expression">subreport_pl.pl_to_report</field>
         <field name="auto_expand_accounts">false</field>
-        <field name="style_id" ref="style_header_indent" />
+        <field name="style_id" ref="style_header" />
         <field name="type">num</field>
         <field name="compare_method">pct</field>
         <field name="accumulation_method">sum</field>
-        <field name="sequence">102</field>
+        <field name="sequence">110</field>
         <field name="report_id" ref="report_bs" />
     </record>
 </odoo>


### PR DESCRIPTION
The account type equity_unaffected (Current Year Earnings)  is currently used on the P&L report which makes no sense IMO.

After reading [the official documentation](https://www.odoo.com/documentation/18.0/applications/finance/accounting/reporting/year_end.html#current-year-s-earnings) and some feedback from accounting colleagues I propose to put the equity_unaffected on the balance sheet.

We could go further and implement "Retained earnings" in the bottom of the balance sheet instead of showing the Profit / Loss there.


