### PR TITLE
[18.0][FIX] account_financial_report: display results considering archived accounts and journals

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -123,7 +123,11 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         return move_lines
 
     def _get_accounts_data(self, accounts_ids):
-        accounts = self.env["account.account"].browse(accounts_ids)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .browse(accounts_ids)
+        )
         accounts_data = {}
         for account in accounts:
             accounts_data.update(
@@ -143,8 +147,10 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         return accounts_data
 
     def _get_journals_data(self, journals_ids):
-        journals = self.env["account.journal"].search_fetch(
-            [("id", "in", journals_ids)], ["code"]
+        journals = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .search_fetch([("id", "in", journals_ids)], ["code"])
         )
         journals_data = {}
         for journal in journals:

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -27,8 +27,12 @@ class GeneralLedgerReport(models.AbstractModel):
         return analytic_data
 
     def _get_taxes_data(self, taxes_ids):
-        taxes = self.env["account.tax"].search_fetch(
-            [("id", "in", taxes_ids)], ["amount", "amount_type", "display_name"]
+        taxes = (
+            self.env["account.tax"]
+            .with_context(active_test=False)
+            .search_fetch(
+                [("id", "in", taxes_ids)], ["amount", "amount_type", "display_name"]
+            )
         )
         taxes_data = {}
         for tax in taxes:
@@ -131,7 +135,11 @@ class GeneralLedgerReport(models.AbstractModel):
         domain = []
         domain += base_domain
         domain += [("date", "<", fy_start_date)]
-        accounts = self.env["account.account"].search(accounts_domain)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .search(accounts_domain)
+        )
         domain += [("account_id", "in", accounts.ids)]
         return domain
 
@@ -432,8 +440,10 @@ class GeneralLedgerReport(models.AbstractModel):
                 res.append({"id": item_id, "name": item_name})
             elif move_line["tax_ids"]:
                 for tax_id in move_line["tax_ids"]:
-                    tax_item = self.env["account.tax"].search_fetch(
-                        [("id", "=", tax_id)], ["name"]
+                    tax_item = (
+                        self.env["account.tax"]
+                        .with_context(active_test=False)
+                        .search_fetch([("id", "=", tax_id)], ["name"])
                     )
                     res.append({"id": tax_item.id, "name": tax_item.name})
             else:

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -34,9 +34,13 @@ class JournalLedgerReport(models.AbstractModel):
         return domain
 
     def _get_journal_ledgers(self, wizard, journal_ids, company):
-        journals = self.env["account.journal"].search(
-            self._get_journal_ledgers_domain(wizard, journal_ids, company),
-            order="name asc",
+        journals = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .search(
+                self._get_journal_ledgers_domain(wizard, journal_ids, company),
+                order="name asc",
+            )
         )
         journal_ledgers_data = []
         for journal in journals:
@@ -264,8 +268,10 @@ class JournalLedgerReport(models.AbstractModel):
                 journal_id = ml_data["journal_id"]
                 if journal_id not in journals_taxes_data.keys():
                     journals_taxes_data[journal_id] = {}
-                taxes = self.env["account.tax"].search_fetch(
-                    [("id", "in", tax_ids)], ["name", "description"]
+                taxes = (
+                    self.env["account.tax"]
+                    .with_context(active_test=False)
+                    .search_fetch([("id", "in", tax_ids)], ["name", "description"])
                 )
                 for tax in taxes:
                     if tax.id not in journals_taxes_data[journal_id]:

--- a/account_financial_report/report/journal_ledger_xlsx.py
+++ b/account_financial_report/report/journal_ledger_xlsx.py
@@ -178,7 +178,11 @@ class JournalLedgerXslx(models.AbstractModel):
     def _generate_journal_content(
         self, workbook, report, res_data, ledger, report_data
     ):
-        journal = self.env["account.journal"].browse(ledger["id"])
+        journal = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .browse(ledger["id"])
+        )
         currency_name = (
             journal.currency_id
             and journal.currency_id.name
@@ -196,7 +200,11 @@ class JournalLedgerXslx(models.AbstractModel):
         )
 
     def _generate_journal_taxes_summary(self, workbook, ledger, report_data):
-        journal = self.env["account.journal"].browse(ledger["id"])
+        journal = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .browse(ledger["id"])
+        )
         currency_name = (
             journal.currency_id
             and journal.currency_id.name

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -31,7 +31,11 @@ class TrialBalanceReport(models.AbstractModel):
         if account_ids:
             accounts_domain += [("id", "in", account_ids)]
         domain = [("date", "<", date_from)]
-        accounts = self.env["account.account"].search(accounts_domain)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .search(accounts_domain)
+        )
         domain += [("account_id", "in", accounts.ids)]
         if company_id:
             domain += [("company_id", "=", company_id)]
@@ -71,7 +75,11 @@ class TrialBalanceReport(models.AbstractModel):
         if account_ids:
             accounts_domain += [("id", "in", account_ids)]
         domain = [("date", "<", date_from), ("date", ">=", fy_start_date)]
-        accounts = self.env["account.account"].search(accounts_domain)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .search(accounts_domain)
+        )
         domain += [("account_id", "in", accounts.ids)]
         if company_id:
             domain += [("company_id", "=", company_id)]
@@ -149,7 +157,11 @@ class TrialBalanceReport(models.AbstractModel):
         if account_ids:
             accounts_domain += [("id", "in", account_ids)]
         domain = [("date", "<", fy_start_date)]
-        accounts = self.env["account.account"].search(accounts_domain)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .search(accounts_domain)
+        )
         domain += [("account_id", "in", accounts.ids)]
         if company_id:
             domain += [("company_id", "=", company_id)]
@@ -426,7 +438,11 @@ class TrialBalanceReport(models.AbstractModel):
             # If explicit list of accounts is provided,
             # don't include unaffected earnings account
             unaffected_earnings_account = False
-        accounts = self.env["account.account"].search(accounts_domain)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .search(accounts_domain)
+        )
         tb_initial_acc = []
         for account in accounts:
             tb_initial_acc.append(
@@ -746,7 +762,11 @@ class TrialBalanceReport(models.AbstractModel):
 
     def _get_groups_data(self, accounts_data, total_amount, foreign_currency):
         accounts_ids = list(accounts_data.keys())
-        accounts = self.env["account.account"].browse(accounts_ids)
+        accounts = (
+            self.env["account.account"]
+            .with_context(active_test=False)
+            .browse(accounts_ids)
+        )
         account_group_relation = {}
         for account in accounts:
             accounts_data[account.id]["complete_code"] = (

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -13,7 +13,7 @@ class VATReport(models.AbstractModel):
     _description = "Vat Report Report"
 
     def _get_tax_data(self, tax_ids):
-        taxes = self.env["account.tax"].browse(tax_ids)
+        taxes = self.env["account.tax"].with_context(active_test=False).browse(tax_ids)
         tax_data = {}
         for tax in taxes:
             tax_data.update(

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -99,8 +99,10 @@ class JournalLedgerReportWizard(models.TransientModel):
         journals = self.journal_ids
         if not journals:
             # Not selecting a journal means that we'll display all journals
-            journals = self.env["account.journal"].search(
-                [("company_id", "=", self.company_id.id)]
+            journals = (
+                self.env["account.journal"]
+                .with_context(active_test=False)
+                .search([("company_id", "=", self.company_id.id)])
             )
         return {
             "wizard_id": self.id,


### PR DESCRIPTION
Archiving a journal or an account should not result in not being able to displaying the financial results related with them. For example, consider a sales journal that you don't want to use going forward. You will still want to see financial activity related with that journal for past periods.