### PR TITLE
[18.0][FIX] partner_statement: Filter by company

### DIFF
--- a/partner_statement/tests/test_outstanding_statement.py
+++ b/partner_statement/tests/test_outstanding_statement.py
@@ -136,6 +136,7 @@ class TestOutstandingStatement(TransactionCase):
             [
                 ("id", "!=", copy_account.id),
                 ("account_type", "=", wizard.account_type),
+                ("company_ids", "in", self.env.company.ids),
             ],
         )
         wizard.excluded_accounts_selector = ", ".join(


### PR DESCRIPTION
if you have 2 localizations installed, the test fails. This happens because the code_store is not filled and then the code is empty.