### PR TITLE
[IMP] account_financial_report: Open Items reports, display residual currency in ending balance lines for account when all journal items have the same currency

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -122,12 +122,13 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 move_line["amount_currency"] = 0
         return move_lines
 
-    def _get_accounts_data(self, accounts_ids):
+    def _get_accounts_data(self, accounts_ids, company_id):
         accounts = (
             self.env["account.account"]
             .with_context(active_test=False)
             .browse(accounts_ids)
         )
+        company = self.env["res.company"].browse(company_id)
         accounts_data = {}
         for account in accounts:
             accounts_data.update(
@@ -140,6 +141,12 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                         "group_id": account.group_id.id,
                         "currency_id": account.currency_id.id,
                         "currency_name": account.currency_id.name,
+                        "foreign_currency_id": (
+                            account.currency_id.id
+                            if account.currency_id
+                            and account.currency_id != company.currency_id
+                            else False
+                        ),
                         "centralized": account.centralized,
                     }
                 }

--- a/account_financial_report/report/abstract_report_xlsx.py
+++ b/account_financial_report/report/abstract_report_xlsx.py
@@ -497,7 +497,7 @@ class AbstractReportXslx(models.AbstractModel):
                     )
                 elif cell_type == "amount_currency":
                     if my_object["currency_id"]:
-                        format_amt = self._get_currency_amt_format_dict(
+                        format_amt = self._get_currency_amt_header_format_dict(
                             my_object, report_data
                         )
                         report_data["sheet"].write_number(

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -248,7 +248,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 date_at_object,
             )
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(ag_pb_data.keys())
+        accounts_data = self._get_accounts_data(ag_pb_data.keys(), company_id)
         return ag_pb_data, accounts_data, partners_data, journals_data
 
     @api.model

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -552,7 +552,7 @@ class GeneralLedgerReport(models.AbstractModel):
                     "amount_currency"
                 ]
         journals_data = self._get_journals_data(list(journal_ids))
-        accounts_data = self._get_accounts_data(gen_ld_data.keys())
+        accounts_data = self._get_accounts_data(gen_ld_data.keys(), company_id)
         taxes_data = self._get_taxes_data(list(taxes_ids))
         analytic_data = self._get_analytic_data(list(analytic_ids))
         rec_after_date_to_ids = self._get_reconciled_after_date_to_ids(

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -179,7 +179,9 @@ class OpenItemsReport(models.AbstractModel):
                 else:
                     open_items_move_lines_data[acc_id][group_id].append(move_line)
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(open_items_move_lines_data.keys())
+        accounts_data = self._get_accounts_data(
+            open_items_move_lines_data.keys(), company_id
+        )
         return (
             move_lines,
             partners_data,
@@ -189,19 +191,48 @@ class OpenItemsReport(models.AbstractModel):
         )
 
     @api.model
-    def _calculate_amounts(self, open_items_move_lines_data):
+    def _calculate_amounts(self, open_items_move_lines_data, company_id):
         total_amount = {}
+        company = self.env["res.company"].browse(company_id)
         for account_id in open_items_move_lines_data.keys():
             total_amount[account_id] = {}
             total_amount[account_id]["residual"] = 0.0
+            total_amount[account_id]["residual_currency"] = 0.0
             for partner_id in open_items_move_lines_data[account_id].keys():
                 total_amount[account_id][partner_id] = {}
                 total_amount[account_id][partner_id]["residual"] = 0.0
-                for move_line in open_items_move_lines_data[account_id][partner_id]:
+                total_amount[account_id][partner_id]["residual_currency"] = 0.0
+                move_lines_by_partner = open_items_move_lines_data[account_id][
+                    partner_id
+                ]
+                move_currency_id = (
+                    move_lines_by_partner
+                    and move_lines_by_partner[0]["currency_id"]
+                    or False
+                )
+                move_lines_have_same_currency = all(
+                    element["currency_id"] == move_lines_by_partner[0]["currency_id"]
+                    for element in move_lines_by_partner
+                )
+                foreign_currency_id = (
+                    move_currency_id
+                    if move_currency_id
+                    and move_lines_have_same_currency
+                    and move_currency_id != company.currency_id.id
+                    else False
+                )
+                for move_line in move_lines_by_partner:
                     total_amount[account_id][partner_id]["residual"] += move_line[
                         "amount_residual"
                     ]
+                    total_amount[account_id][partner_id]["residual_currency"] += (
+                        move_line["amount_residual_currency"]
+                    )
                     total_amount[account_id]["residual"] += move_line["amount_residual"]
+                total_amount[account_id][partner_id]["foreign_currency_id"] = (
+                    foreign_currency_id
+                )
+
         return total_amount
 
     @api.model
@@ -271,7 +302,7 @@ class OpenItemsReport(models.AbstractModel):
             grouped_by,
         )
 
