### PR TITLE
[18.0][FIX] partner_statement: Fixed multiple XLSX generation

### DIFF
--- a/partner_statement/report/activity_statement_xlsx.py
+++ b/partner_statement/report/activity_statement_xlsx.py
@@ -324,7 +324,11 @@ class ActivityStatementXslx(models.AbstractModel):
             sheet.set_column(0, i, 20)
 
     def generate_xlsx_report(self, workbook, data, objects):
-        lang = objects.lang or self.env.user.partner_id.lang
+        lang = (
+            objects.lang
+            if len(objects) == 1 and objects.lang
+            else self.env.user.partner_id.lang
+        )
         self = self.with_context(lang=lang)
         report_model = self.env["report.partner_statement.activity_statement"]
         self._define_formats(workbook)

--- a/partner_statement/report/detailed_activity_statement_xlsx.py
+++ b/partner_statement/report/detailed_activity_statement_xlsx.py
@@ -470,7 +470,11 @@ class DetailedActivityStatementXslx(models.AbstractModel):
             sheet.set_column(0, i, 20)
 
     def generate_xlsx_report(self, workbook, data, objects):
-        lang = objects.lang or self.env.user.partner_id.lang
+        lang = (
+            objects.lang
+            if len(objects) == 1 and objects.lang
+            else self.env.user.partner_id.lang
+        )
         self = self.with_context(lang=lang)
         report_model = self.env["report.partner_statement.detailed_activity_statement"]
         self._define_formats(workbook)

--- a/partner_statement/report/outstanding_statement_xlsx.py
+++ b/partner_statement/report/outstanding_statement_xlsx.py
@@ -242,7 +242,11 @@ class OutstandingStatementXslx(models.AbstractModel):
             sheet.set_column(0, i, 20)
 
     def generate_xlsx_report(self, workbook, data, objects):
-        lang = objects.lang or self.env.user.partner_id.lang
+        lang = (
+            objects.lang
+            if len(objects) == 1 and objects.lang
+            else self.env.user.partner_id.lang
+        )
         self = self.with_context(lang=lang)
         report_model = self.env["report.partner_statement.outstanding_statement"]
         self._define_formats(workbook)


### PR DESCRIPTION
Issue: XLSX export fails when multiple customers or vendors are selected for the Partner Statement.

Fixed: 
- Multiple customers/vendors: XLSX will use the current logged-in user’s language during export.

Regenerate steps: 
Step 1: Go to Invoicing > Customers(select two or more customers from the list view) 
Step 2: Click on Actions > Partner Activity Statement > Export XLSX. The traceback can be found there.

Note: These steps also apply to Vendors. The same traceback occurs when clicking the Partner Detailed/Outstanding Statement reports.
