### PR TITLE
[18.0][FIX] account_tax_balance: invalid isoformat date in test

### DIFF
--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -107,7 +107,7 @@ class TestAccountTaxBalance(HttpCase):
                 (
                     "date_start",
                     "=",
-                    f"{self.current_year}-{self.current_month}-01",
+                    f"{self.current_year}-{self.current_month:02d}-01",
                 )
             ]
         )


### PR DESCRIPTION
Forward port of https://github.com/OCA/account-financial-reporting/pull/1430.