### PR TITLE
[18.0][FIX] account_financial_report: journal ledger move_line_ids_taxes_data

### DIFF
--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -178,7 +178,7 @@ class JournalLedgerReport(models.AbstractModel):
             SELECT aml_at_rel.account_move_line_id, aml_at_rel.account_tax_id,
             at.description, at.name
             FROM account_move_line_account_tax_rel AS aml_at_rel
-            LEFT JOIN
+            INNER JOIN
                 account_tax AS at on (at.id = aml_at_rel.account_tax_id)
             WHERE account_move_line_id IN %(move_line_ids)s
         """
@@ -207,6 +207,7 @@ class JournalLedgerReport(models.AbstractModel):
         )
         move_line_ids_taxes_data = {}
         if move_lines:
+            lang = self.env.context.get("lang", "en_US")
             # Get the taxes ids for the move lines
             query_taxes_params = self._get_query_taxes_params(move_lines)
             query_taxes = self._get_query_taxes()
@@ -221,8 +222,12 @@ class JournalLedgerReport(models.AbstractModel):
                 if move_line_id not in move_line_ids_taxes_data.keys():
                     move_line_ids_taxes_data[move_line_id] = {}
                 move_line_ids_taxes_data[move_line_id][account_tax_id] = {
-                    "name": tax_name,
-                    "description": tax_description,
+                    "name": tax_name.get(lang) or tax_name.get("en_US"),
+                    "description": (
+                        tax_description.get(lang) or tax_description.get("en_US")
+                        if tax_description
+                        else False
+                    ),
                 }
         Move_Lines = {}
         auto_sequence = len(move_ids)
@@ -331,6 +336,7 @@ class JournalLedgerReport(models.AbstractModel):
             partner_ids_data = move_lines[3]
             currency_ids_data = move_lines[4]
             tax_line_ids_data = move_lines[5]
+            move_line_ids_taxes_data = move_lines[6]
         for move_data in moves_data:
             move_id = move_data["move_id"]
             move_data["report_move_lines"] = []

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -203,6 +203,7 @@ class JournalLedgerReport(models.AbstractModel):
         )
         move_line_ids_taxes_data = {}
         if move_lines:
+            lang = self.env.context.get("lang", "en_US")
             # Get the taxes ids for the move lines
             query_taxes_params = self._get_query_taxes_params(move_lines)
             query_taxes = self._get_query_taxes()
@@ -217,8 +218,12 @@ class JournalLedgerReport(models.AbstractModel):
                 if move_line_id not in move_line_ids_taxes_data.keys():
                     move_line_ids_taxes_data[move_line_id] = {}
                 move_line_ids_taxes_data[move_line_id][account_tax_id] = {
-                    "name": tax_name,
-                    "description": tax_description,
+                    "name": tax_name.get(lang) or tax_name.get("en_US"),
+                    "description": (
+                        tax_description.get(lang) or tax_description.get("en_US")
+                        if tax_description
+                        else False
+                    ),
                 }
         Move_Lines = {}
         auto_sequence = len(move_ids)
@@ -325,6 +330,7 @@ class JournalLedgerReport(models.AbstractModel):
             partner_ids_data = move_lines[3]
             currency_ids_data = move_lines[4]
             tax_line_ids_data = move_lines[5]
+            move_line_ids_taxes_data = move_lines[6]
         for move_data in moves_data:
             move_id = move_data["move_id"]
             move_data["report_move_lines"] = []

--- a/account_financial_report/tests/test_journal_ledger.py
+++ b/account_financial_report/tests/test_journal_ledger.py
@@ -280,3 +280,13 @@ class TestJournalReport(AccountTestInvoicingCommon):
 
         self.check_report_journal_debit_credit(res_data, 250, 250)
         self.check_report_journal_debit_credit_taxes(res_data, 300, 0, 50, 0)
+
+        move_line_ids_taxes_data = res_data["move_line_ids_taxes_data"]
+        self.assertEqual(len(invoice.invoice_line_ids), 2)
+        for ml in invoice.invoice_line_ids:
+            taxes_description = wiz._get_ml_tax_description(
+                {"tax_line_id": False},
+                False,
+                move_line_ids_taxes_data.get(ml.id),
+            )
+            self.assertTrue(taxes_description)


### PR DESCRIPTION
In the journal ledger report, only move lines with `tax_line_id` had their taxes displayed.
The case where taxes come from `move_line_ids_taxes_data` seems to have been forgotten.

We solve two problems.
First, `move_line_ids_taxes_data` was never propagated, thus always empty.
Second, tax name and description get from sql queries are json values. We now handle translations.