### PR TITLE
[18.0][FIX] account_financial_report: Don't fail on inactive journal

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -143,8 +143,10 @@ class AgedPartnerBalanceReport(models.AbstractModel):
         return accounts_data
 
     def _get_journals_data(self, journals_ids):
-        journals = self.env["account.journal"].search_fetch(
-            [("id", "in", journals_ids)], ["code"]
+        journals = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .search_fetch([("id", "in", journals_ids)], ["code"])
         )
         journals_data = {}
         for journal in journals:


### PR DESCRIPTION
Steps to reproduce:

- Archive a journal that contains journal entries.
- Print a general ledger including at least one of those journal entries.
- You get a KeyError:

  ```
  File ".../addons/account_financial_report/models/ir_actions_report.py", line 27, in _render_xlsx
        return super(IrActionsReport, obj)._render_xlsx(report_ref, docids, data=data)
  File ".../addons/report_xlsx_helper/models/ir_actions_report.py", line 19, in _render_xlsx
    return super()._render_xlsx(report_ref, docids, data)
  File ".../addons/report_xlsx/models/ir_report.py", line 27, in _render_xlsx
    .create_xlsx_report(docids, data)  # noqa
  File ".../addons/report_xlsx/report/report_abstract_xlsx.py", line 105, in create_xlsx_report
    self.generate_xlsx_report(workbook, data, objs)
  File ".../addons/account_financial_report/report/abstract_report_xlsx.py", line 40, in generate_xlsx_report
    self._generate_report_content(workbook, objects, data, report_data)
  File ".../addons/account_financial_report/report/general_ledger_xlsx.py", line 287, in _generate_report_content
    "journal": journals_data[line["journal_id"]]["code"],
  KeyError: 93
  ```

That's because the code of the journals are fetched with a search without active_test=False context, so archived journals are not taken into account, and when later trying to get the information, failing.

The solution is to pass the context for getting all the journals, including archived ones.

TT59739