### PR TITLE
[16.0][IMP] add field account_internal_group to account_financial_report

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -473,7 +473,12 @@ class TrialBalanceReport(models.AbstractModel):
         tb_initial_acc = []
         for account in accounts:
             tb_initial_acc.append(
-                {"account_id": account.id, "balance": 0.0, "amount_currency": 0.0}
+                {
+                    "account_id": account.id,
+                    "balance": 0.0,
+                    "amount_currency": 0.0,
+                    "account_internal_group": account.internal_group,
+                }
             )
         groupby_fields = ["account_id"]
         if grouped_by:


### PR DESCRIPTION
Porting of https://github.com/OCA/account-financial-reporting/pull/1251

Add field `account_internal_group` to initial balance data to filter out expense/revenue account on initial balance value for Italian account financial report.