### PR TITLE
[16.0][IMP] mis_builder_cash_flow: Add multi-company security rules

### DIFF
--- a/mis_builder_cash_flow/security/mis_cash_flow_security.xml
+++ b/mis_builder_cash_flow/security/mis_cash_flow_security.xml
@@ -20,4 +20,26 @@
         <field name="perm_write" eval="1" />
         <field name="perm_unlink" eval="1" />
     </record>
+    <record model="ir.rule" id="mis_cash_flow_company_rule">
+        <field name="name">mis.cash_flow:Company</field>
+        <field name="model_id" ref="model_mis_cash_flow" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]</field>
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
+    <record model="ir.rule" id="mis_cash_flow_forecast_line_company_rule">
+        <field name="name">mis.cash_flow.forecast_line:Company</field>
+        <field name="model_id" ref="model_mis_cash_flow_forecast_line" />
+        <field
+            name="domain_force"
+        >['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]</field>
+        <field name="perm_read" eval="1" />
+        <field name="perm_create" eval="1" />
+        <field name="perm_write" eval="1" />
+        <field name="perm_unlink" eval="1" />
+    </record>
 </odoo>


### PR DESCRIPTION
## Summary

Backport multi-company `ir.rule` records for `mis.cash_flow` and `mis.cash_flow.forecast_line` models from the 18.0 migration.

Without these rules, in multi-company environments cash flow data from all companies is visible to all users.

### Rules added:
- `mis_cash_flow_company_rule` — restricts `mis.cash_flow` by company
- `mis_cash_flow_forecast_line_company_rule` — restricts `mis.cash_flow.forecast_line` by company

Domain: `['|',('company_id','=',False),('company_id', 'parent_of', company_ids)]`

## References

- 18.0 source: https://github.com/OCA/account-financial-reporting/blob/18.0/mis_builder_cash_flow/security/mis_cash_flow_security.xml#L34-L44
- Equivalent PR for 14.0: #1451