### PR TITLE
[17.0][FIX] partner_statement: avoid KeyError for 'active_ids'

### DIFF
--- a/partner_statement/wizard/statement_common.py
+++ b/partner_statement/wizard/statement_common.py
@@ -24,7 +24,7 @@ class StatementCommon(models.AbstractModel):
         help="Show only lines due before the selected date",
     )
     number_partner_ids = fields.Integer(
-        default=lambda self: len(self._context["active_ids"])
+        default=lambda self: len(self._context.get("active_ids", []))
     )
     filter_partners_non_due = fields.Boolean(
         string="Don't show partners with no due entries", default=True


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-financial-reporting/pull/1427.