### PR TITLE
[19.0][FIX] account_financial_report: fix TypeError on account range …

### DIFF
--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -731,3 +731,55 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_05_onchange_account_range_no_typeerror(self):
+        company_id = self.env.user.company_id.id
+        acc_from = self.env["account.account"].create(
+            {
+                "code": "TEST43000",
+                "name": "Test From",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        acc_to = self.env["account.account"].create(
+            {
+                "code": "TEST43005",
+                "name": "Test To",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        acc_out = self.env["account.account"].create(
+            {
+                "code": "TEST44000",
+                "name": "Test Out",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        wizard = (
+            self.env["general.ledger.report.wizard"]
+            .with_context(company_id=company_id)
+            .create(
+                {
+                    "company_id": company_id,
+                    "account_code_from": acc_from.id,
+                    "account_code_to": acc_to.id,
+                }
+            )
+        )
+        wizard.on_change_account_range()
+        self.assertIn(
+            acc_from,
+            wizard.account_ids,
+            "The starting account should be in the filter.",
+        )
+        self.assertIn(
+            acc_to, wizard.account_ids, "The ending account should be in the filter."
+        )
+        self.assertNotIn(
+            acc_out,
+            wizard.account_ids,
+            "Accounts out of the range should NOT be in the filter.",
+        )

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -7,7 +7,7 @@ import time
 from datetime import date
 
 from odoo import api, fields
-from odoo.tests import tagged
+from odoo.tests import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
@@ -731,3 +731,49 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_05_onchange_account_range_no_typeerror(self):
+        company_id = self.env.user.company_id.id
+        acc_from = self.env["account.account"].create(
+            {
+                "code": "TEST43000",
+                "name": "Test From",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        acc_to = self.env["account.account"].create(
+            {
+                "code": "TEST43005",
+                "name": "Test To",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        acc_out = self.env["account.account"].create(
+            {
+                "code": "TEST44000",
+                "name": "Test Out",
+                "account_type": "asset_receivable",
+                "company_ids": [(6, 0, [company_id])],
+            }
+        )
+        wizard_form = Form(
+            self.env["general.ledger.report.wizard"].with_context(company_id=company_id)
+        )
+        wizard_form.account_code_from = acc_from
+        wizard_form.account_code_to = acc_to
+        wizard = wizard_form.save()
+        self.assertIn(
+            acc_from,
+            wizard.account_ids,
+            "The starting account should be in the filter.",
+        )
+        self.assertIn(
+            acc_to, wizard.account_ids, "The ending account should be in the filter."
+        )
+        self.assertNotIn(
+            acc_out,
+            wizard.account_ids,
+            "Accounts out of the range should NOT be in the filter.",
+        )

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -98,16 +98,19 @@ class GeneralLedgerReportWizard(models.TransientModel):
     def on_change_account_range(self):
         if (
             self.account_code_from
-            and self.account_code_from.code.isdigit()
+            and self.account_code_from.code
             and self.account_code_to
-            and self.account_code_to.code.isdigit()
+            and self.account_code_to.code
         ):
-            start_range = int(self.account_code_from.code)
-            end_range = int(self.account_code_to.code)
-            domain = [("code", ">=", start_range), ("code", "<=", end_range)]
+            start_range = str(self.account_code_from.code)
+            end_range = str(self.account_code_to.code)
+            domain = [
+                ("code_store", ">=", start_range),
+                ("code_store", "<=", end_range),
+            ]
             if self.company_id:
                 domain.append(("company_ids", "in", self.company_id.ids))
-            self.account_ids = self.env["account.account"].search(domain)
+            self.account_ids = [(6, 0, self.env["account.account"].search(domain).ids)]
 
     def _init_date_from(self):
         """set start date to begin of current year if fiscal year running"""


### PR DESCRIPTION
When attempting to filter by an account range (e.g., from "430" to "430") in the financial report wizards (such as General Ledger or Trial Balance), Odoo 19 raises a TypeError during the onchange event:
TypeError: '<=' not supported between instances of 'str' and 'int'

To Reproduce
Steps to reproduce the behavior:

1 - Go to Accounting > Reporting > General Ledger.

2 - In the wizard, try to set a range in the "From Account" and "To Account" fields.

3 - The system throws a Traceback triggered by the onchange method.

In Runbot
<img width="1167" height="723" alt="image" src="https://github.com/user-attachments/assets/9731235a-9fcd-4be1-a448-aa38fa87746f" />

<img width="1913" height="1010" alt="image" src="https://github.com/user-attachments/assets/463880cc-26d1-4a1c-8a3a-ea00392040fa" />
