### PR TITLE
[18.0][FIX] account_financial_report: correctly sum amount_currency in read_group for trial balance

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -31,12 +31,12 @@ Account Financial Reports
 This module adds a set of financial reports. They are accessible under
 Invoicing / Reporting / OCA accounting reports.
 
-- General ledger
-- Trial Balance
-- Open Items
-- Aged Partner Balance
-- VAT Report
-- Journal Ledger
+-  General ledger
+-  Trial Balance
+-  Open Items
+-  Aged Partner Balance
+-  VAT Report
+-  Journal Ledger
 
 Currently General ledger, Trial Balance and Open Items are fully
 compatible with a foreign currency set up in account in order to display
@@ -90,12 +90,12 @@ per company in:
 Known issues / Roadmap
 ======================
 
-- 'VAT Report' is valid only for cases where it's met that for each Tax
-  defined: all the "Account tags" of all the 'Repartition for Invoices'
-  or 'Repartition for Credit Notes' are different.
-- It would be nice to have in reports a column indicating the state of
-  the entries when the option "All Entries" is selected in "Target
-  Moves" field in a wizard
+-  'VAT Report' is valid only for cases where it's met that for each Tax
+   defined: all the "Account tags" of all the 'Repartition for Invoices'
+   or 'Repartition for Credit Notes' are different.
+-  It would be nice to have in reports a column indicating the state of
+   the entries when the option "All Entries" is selected in "Target
+   Moves" field in a wizard
 
 Changelog
 =========
@@ -103,22 +103,22 @@ Changelog
 11.0.2.5.0 (2019-04-26)
 -----------------------
 
-- In the Trial Balance you have an option to hide parent hierarchy
-  levels
+-  In the Trial Balance you have an option to hide parent hierarchy
+   levels
 
 11.0.2.4.1 (2019-01-08)
 -----------------------
 
-- Handle better multicompany behaviour
-- Improve how title appears in the reports
-- Improve performance in General Ledger
+-  Handle better multicompany behaviour
+-  Improve how title appears in the reports
+-  Improve performance in General Ledger
 
 11.0.2.3.1 (2018-11-29)
 -----------------------
 
-- In the Trial Balance you can apply a filter by hierarchy levels
-- In the General Ledger you can apply a filter by Analytic Tag
-- In the Journal Ledger the field 'Journal' is now optional
+-  In the Trial Balance you can apply a filter by hierarchy levels
+-  In the General Ledger you can apply a filter by Analytic Tag
+-  In the Journal Ledger the field 'Journal' is now optional
 
 Bug Tracker
 ===========
@@ -144,43 +144,46 @@ Authors
 Contributors
 ------------
 
-- Jordi Ballester <jordi.ballester@forgeflow.com>
-- Yannick Vaucher <yannick.vaucher@camptocamp.com>
-- Simone Orsi <simone.orsi@abstract.com>
-- Leonardo Pistone <leonardo.pistone@camptocamp.com>
-- Damien Crier <damien.crier@camptocamp.com>
-- Andrea Stirpe <a.stirpe@onestein.nl>
-- Thomas Rehn <thomas.rehn@initos.com>
-- Andrea Gallina <4everamd@gmail.com>
-- Robert Rottermann <robert@redcor.ch>
-- Ciro Urselli <c.urselli@apuliasoftware.it>
-- Francesco Apruzzese <opencode@e-ware.org>
-- Lorenzo Battistini <https://github.com/eLBati>
-- Julien Coux <julien.coux@camptocamp.com>
-- Akim Juillerat <akim.juillerat@camptocamp.com>
-- Alexis de Lattre <alexis@via.ecp.fr>
-- Mihai Fekete <feketemihai@gmail.com>
-- Miquel Ra??ch <miquel.raich@forgeflow.com>
-- Joan Sisquella <joan.sisquella@forgeflow.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Jordi Ballester <jordi.ballester@forgeflow.com>
+-  Yannick Vaucher <yannick.vaucher@camptocamp.com>
+-  Simone Orsi <simone.orsi@abstract.com>
+-  Leonardo Pistone <leonardo.pistone@camptocamp.com>
+-  Damien Crier <damien.crier@camptocamp.com>
+-  Andrea Stirpe <a.stirpe@onestein.nl>
+-  Thomas Rehn <thomas.rehn@initos.com>
+-  Andrea Gallina <4everamd@gmail.com>
+-  Robert Rottermann <robert@redcor.ch>
+-  Ciro Urselli <c.urselli@apuliasoftware.it>
+-  Francesco Apruzzese <opencode@e-ware.org>
+-  Lorenzo Battistini <https://github.com/eLBati>
+-  Julien Coux <julien.coux@camptocamp.com>
+-  Akim Juillerat <akim.juillerat@camptocamp.com>
+-  Alexis de Lattre <alexis@via.ecp.fr>
+-  Mihai Fekete <feketemihai@gmail.com>
+-  Miquel Ra??ch <miquel.raich@forgeflow.com>
+-  Joan Sisquella <joan.sisquella@forgeflow.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
-  - Sergio Teruel
-  - Ernesto Tejeda
-  - João Marques
-  - Alexandre D. D??az
-  - V??ctor Mart??nez
-  - Carolina Fernandez
+   -  Pedro M. Baeza
+   -  Sergio Teruel
+   -  Ernesto Tejeda
+   -  João Marques
+   -  Alexandre D. D??az
+   -  V??ctor Mart??nez
+   -  Carolina Fernandez
 
