### PR TITLE
[14.0][FIX] partner_statement: make deterministic test_show_only_overdue

### DIFF
--- a/partner_statement/tests/test_outstanding_statement.py
+++ b/partner_statement/tests/test_outstanding_statement.py
@@ -1,8 +1,8 @@
 # Copyright 2018 ForgeFlow, S.L. (https://www.forgeflow.com)
 # Copyright 2025 Simone Rubino - PyTech
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
 from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
 
 from odoo import fields
 from odoo.tests.common import Form, TransactionCase
@@ -163,6 +163,7 @@ class TestOutstandingStatement(TransactionCase):
         other_partner_data = report["data"].get(other_partner.id)
         self.assertFalse(other_partner_data)
 
+    @freeze_time("2026-01-01 08:00")
     def test_show_only_overdue(self):
         """If "Show Only Overdue" is enabled,
         only overdue lines are shown.


### PR DESCRIPTION
The payment term lines applies a date maturity of 30 days by default, but February has only 28 days. Let's freeze dates.

Backport of https://github.com/OCA/account-financial-reporting/pull/1456.