### PR TITLE
[17.0][FIX] account_financial_report: Don't crash trial balance with partner details

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -374,13 +374,16 @@ class TrialBalanceReport(models.AbstractModel):
                 total_amount, tb, acc_id, prt_id, foreign_currency
             )
         # sort on partner_name
+        # total_amount is a dictionary by account id that contains direct totalized
+        # values for that account (credit, debit, balance...), but also other integer
+        # keys that represents partner ids with the detail of each of them, and one
+        # of the partner id keys is 0 for those with no partner
         for acc_id, total_data in total_amount.items():
             tmp_list = sorted(
                 total_data.items(),
-                key=lambda x: isinstance(x[0], int)
-                and isinstance(x[1], dict)
-                and x[1]["partner_name"]
-                or x[0],
+                key=lambda x: ("\xff" if not x[0] else x[1]["partner_name"])
+                if isinstance(x[0], int)
+                else "!",  # ~ is the last ASCII printable char, and ! the first
             )
             total_amount[acc_id] = {}
             for key, value in tmp_list:


### PR DESCRIPTION
Forward-port of #1420

When using the trial balance clicking on "Show partner details", you get the following crash:

```
  File ".../account_financial_report/models/ir_actions_report.py", line 19, in _render_qweb_html
    return super(IrActionsReport, obj)._render_qweb_html(
  File ".../odoo/addons/base/models/ir_actions_report.py", line 984, in _render_qweb_html
    data = self._get_rendering_context(report, docids, data)
  File ".../odoo/addons/base/models/ir_actions_report.py", line 999, in _get_rendering_context
    data.update(report_model._get_report_values(docids, data=data))
  File ".../account_financial_report/report/trial_balance.py", line 884, in _get_report_values
    total_amount, accounts_data, partners_data = self._get_data(
  File ".../account_financial_report/report/trial_balance.py", line 550, in _get_data
    total_amount, partners_data = self._compute_partner_amount(
  File ".../account_financial_report/report/trial_balance.py", line 368, in _compute_partner_amount
    tmp_list = sorted(
TypeError: '<' not supported between instances of 'int' and 'str'
```

That's because the dictionary containing data (total_amount) contains subdictionaries by account id, that mix both subdetails by partner with direct totalized data.

On the sorted call, there's a condition for using other sorting key trying to prevent this problem, but it was not enough, as the fallback key is an integer (account id), not a string like the others.

Thus, let's bring a string sorting key for not having this crash. The key thas has been selected is "!", being the first printable ASCII char.

On the same mood, those details without partner, have as partner name "Missing partner" (or its translation), so they are sorted in the middle of the list due to this. Using for these cases "\xff" as sorting key, being the last printable Unicode char, ensures they are put at the end of the list of each account.

@Tecnativa TT59770