### PR TITLE
[17.0] [FIX] account_financial_report: use company currency from company report wizard not from currently active company

### DIFF
--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -146,14 +146,14 @@
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
                 <!--## current-->
             <div class="act_as_cell amount">
                     <span
                     t-esc="partner['current']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <t t-if="not age_partner_config">
@@ -161,35 +161,35 @@
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['30_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_60_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['60_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_90_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['90_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_120_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['120_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## older-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['older']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
             </t>
@@ -197,7 +197,7 @@
                 <div class="act_as_cell amount">
                     <span
                         t-out="partner[column_dynamic]"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
             </t>
@@ -353,7 +353,7 @@
                         >
                             <t
                                 t-out="line['residual']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </div>
@@ -362,7 +362,7 @@
                             <t t-if="line['current'] == 0">
                                 <span
                                 t-esc="line['current']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                             </t>
                             <t t-else="">
@@ -372,7 +372,7 @@
                             >
                                     <t
                                     t-out="line['current']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                                 </span>
                             </t>
@@ -383,7 +383,7 @@
                             <t t-if="line['30_days'] == 0">
                                 <span
                                     t-esc="line['30_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -393,7 +393,7 @@
                                 >
                                     <t
                                         t-out="line['30_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -403,7 +403,7 @@
                             <t t-if="line['60_days'] == 0">
                                 <span
                                     t-esc="line['60_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -413,7 +413,7 @@
                                 >
                                     <t
                                         t-out="line['60_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -423,7 +423,7 @@
                             <t t-if="line['90_days'] == 0">
                                 <span
                                     t-esc="line['90_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -433,7 +433,7 @@
                                 >
                                     <t
                                         t-out="line['90_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -443,7 +443,7 @@
                             <t t-if="line['120_days'] == 0">
                                 <span
                                     t-esc="line['120_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -453,7 +453,7 @@
                                 >
                                     <t
                                         t-out="line['120_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -463,7 +463,7 @@
                             <t t-if="line['older'] == 0">
                                 <span
                                     t-esc="line['older']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -473,7 +473,7 @@
                                 >
                                     <t
                                         t-out="line['older']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -484,7 +484,7 @@
                             <t t-if="line[column_dynamic] == 0">
                                 <span
                                     t-esc="line[column_dynamic]"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -494,7 +494,7 @@
                                 >
                                     <t
                                         t-out="line[column_dynamic]"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -519,14 +519,14 @@
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['residual']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                     <!--## current-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                         t-esc="partner_cumul_line['current']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                     </div>
                 <t t-if="not age_partner_config">
@@ -534,35 +534,35 @@
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['30_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_60_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['60_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_90_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['90_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_120_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['120_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## older-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['older']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                 </t>
@@ -570,7 +570,7 @@
                     <div class="act_as_cell amount">
                         <span
                             t-esc="partner_cumul_line[column_dynamic]"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                 </t>
@@ -588,14 +588,14 @@
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                         <!--## current-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                         </div>
                     <t t-if="not age_partner_config">
@@ -603,35 +603,35 @@
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['30_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_60_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['60_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_90_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['90_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_120_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['120_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## older-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['older']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -639,7 +639,7 @@
                         <div class="act_as_cell amount">
                             <span
                                 t-esc="account[column_dynamic]"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -653,14 +653,14 @@
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                         <!--## current-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                         </div>
                     <t t-if="not age_partner_config">
@@ -668,35 +668,35 @@
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['30_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_60_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['60_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_90_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['90_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_120_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['120_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## older-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['older']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -704,7 +704,7 @@
                         <div class="act_as_cell amount">
                             <span
                                 t-esc="account[column_dynamic]"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -552,7 +552,7 @@
                             >
                                 <t
                                     t-out="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -560,7 +560,7 @@
                             <span>
                                 <t
                                     t-out="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -575,7 +575,7 @@
                             >
                                 <t
                                     t-out="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -583,7 +583,7 @@
                             <span>
                                 <t
                                     t-out="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -598,7 +598,7 @@
                             >
                                 <t
                                     t-out="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -606,7 +606,7 @@
                             <span>
                                 <t
                                     t-out="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -230,14 +230,14 @@
                 <span
                     t-if="line.get('original', False)"
                     t-esc="line['original']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <!--## amount_residual-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="line['amount_residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <t t-if="foreign_currency">
@@ -303,13 +303,13 @@
                     <t t-if='type == "account_type"'>
                         <span
                             t-esc="total_amount[account_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-if='type == "partner_type"'>
                         <span
                             t-esc="total_amount[account_id][partner_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -335,7 +335,7 @@
                         >
                             <t
                                 t-out="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -351,7 +351,7 @@
                         >
                             <t
                                 t-out="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -369,7 +369,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -391,7 +391,7 @@
                         >
                             <t
                                 t-out="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -409,7 +409,7 @@
                         >
                             <t
                                 t-out="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -429,7 +429,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -451,7 +451,7 @@
                         >
                             <t
                                 t-out="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -469,7 +469,7 @@
                         >
                             <t
                                 t-out="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -489,7 +489,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -511,7 +511,7 @@
                         >
                             <t
                                 t-out="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -528,7 +528,7 @@
                         >
                             <t
                                 t-out="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -548,7 +548,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -568,7 +568,7 @@
                         >
                             <t
                                 t-out="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -583,7 +583,7 @@
                         >
                             <t
                                 t-out="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -601,7 +601,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -778,7 +778,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                        <t t-att-style="style" t-out="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                        <t t-att-style="style" t-out="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Debit&ndash;&gt;-->
@@ -793,7 +793,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.debit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.debit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Credit&ndash;&gt;-->
@@ -808,7 +808,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.credit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.credit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Period Balance &ndash;&gt;-->
@@ -823,7 +823,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Ending balance&ndash;&gt;-->
@@ -835,7 +835,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style" >-->
-    <!--                            <t t-att-style="style" t-out="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                <t t-if="foreign_currency">-->
@@ -904,13 +904,13 @@
                     >
                         <span
                             t-out="balance['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -921,13 +921,13 @@
                     >
                         <span
                             t-out="balance['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -938,13 +938,13 @@
                     >
                         <span
                             t-out="balance['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -955,13 +955,13 @@
                     >
                         <span
                             t-out="balance['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -972,13 +972,13 @@
                     >
                         <span
                             t-out="balance['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>

--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -74,14 +74,14 @@
                             <t
                                 t-att-style="style"
                                 t-out="tag_or_group['net']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t
                                 t-att-style="style"
                                 t-out="tag_or_group['tax']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </div>
@@ -115,7 +115,7 @@
                                         <t
                                             t-att-style="style"
                                             t-out="tax['net']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                         />
                                     </span>
                                 </div>
@@ -133,7 +133,7 @@
                                         <t
                                             t-att-style="style"
                                             t-out="tax['tax']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                         />
                                     </span>
                                 </div>


### PR DESCRIPTION
fw-port of https://github.com/OCA/account-financial-reporting/pull/1389