### PR TITLE
[17.0][FIX] account_financial_report: reconcile name in general ledger

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -331,7 +331,7 @@ class GeneralLedgerReport(models.AbstractModel):
             "rec_id": move_line["full_reconcile_id"][0]
             if move_line["full_reconcile_id"]
             else False,
-            "rec_name": move_line["full_reconcile_id"][1]
+            "rec_name": move_line["matching_number"]
             if move_line["full_reconcile_id"]
             else "",
             "currency_id": move_line["currency_id"],
@@ -479,7 +479,7 @@ class GeneralLedgerReport(models.AbstractModel):
                         {
                             rec_id: {
                                 "id": rec_id,
-                                "name": move_line["full_reconcile_id"][1],
+                                "name": move_line["matching_number"],
                             }
                         }
                     )
@@ -913,4 +913,5 @@ class GeneralLedgerReport(models.AbstractModel):
             "balance",
             "tax_ids",
             "move_name",
+            "matching_number",
         ]


### PR DESCRIPTION
Backport from 18.0: https://github.com/OCA/account-financial-reporting/pull/1298

Use matching number in general ledger

**Before**
<img width="1301" height="258" alt="antes" src="https://github.com/user-attachments/assets/fd7347fd-80e9-4b85-9848-8c6d0c31d12c" />

**After**
<img width="1298" height="224" alt="despues" src="https://github.com/user-attachments/assets/fe85e0d9-e257-447f-a7a1-98524f5aa58c" />

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa TT58527