### PR TITLE
[14.0][IMP] mis_builder_cash_flow: Multi company

### DIFF
--- a/mis_builder_cash_flow/README.rst
+++ b/mis_builder_cash_flow/README.rst
@@ -85,6 +85,9 @@ Contributors
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/mis_builder_cash_flow/readme/CONTRIBUTORS.rst
+++ b/mis_builder_cash_flow/readme/CONTRIBUTORS.rst
@@ -4,3 +4,6 @@
 * `Tecnativa <https://www.tecnativa.com>`_:
 
   * Pedro M. Baeza
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/mis_builder_cash_flow/security/mis_cash_flow_security.xml
+++ b/mis_builder_cash_flow/security/mis_cash_flow_security.xml
@@ -20,4 +20,17 @@
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
     </record>
+    <data noupdate="1">
+        <record id="mis_cash_flow_forecast_line_company_rule" model="ir.rule">
+            <field name="name">MIS Cash Flow Forecast Line multi company rule</field>
+            <field name="model_id" ref="model_mis_cash_flow_forecast_line" />
+            <field name="domain_force">
+                [
+                    '|',
+                        ('company_id', '=', False),
+                        ('company_id', 'in', company_ids),
+                ]
+            </field>
+        </record>
+    </data>
 </odoo>

--- a/mis_builder_cash_flow/static/description/index.html
+++ b/mis_builder_cash_flow/static/description/index.html
@@ -434,6 +434,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro M. Baeza</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mis_builder_cash_flow/tests/test_cash_flow.py
+++ b/mis_builder_cash_flow/tests/test_cash_flow.py
@@ -8,6 +8,8 @@ from odoo.fields import Date
 from odoo.tests.common import TransactionCase, tagged
 from odoo.tools import mute_logger
 
+from odoo.addons.mail.tests.common import mail_new_test_user
+
 
 @tagged("post_install", "-at_install")
 class TestCashFlow(TransactionCase):
@@ -155,3 +157,29 @@ class TestCashFlow(TransactionCase):
                         break
                 if not found:
                     self.assertEqual(cell.val, 0)
+
+    def test_multi_company(self):
+        """Forecast lines can only be accessed within their company."""
+        # Arrange
+        company = self.company
+        company_line = self.env["mis.cash_flow.forecast_line"].create(
+            {
+                "account_id": self.account.id,
+                "date": Date.to_date("2020-01-01"),
+                "balance": 1000,
+                "company_id": company.id,
+            }
+        )
+        other_company_user = mail_new_test_user(
+            self.env,
+            login="test user from another company",
+        )
+        # pre-condition
+        self.assertNotEqual(company, other_company_user.company_id)
+
+        # Assert
+        self.assertFalse(
+            self.env["mis.cash_flow.forecast_line"]
+            .with_user(other_company_user)
+            .search([("id", "=", company_line.id)])
+        )


### PR DESCRIPTION
Add multi company security rules to forecast lines.

I have used the XMLID of the same rule that has been created in `18.0` during the migration: https://github.com/OCA/account-financial-reporting/blob/cc76e3adb1488ea967eb9db6dbd420d371b848dd/mis_builder_cash_flow/security/mis_cash_flow_security.xml#L34-L44.