### PR TITLE
[16.0][FIX] account_financial_report: Archived journals in journal ledger

### DIFF
--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -34,9 +34,13 @@ class JournalLedgerReport(models.AbstractModel):
         return domain
 
     def _get_journal_ledgers(self, wizard, journal_ids, company):
-        journals = self.env["account.journal"].search(
-            self._get_journal_ledgers_domain(wizard, journal_ids, company),
-            order="name asc",
+        journals = (
+            self.env["account.journal"]
+            .with_context(active_test=False)
+            .search(
+                self._get_journal_ledgers_domain(wizard, journal_ids, company),
+                order="name asc",
+            )
         )
         journal_ledgers_data = []
         for journal in journals:

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -94,8 +94,10 @@ class JournalLedgerReportWizard(models.TransientModel):
         journals = self.journal_ids
         if not journals:
             # Not selecting a journal means that we'll display all journals
-            journals = self.env["account.journal"].search(
-                [("company_id", "=", self.company_id.id)]
+            journals = (
+                self.env["account.journal"]
+                .with_context(active_test=False)
+                .search([("company_id", "=", self.company_id.id)])
             )
         res.update(
             {


### PR DESCRIPTION
Forward-port of #1443 

If there are archived journals containing entries, and the journal ledger is issued without selecting any journal (which means, all the journals), it will be generated without taking into account that entries.

This commit makes the journal search where found with the context to take into account archived journals.

It's a pity that there's no global context in the abstract report that can be used for this for preventing similar errors, but the current architecture doesn't allow it, so let's go for the local patch.

Similar to #1417 and #1439.

TT60917