-        total_amount = self._calculate_amounts(open_items_move_lines_data)
+        total_amount = self._calculate_amounts(open_items_move_lines_data, company_id)
         open_items_move_lines_data = self._order_open_items_by_date(
             open_items_move_lines_data,
             show_partner_details,

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -229,6 +229,9 @@ class OpenItemsReport(models.AbstractModel):
                         move_line["amount_residual_currency"]
                     )
                     total_amount[account_id]["residual"] += move_line["amount_residual"]
+                    total_amount[account_id]["residual_currency"] += move_line[
+                        "amount_residual_currency"
+                    ]
                 total_amount[account_id][partner_id]["foreign_currency_id"] = (
                     foreign_currency_id
                 )

--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -62,7 +62,7 @@ class OpenItemsXslx(models.AbstractModel):
                 11: {
                     "header": _("Cur. Residual"),
                     "field": "amount_residual_currency",
-                    "field_final_balance": "amount_currency",
+                    "field_final_balance": "residual_currency",
                     "type": "amount_currency",
                     "width": 14,
                 },
@@ -269,6 +269,9 @@ class OpenItemsXslx(models.AbstractModel):
                                 ],
                             }
                         )
+                        foreign_currency_id = total_amount[account_id][partner_id][
+                            "foreign_currency_id"
+                        ]
                         self.write_ending_balance_from_dict(
                             partners_data[partner_id],
                             type_object,
@@ -276,6 +279,7 @@ class OpenItemsXslx(models.AbstractModel):
                             report_data,
                             account_id=account_id,
                             partner_id=partner_id,
+                            foreign_currency_id=foreign_currency_id,
                         )
 
                         # Line break
@@ -302,6 +306,7 @@ class OpenItemsXslx(models.AbstractModel):
                         total_amount,
                         report_data,
                         account_id=account_id,
+                        foreign_currency_id=foreign_currency_id,
                     )
 
                     # 2 lines break
@@ -330,15 +335,24 @@ class OpenItemsXslx(models.AbstractModel):
         report_data,
         account_id=False,
         partner_id=False,
+        foreign_currency_id=False,
     ):
         """Specific function to write ending balance for Open Items"""
         if type_object == "partner":
             name = my_object["name"]
             my_object["residual"] = total_amount[account_id][partner_id]["residual"]
+            if foreign_currency_id:
+                my_object["residual_currency"] = total_amount[account_id][partner_id][
+                    "residual_currency"
+                ]
             label = _("Partner ending balance")
         elif type_object == "account":
             name = my_object["code"] + " - " + my_object["name"]
             my_object["residual"] = total_amount[account_id]["residual"]
+            if foreign_currency_id:
+                my_object["residual_currency"] = total_amount[account_id][
+                    "residual_currency"
+                ]
             label = _("Ending balance")
         elif type_object == "partner_subtotal":
             name = my_object["name"]

--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -357,6 +357,10 @@ class OpenItemsXslx(models.AbstractModel):
         elif type_object == "partner_subtotal":
             name = my_object["name"]
             my_object["residual"] = total_amount[account_id][partner_id]["residual"]
+            if foreign_currency_id:
+                my_object["residual_currency"] = total_amount[account_id][partner_id][
+                    "residual_currency"
+                ]
             label = _("Ending balance")
         return super().write_ending_balance_from_dict(
             my_object, name, label, report_data

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -121,6 +121,10 @@
                                     t-set="currency_id"
                                     t-value="accounts_data[account_id]['currency_name']"
                                 />
+                                <t
+                                    t-set="foreign_currency_id"
+                                    t-value="total_amount[account_id][partner_id]['foreign_currency_id']"
+                                />
                                 <t t-set="type" t-value='"partner_type"' />
                             </t>
                         </t>
@@ -202,6 +206,10 @@
                         <t
                             t-set="currency_id"
                             t-value="accounts_data[account_id]['currency_name']"
+                        />
+                        <t
+                            t-set="foreign_currency_id"
+                            t-value="accounts_data[account_id]['foreign_currency_id']"
                         />
                         <t t-set="type" t-value='"account_type"' />
                     </t>
@@ -446,7 +454,17 @@
                     <!--## amount_total_due_currency-->
                     <div class="act_as_cell" />
                     <!--## amount_residual_currency-->
-                    <div class="act_as_cell" />
+                    <div class="act_as_cell amount" style="width: 6.57%;">
+                        <t t-if='type == "partner_type" and foreign_currency_id'>
+                            <span
+                                t-esc="total_amount[account_id][partner_id]['residual_currency']"
+                                t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(foreign_currency_id)}"
+                            />
+                        </t>
+                        <t t-else="">
+                            <div class="act_as_cell" />
+                        </t>
+                    </div>
                 </t>
             </div>
         </div>

