### PR TITLE
[17.0][FIX] account_tax_balance: invalid isoformat date in test

### DIFF
--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -107,7 +107,7 @@ class TestAccountTaxBalance(HttpCase):
                 (
                     "date_start",
                     "=",
-                    f"{self.current_year}-{self.current_month}-01",
+                    f"{self.current_year}-{self.current_month:02d}-01",
                 )
             ]
         )


### PR DESCRIPTION
<img width="1134" height="164" alt="Selection_5323" src="https://github.com/user-attachments/assets/cbb6f6a8-3cd1-44a4-8725-ca1839f935ef" />
