### PR TITLE
[18.0][FIX] account_financial_report: Ability to filter by code

### DIFF
--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -715,3 +715,36 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         ]
         self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
         self.assertTrue(trial_balance_code_set == all_accounts_code_set)
+
+    def test_06_all_accounts_loaded_newid(self):
+        all_accounts = (
+            self.env["account.account"]
+            .search([], order="code")
+            .filtered(lambda acc: re.fullmatch(r"[0-9]+(\.[0-9]+)?", acc.code))
+        )
+        company = self.env.user.company_id
+        trial_balance = self.env["trial.balance.report.wizard"].new(
+            {
+                "date_from": self.date_start,
+                "date_to": self.date_end,
+                "target_move": "posted",
+                "hide_account_at_0": False,
+                "show_hierarchy": False,
+                "company_id": company.id,
+                "fy_start_date": self.fy_date_start,
+                "account_code_from": self.account001.id,
+                "account_code_to": all_accounts[-1].id,
+            }
+        )
+        trial_balance.on_change_account_range()
+        # sets are needed because some codes are duplicated and
+        # thus the length of all_accounts would be higher
+        all_accounts_code_set = set()
+        trial_balance_code_set = set()
+        [all_accounts_code_set.add(account.code) for account in all_accounts]
+        [
+            trial_balance_code_set.add(account.code)
+            for account in trial_balance.account_ids
+        ]
+        self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
+        self.assertTrue(trial_balance_code_set == all_accounts_code_set)

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -91,10 +91,18 @@ class TrialBalanceReportWizard(models.TransientModel):
             self.account_ids = self.env["account.account"].search(
                 [("code", ">=", start_range), ("code", "<=", end_range)]
             )
-            if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
-                )
+            if isinstance(self.account_ids[0].id, models.NewId):
+                real_ids = self.account_ids.ids
+                account_ids = self.env["account.account"].browse(real_ids)
+                if self.company_id:
+                    self.account_ids = account_ids.filtered(
+                        lambda a: self.company_id in a.company_ids
+                    )
+            else:
+                if self.company_id:
+                    self.account_ids = self.account_ids.filtered(
+                        lambda a: self.company_id in a.company_ids
+                    )
 
     @api.constrains("show_hierarchy", "show_hierarchy_level")
     def _check_show_hierarchy_level(self):


### PR DESCRIPTION
- The way accounts are collected has been modified, as they were returning ‘NewId’, which meant that filtering was not possible at any point. I check whether the first position is already a ‘NewId’ and, if so, I browse the IDs so that ‘self.account_ids’ is filled in correctly and filtered correctly.

- The example that it is not filtering is taken from a runboat. As you can see in the screenshots, it does not filter and shows all accounts.

<img width="1299" height="876" alt="image" src="https://github.com/user-attachments/assets/f8aa4829-582d-4e31-936b-77aacbfd1e36" />
<img width="2556" height="1316" alt="image" src="https://github.com/user-attachments/assets/d78feabe-2a1d-480a-9d43-d2be62ae0054" />

- Here is an example of how it should look once the filter is working correctly. As you can see in the screenshot, after applying the filter, you can see which accounts will be displayed.

<img width="1010" height="1061" alt="image" src="https://github.com/user-attachments/assets/27e37895-ce7c-4090-a18d-7f4e29b719e1" />