--- a/account_financial_report/report/templates/open_items.xml
+++ b/account_financial_report/report/templates/open_items.xml
@@ -102,6 +102,10 @@
                                                 t-value="accounts_data[account_id]['currency_name']"
                                             />
                                             <t
+                                                t-set="foreign_currency_id"
+                                                t-value="accounts_data[account_id]['foreign_currency_id']"
+                                            />
+                                            <t
                                                 t-set="type"
                                                 t-value="'partner_subtotal_type'"
                                             />
@@ -191,6 +195,10 @@
                                     <t
                                         t-set="currency_id"
                                         t-value="accounts_data[account_id]['currency_name']"
+                                    />
+                                    <t
+                                        t-set="foreign_currency_id"
+                                        t-value="total_amount[account_id][partner_id]['foreign_currency_id']"
                                     />
                                     <t t-set="type" t-value='"partner_type"' />
                                 </t>
@@ -455,14 +463,23 @@
                     <div class="act_as_cell" />
                     <!--## amount_residual_currency-->
                     <div class="act_as_cell amount" style="width: 6.57%;">
+                        <t t-if='type == "account_type" and foreign_currency_id'>
+                            <span
+                                t-esc="total_amount[account_id]['residual_currency']"
+                                t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(foreign_currency_id)}"
+                            />
+                        </t>
                         <t t-if='type == "partner_type" and foreign_currency_id'>
                             <span
                                 t-esc="total_amount[account_id][partner_id]['residual_currency']"
                                 t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(foreign_currency_id)}"
                             />
                         </t>
-                        <t t-else="">
-                            <div class="act_as_cell" />
+                        <t t-if='type == "partner_subtotal_type"'>
+                            <span
+                                t-esc="partner_totals[account_id][partner_id_key]['residual_currency']"
+                                t-options="{'widget': 'monetary', 'display_currency': env['res.currency'].browse(foreign_currency_id)}"
+                            />
                         </t>
                     </div>
                 </t>

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -597,7 +597,7 @@ class TrialBalanceReport(models.AbstractModel):
                     total_amount[unaffected_id], foreign_currency
                 )
                 total_amount[unaffected_id]["group_by_data"][0] = group_by_data_item
-        accounts_data = self._get_accounts_data(accounts_ids)
+        accounts_data = self._get_accounts_data(accounts_ids, company_id)
         (
             pl_initial_balance,
             pl_initial_currency_balance,

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -145,9 +145,14 @@ class OpenItemsReportWizard(models.TransientModel):
             if account_id not in total_amount:
                 total_amount[account_id] = {}
             if partner_id_key not in total_amount[account_id]:
-                total_amount[account_id][partner_id_key] = {"residual": 0.0}
+                total_amount[account_id][partner_id_key] = {}
+                total_amount[account_id][partner_id_key]["residual"] = 0.0
+                total_amount[account_id][partner_id_key]["residual_currency"] = 0.0
             total_amount[account_id][partner_id_key]["residual"] += line[
                 "amount_residual"
+            ]
+            total_amount[account_id][partner_id_key]["residual_currency"] += line[
+                "amount_residual_currency"
             ]
         return total_amount
 


### PR DESCRIPTION
### Description & Purpose

The primary goal of this pull request is to improve the Open Items report within the `account_financial_report` module.

Specifically, it addresses the display of currencies in the "ending balance" lines of the report. Previously, these lines might not consistently show the secondary (residual) currency. This PR introduces logic to:

* identify if all journal items (lines) for a specific account use the same foreign currency.
* if they do, the report will now display the residual currency amount in the ending balance lines for that account.
* this provides better clarity for multi-currency reconciliation and auditing directly from the Open Items view.

Check the screenshot below to see how it looks:
<img width="2221" height="761" alt="image" src="https://github.com/user-attachments/assets/690675dc-a209-4123-a9de-ea6047d708cd" />