### PR TITLE
[16.0][BP][FIX] mis_builder_cash_flow: Edit KPI expression and fix posted filter

### DIFF
--- a/mis_builder_cash_flow/data/mis_report.xml
+++ b/mis_builder_cash_flow/data/mis_report.xml
@@ -16,7 +16,7 @@
         <field name="sequence">20</field>
         <field
             name="expression"
-        >bal[][('account_type', '=', 'asset_cash'), ('line_type', '=', 'move_line'), ('account_id.hide_in_cash_flow', '=', False)]</field>
+        >bal[][('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('line_type', '=', 'move_line'), ('account_id.hide_in_cash_flow', '=', False)]</field>
     </record>
     <record id="mis_kpi_in_total" model="mis.report.kpi">
         <field name="report_id" ref="mis_report_cash_flow" />
@@ -101,7 +101,7 @@
         <field name="sequence">150</field>
         <field
             name="expression"
-        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), ('line_type', '=', 'move_line'), '|', ('account_type', '=', 'asset_cash'), ('account_type', 'in', ('asset_receivable', 'liability_payable')), ('full_reconcile_id', '=', False)]</field>
+        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), ('line_type', '=', 'move_line'), '|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('account_type', 'in', ('asset_receivable', 'liability_payable')), ('full_reconcile_id', '=', False)]</field>
         <field
             name="style_expression"
         >'Cash Flow - Good' if balance >= 0.0 else 'Cash Flow - Bad'</field>

--- a/mis_builder_cash_flow/migrations/16.0.1.0.0/noupdate_changes.xml
+++ b/mis_builder_cash_flow/migrations/16.0.1.0.0/noupdate_changes.xml
@@ -3,12 +3,12 @@
   <record id="mis_kpi_aliquidity" model="mis.report.kpi">
     <field
             name="expression"
-        >bal[][('account_type', '=', 'asset_cash'), ('line_type', '=', 'move_line'), ('account_id.hide_in_cash_flow', '=', False)]</field>
+        >bal[][('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('line_type', '=', 'move_line'), ('account_id.hide_in_cash_flow', '=', False)]</field>
   </record>
   <record id="mis_kpi_balance" model="mis.report.kpi">
     <field
             name="expression"
-        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), ('line_type', '=', 'move_line'), '|', ('account_type', '=', 'asset_cash'), ('account_type', 'in', ('asset_receivable', 'liability_payable')), ('full_reconcile_id', '=', False)]</field>
+        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), ('line_type', '=', 'move_line'), '|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('account_type', 'in', ('asset_receivable', 'liability_payable')), ('full_reconcile_id', '=', False)]</field>
   </record>
   <record id="mis_kpi_in_receivable" model="mis.report.kpi">
     <field

--- a/mis_builder_cash_flow/report/mis_cash_flow.py
+++ b/mis_builder_cash_flow/report/mis_cash_flow.py
@@ -48,7 +48,7 @@ class MisCashFlow(models.Model):
         "account.full.reconcile", string="Matching Number", readonly=True, index=True
     )
     account_type = fields.Selection(related="account_id.account_type", readonly=True)
-    state = fields.Selection(selection="_selection_parent_state")
+    parent_state = fields.Selection(selection="_selection_parent_state")
 
     def _selection_parent_state(self):
         return self.env["account.move"].fields_get(allfields=["state"])["state"][
@@ -79,7 +79,7 @@ class MisCashFlow(models.Model):
                 aml.partner_id as partner_id,
                 aml.company_id as company_id,
                 aml.name as name,
-                aml.parent_state as state,
+                aml.parent_state as parent_state,
                 COALESCE(aml.date_maturity, aml.date) as date
             FROM account_move_line as aml
             WHERE aml.parent_state != 'cancel'
@@ -104,7 +104,7 @@ class MisCashFlow(models.Model):
                 fl.partner_id as partner_id,
                 fl.company_id as company_id,
                 fl.name as name,
-                'posted' as state,
+                'posted' as parent_state,
                 fl.date as date
             FROM mis_cash_flow_forecast_line as fl
         """


### PR DESCRIPTION
Change the state field to parent_state of the mis.cash_flow model to compute correctly posted filter added by the mis_builder module. In migration to 16, KPI expressions were modified to adapt the account_internal_type field to account_type. However, in this process, in liquidity and balance KPIs, the liability_credit_card type was forgotten. This account_type in v15 had account_internal_type equal to liquidity.

BackPort of https://github.com/OCA/account-financial-reporting/pull/1403