-- `Sygel <https://www.sygel.es>`__:
+-  `Sygel <https://www.sygel.es>`__:
 
-  - Harald Panten
-  - Valentin Vinagre
+   -  Harald Panten
+   -  Valentin Vinagre
 
-- Lois Rilo <lois.rilo@forgeflow.com>
-- Saran Lim. <saranl@ecosoft.co.th>
-- Omar Casti??eira <omar@comunitea.com>
-- Chau Le <chaulb@trobz.com>
+-  Lois Rilo <lois.rilo@forgeflow.com>
+-  Saran Lim. <saranl@ecosoft.co.th>
+-  Omar Casti??eira <omar@comunitea.com>
+-  Chau Le <chaulb@trobz.com>
+-  `Stesi Consulting <https://www.stesi.consulting>`__:
+
+   -  Michele Di Croce <dicroce.m@stesi.consulting>
 
 Much of the work in this module was done at a sprint in Sorrento, Italy
 in April 2016.

--- a/account_financial_report/readme/CONTRIBUTORS.md
+++ b/account_financial_report/readme/CONTRIBUTORS.md
@@ -31,6 +31,8 @@
 - Saran Lim. \<<saranl@ecosoft.co.th>\>
 - Omar Casti??eira \<<omar@comunitea.com>\>
 - Chau Le \<<chaulb@trobz.com>\>
-
+- [Stesi Consulting](https://www.stesi.consulting):
+  - Michele Di Croce \<<dicroce.m@stesi.consulting>\>
+  
 Much of the work in this module was done at a sprint in Sorrento, Italy
 in April 2016.

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -194,7 +194,7 @@ class TrialBalanceReport(models.AbstractModel):
         initial_balances = self.env["account.move.line"].read_group(
             domain=domain,
             fields=["account_id", "balance", "amount_currency:sum"],
-            groupby=["account_id"],
+            groupby=["account_id", "currency_id"],
         )
         pl_initial_balance = 0.0
         pl_initial_currency_balance = 0.0
@@ -432,7 +432,7 @@ class TrialBalanceReport(models.AbstractModel):
             tb_initial_acc.append(
                 {"account_id": account.id, "balance": 0.0, "amount_currency": 0.0}
             )
-        groupby_fields = ["account_id"]
+        groupby_fields = ["account_id", "currency_id"]
         if grouped_by:
             groupby_fields.append("analytic_account_ids")
         initial_domain_bs = self._get_initial_balances_bs_ml_domain(
@@ -515,13 +515,13 @@ class TrialBalanceReport(models.AbstractModel):
             tb_initial_prt_bs = self.env["account.move.line"].read_group(
                 domain=initial_domain_bs,
                 fields=["account_id", "partner_id", "balance", "amount_currency:sum"],
-                groupby=["account_id", "partner_id"],
+                groupby=["account_id", "partner_id", "currency_id"],
                 lazy=False,
             )
             tb_initial_prt_pl = self.env["account.move.line"].read_group(
                 domain=initial_domain_pl,
                 fields=["account_id", "partner_id", "balance", "amount_currency:sum"],
-                groupby=["account_id", "partner_id"],
+                groupby=["account_id", "partner_id", "currency_id"],
             )
             tb_initial_prt = tb_initial_prt_bs + tb_initial_prt_pl
             if hide_account_at_0:
@@ -536,7 +536,7 @@ class TrialBalanceReport(models.AbstractModel):
                     "balance",
                     "amount_currency:sum",
                 ],
-                groupby=["account_id", "partner_id"],
+                groupby=["account_id", "currency_id", "partner_id"],
                 lazy=False,
             )
         total_amount = {}

--- a/account_financial_report/static/description/index.html
+++ b/account_financial_report/static/description/index.html
@@ -527,6 +527,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
 <li>Omar Casti??eira &lt;<a class="reference external" href="mailto:omar&#64;comunitea.com">omar&#64;comunitea.com</a>&gt;</li>
 <li>Chau Le &lt;<a class="reference external" href="mailto:chaulb&#64;trobz.com">chaulb&#64;trobz.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.stesi.consulting">Stesi Consulting</a>:<ul>
+<li>Michele Di Croce &lt;<a class="reference external" href="mailto:dicroce.m&#64;stesi.consulting">dicroce.m&#64;stesi.consulting</a>&gt;</li>
+</ul>
+</li>
 </ul>
 <p>Much of the work in this module was done at a sprint in Sorrento, Italy
 in April 2016.</p>


### PR DESCRIPTION
### After this PR

On Odoo18 if you group:sum by amount_currency, if you don't put currency_id in the group field the amount_currency is removed by read_group function on account addon

Fixes: https://github.com/OCA/account-financial-reporting/issues/1388