### PR TITLE
[18.0] [FIX] account_financial_report: use company currency from company report wizard not from currently active company

### DIFF
--- a/account_financial_report/report/templates/aged_partner_balance.xml
+++ b/account_financial_report/report/templates/aged_partner_balance.xml
@@ -148,14 +148,14 @@
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <!--## current-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="partner['current']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <t t-if="not age_partner_config">
@@ -163,35 +163,35 @@
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['30_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_60_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['60_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_90_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['90_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## age_120_days-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['120_days']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## older-->
                 <div class="act_as_cell amount">
                     <span
                         t-esc="partner['older']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
             </t>
@@ -199,7 +199,7 @@
                 <div class="act_as_cell amount">
                     <span
                         t-out="partner[column_dynamic]"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
             </t>
@@ -355,7 +355,7 @@
                         >
                             <t
                                 t-out="line['residual']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </div>
@@ -364,7 +364,7 @@
                         <t t-if="line['current'] == 0">
                             <span
                                 t-esc="line['current']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </t>
                         <t t-else="">
@@ -374,7 +374,7 @@
                             >
                                 <t
                                     t-out="line['current']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -385,7 +385,7 @@
                             <t t-if="line['30_days'] == 0">
                                 <span
                                     t-esc="line['30_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -395,7 +395,7 @@
                                 >
                                     <t
                                         t-out="line['30_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -405,7 +405,7 @@
                             <t t-if="line['60_days'] == 0">
                                 <span
                                     t-esc="line['60_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -415,7 +415,7 @@
                                 >
                                     <t
                                         t-out="line['60_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -425,7 +425,7 @@
                             <t t-if="line['90_days'] == 0">
                                 <span
                                     t-esc="line['90_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -435,7 +435,7 @@
                                 >
                                     <t
                                         t-out="line['90_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -445,7 +445,7 @@
                             <t t-if="line['120_days'] == 0">
                                 <span
                                     t-esc="line['120_days']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -455,7 +455,7 @@
                                 >
                                     <t
                                         t-out="line['120_days']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -465,7 +465,7 @@
                             <t t-if="line['older'] == 0">
                                 <span
                                     t-esc="line['older']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -475,7 +475,7 @@
                                 >
                                     <t
                                         t-out="line['older']"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -486,7 +486,7 @@
                             <t t-if="line[column_dynamic] == 0">
                                 <span
                                     t-esc="line[column_dynamic]"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </t>
                             <t t-else="">
@@ -496,7 +496,7 @@
                                 >
                                     <t
                                         t-out="line[column_dynamic]"
-                                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                     />
                                 </span>
                             </t>
@@ -521,14 +521,14 @@
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['residual']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <!--## current-->
                 <div class="act_as_cell amount" style="width: 6.00%;">
                     <span
                         t-esc="partner_cumul_line['current']"
-                        t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                        t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                     />
                 </div>
                 <t t-if="not age_partner_config">
@@ -536,35 +536,35 @@
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['30_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_60_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['60_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_90_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['90_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## age_120_days-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['120_days']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## older-->
                     <div class="act_as_cell amount" style="width: 6.00%;">
                         <span
                             t-esc="partner_cumul_line['older']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                 </t>
@@ -572,7 +572,7 @@
                     <div class="act_as_cell amount">
                         <span
                             t-esc="partner_cumul_line[column_dynamic]"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                 </t>
@@ -590,14 +590,14 @@
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## current-->
                     <div class="act_as_cell amount" style="width: 9.64%;">
                         <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <t t-if="not age_partner_config">
@@ -605,35 +605,35 @@
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['30_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_60_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['60_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_90_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['90_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_120_days-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['120_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## older-->
                         <div class="act_as_cell amount" style="width: 9.64%;">
                             <span
                                 t-esc="account['older']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -641,7 +641,7 @@
                         <div class="act_as_cell amount">
                             <span
                                 t-esc="account[column_dynamic]"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -655,14 +655,14 @@
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <!--## current-->
                     <div class="act_as_cell amount" style="width: 6.00%">
                         <span
                             t-esc="account['current']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </div>
                     <t t-if="not age_partner_config">
@@ -670,35 +670,35 @@
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['30_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_60_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['60_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_90_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['90_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## age_120_days-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['120_days']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <!--## older-->
                         <div class="act_as_cell amount" style="width: 6.00%">
                             <span
                                 t-esc="account['older']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>
@@ -706,7 +706,7 @@
                         <div class="act_as_cell amount">
                             <span
                                 t-esc="account[column_dynamic]"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </t>

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -539,7 +539,7 @@
                             >
                                 <t
                                     t-out="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -547,7 +547,7 @@
                             <span>
                                 <t
                                     t-out="line['debit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -562,7 +562,7 @@
                             >
                                 <t
                                     t-out="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -570,7 +570,7 @@
                             <span>
                                 <t
                                     t-out="line['credit']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -585,7 +585,7 @@
                             >
                                 <t
                                     t-out="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>
@@ -593,7 +593,7 @@
                             <span>
                                 <t
                                     t-out="line['balance']"
-                                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                 />
                             </span>
                         </t>

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -230,14 +230,14 @@
                 <span
                     t-if="line.get('original', False)"
                     t-esc="line['original']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <!--## amount_residual-->
             <div class="act_as_cell amount">
                 <span
                     t-esc="line['amount_residual']"
-                    t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                    t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                 />
             </div>
             <t t-if="foreign_currency">
@@ -303,13 +303,13 @@
                     <t t-if='type == "account_type"'>
                         <span
                             t-esc="total_amount[account_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-if='type == "partner_type"'>
                         <span
                             t-esc="total_amount[account_id][partner_id]['residual']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>

--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -333,7 +333,7 @@
                         >
                             <t
                                 t-out="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -349,7 +349,7 @@
                         >
                             <t
                                 t-out="balance['initial_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -367,7 +367,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -389,7 +389,7 @@
                         >
                             <t
                                 t-out="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -407,7 +407,7 @@
                         >
                             <t
                                 t-out="balance['debit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -427,7 +427,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -449,7 +449,7 @@
                         >
                             <t
                                 t-out="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -467,7 +467,7 @@
                         >
                             <t
                                 t-out="balance['credit']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -487,7 +487,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -509,7 +509,7 @@
                         >
                             <t
                                 t-out="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -526,7 +526,7 @@
                         >
                             <t
                                 t-out="balance['balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -546,7 +546,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -566,7 +566,7 @@
                         >
                             <t
                                 t-out="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -581,7 +581,7 @@
                         >
                             <t
                                 t-out="balance['ending_balance']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </span>
                     </t>
@@ -599,7 +599,7 @@
                     >
                         <t
                             t-out="total_amount[account_id][partner_id]['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </span>
                 </t>
@@ -776,7 +776,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                        <t t-att-style="style" t-out="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                        <t t-att-style="style" t-out="account.initial_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Debit&ndash;&gt;-->
@@ -791,7 +791,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.debit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.debit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Credit&ndash;&gt;-->
@@ -806,7 +806,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.credit" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.credit" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Period Balance &ndash;&gt;-->
@@ -821,7 +821,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style">-->
-    <!--                            <t t-att-style="style" t-out="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.period_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                &lt;!&ndash;## Ending balance&ndash;&gt;-->
@@ -833,7 +833,7 @@
     <!--                           t-att-data-res-model="'account.move.line'"-->
     <!--                           class="o_account_financial_reports_web_action_monetary_multi"-->
     <!--                           t-att-style="style" >-->
-    <!--                            <t t-att-style="style" t-out="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"/></a>-->
+    <!--                            <t t-att-style="style" t-out="account.final_balance" t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"/></a>-->
     <!--                    </span>-->
     <!--                </div>-->
     <!--                <t t-if="foreign_currency">-->
@@ -902,13 +902,13 @@
                     >
                         <span
                             t-out="balance['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['initial_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -919,13 +919,13 @@
                     >
                         <span
                             t-out="balance['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['debit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -936,13 +936,13 @@
                     >
                         <span
                             t-out="balance['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['credit']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -953,13 +953,13 @@
                     >
                         <span
                             t-out="balance['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>
@@ -970,13 +970,13 @@
                     >
                         <span
                             t-out="balance['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                     <t t-else="">
                         <span
                             t-out="total_amount[account_id]['ending_balance']"
-                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                         />
                     </t>
                 </div>

--- a/account_financial_report/report/templates/vat_report.xml
+++ b/account_financial_report/report/templates/vat_report.xml
@@ -74,14 +74,14 @@
                             <t
                                 t-att-style="style"
                                 t-out="tag_or_group['net']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                         <div class="act_as_cell amount" style="width: 15%;">
                             <t
                                 t-att-style="style"
                                 t-out="tag_or_group['tax']"
-                                t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                             />
                         </div>
                     </div>
@@ -115,7 +115,7 @@
                                         <t
                                             t-att-style="style"
                                             t-out="tax['net']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                         />
                                     </span>
                                 </div>
@@ -133,7 +133,7 @@
                                         <t
                                             t-att-style="style"
                                             t-out="tax['tax']"
-                                            t-options="{'widget': 'monetary', 'display_currency': res_company.currency_id}"
+                                            t-options="{'widget': 'monetary', 'display_currency': o.company_id.currency_id}"
                                         />
                                     </span>
                                 </div>


### PR DESCRIPTION
fw-port of https://github.com/OCA/account-financial-reporting/pull/1389