### PR TITLE
[17.0][FIX] mis_template_financial_report: make compatible with mis_builder updates

### DIFF
--- a/mis_template_financial_report/models/mis_report_instance.py
+++ b/mis_template_financial_report/models/mis_report_instance.py
@@ -24,11 +24,11 @@ class MisReportInstance(models.Model):
         if not self.horizontal:
             return super().compute()
 
+        result = super().compute()
         full_matrix = self._compute_matrix()
 
         matrices = self._split_matrix(full_matrix)
 
-        result = full_matrix.as_dict()
         result["split_matrices"] = [extra_matrix.as_dict() for extra_matrix in matrices]
 
         return result


### PR DESCRIPTION
Fixes
TypeError: can't access property "2##1#", ctx.notes is undefined

since https://github.com/OCA/mis-builder/commit/a08dfa72af1986ac4fc7eec2c8ac92f0ed78627c we can't get away with breaking inheritance