### PR TITLE
[16.0][FIX] account_financial_report: Set int(partner_id) or False in the trial_balance report

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -360,7 +360,7 @@
                     <t
                         t-set="domain"
                         t-value="[('account_id', '=', int(account_id)),
-                                 ('partner_id', '=', int(partner_id)),
+                                 ('partner_id', '=', int(partner_id) or False),
                                  ('date', '&lt;', date_from)]"
                     />
                     <span
@@ -418,7 +418,7 @@
                     <t
                         t-set="domain"
                         t-value="[('account_id', '=', int(account_id)),
-                                 ('partner_id', '=', int(partner_id)),
+                                 ('partner_id', '=', int(partner_id) or False),
                                  ('date', '&gt;=', date_from),
                                  ('date', '&lt;=', date_to),
                                  ('debit', '&lt;&gt;', 0)]"
@@ -478,7 +478,7 @@
                     <t
                         t-set="domain"
                         t-value="[('account_id', '=', int(account_id)),
-                                 ('partner_id', '=', int(partner_id)),
+                                 ('partner_id', '=', int(partner_id) or False),
                                  ('date', '&gt;=', date_from),
                                  ('date', '&lt;=', date_to),
                                  ('credit', '&lt;&gt;', 0)]"
@@ -537,7 +537,7 @@
                     <t
                         t-set="domain"
                         t-value="[('account_id', '=', int(account_id)),
-                                 ('partner_id', '=', int(partner_id)),
+                                 ('partner_id', '=', int(partner_id) or False),
                                  ('date', '&gt;=', date_from),
                                  ('date', '&lt;=', date_to),
                                  ('balance', '&lt;&gt;', 0)]"
@@ -592,7 +592,7 @@
                     <t
                         t-set="domain"
                         t-value="[('account_id', '=', int(account_id)),
-                                 ('partner_id', '=', int(partner_id)),
+                                 ('partner_id', '=', int(partner_id) or False),
                                  ('date', '&lt;=', date_to)]"
                     />
                     <span


### PR DESCRIPTION
In cases where report lines display **Missing Partner**, it is not possible to identify the corresponding entries because `partner_id` is converted to 0 when it is False (`int(partner_id)`)
We have updated the logic in the trial_balance report to use `int(partner_id) or False`

@pedrobaeza can you review this PR?

@Tecnativa
