### PR TITLE
[18.0][FIX] account_financial_report: account selection by interval when handling NewId records

### DIFF
--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -54,17 +54,14 @@ class AgedPartnerBalanceWizard(models.TransientModel):
         ):
             start_range = int(self.account_code_from.code)
             end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [
-                    ("code", ">=", start_range),
-                    ("code", "<=", end_range),
-                    ("reconcile", "=", True),
-                ]
-            )
+            domain = [
+                ("code", ">=", start_range),
+                ("code", "<=", end_range),
+                ("reconcile", "=", True),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
-                )
+                domain.append(("company_ids", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
         return {
             "domain": {
                 "account_code_from": [("reconcile", "=", True)],

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -74,17 +74,14 @@ class OpenItemsReportWizard(models.TransientModel):
         ):
             start_range = int(self.account_code_from.code)
             end_range = int(self.account_code_to.code)
-            self.account_ids = self.env["account.account"].search(
-                [
-                    ("code", ">=", start_range),
-                    ("code", "<=", end_range),
-                    ("reconcile", "=", True),
-                ]
-            )
+            domain = [
+                ("code", ">=", start_range),
+                ("code", "<=", end_range),
+                ("reconcile", "=", True),
+            ]
             if self.company_id:
-                self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
-                )
+                domain.append(("company_ids", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
         return {
             "domain": {
                 "account_code_from": [("reconcile", "=", True)],

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -88,21 +88,10 @@ class TrialBalanceReportWizard(models.TransientModel):
         ):
             start_range = self.account_code_from.code
             end_range = self.account_code_to.code
-            self.account_ids = self.env["account.account"].search(
-                [("code", ">=", start_range), ("code", "<=", end_range)]
-            )
-            if isinstance(self.account_ids[0].id, models.NewId):
-                real_ids = self.account_ids.ids
-                account_ids = self.env["account.account"].browse(real_ids)
-                if self.company_id:
-                    self.account_ids = account_ids.filtered(
-                        lambda a: self.company_id in a.company_ids
-                    )
-            else:
-                if self.company_id:
-                    self.account_ids = self.account_ids.filtered(
-                        lambda a: self.company_id in a.company_ids
-                    )
+            domain = [("code", ">=", start_range), ("code", "<=", end_range)]
+            if self.company_id:
+                domain.append(("company_ids", "=", self.company_id.id))
+            self.account_ids = self.env["account.account"].search(domain)
 
     @api.constrains("show_hierarchy", "show_hierarchy_level")
     def _check_show_hierarchy_level(self):


### PR DESCRIPTION
Fixing some unfixed `on_change_account_range` methods following the same approach as the ones done in https://github.com/OCA/account-financial-reporting/pull/1416 and https://github.com/OCA/account-financial-reporting/pull/1293 

Useful explanation from the comments 

> Q: it is not clear to me why we no longer have to handle the NewId case here. Could you enlighten me?
> 
> A: Because this is an onchange method on an unsaved Transient Model record. Odoo wraps the assigned records with NewId objects. By calling the filtered on those records of NewId type, it fails.
And now we are only calling the search method once with the adapted domain, improving overall performances also.