### PR TITLE
[18.0][FIX] partner_statement: fix account_type comparison in report titles

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -20,7 +20,7 @@ class ActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("is_detailed"):
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Detailed Statement "
                     "between %(starting_date)s and %(ending_date)s "
@@ -35,7 +35,7 @@ class ActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         else:
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Statement between "
                     "%(starting_date)s and %(ending_date)s "

--- a/partner_statement/report/detailed_activity_statement.py
+++ b/partner_statement/report/detailed_activity_statement.py
@@ -18,7 +18,7 @@ class DetailedActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("line_type") == "prior_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Prior Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )
@@ -28,7 +28,7 @@ class DetailedActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         elif kwargs.get("line_type") == "ending_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Ending Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )

--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -16,7 +16,7 @@ class OutstandingStatement(models.AbstractModel):
         kwargs["context"] = {
             "lang": partner.lang,
         }
-        if kwargs.get("account_type") == "receivable":
+        if kwargs.get("account_type") == "asset_receivable":
             title = _("Statement up to %(ending_date)s in %(currency)s", **kwargs)
         else:
             title = _(


### PR DESCRIPTION
## Description

The `_get_title` methods in `outstanding_statement.py`, `activity_statement.py`, and `detailed_activity_statement.py` compare `account_type` against `"receivable"`, but the wizard (`statement_common.py`) sends `"asset_receivable"` via a Selection field.

This mismatch causes all partner statements to always display the **supplier** title variant, regardless of the selected account type.

### Changes

- Updated 5 comparisons across 3 files from `"receivable"` to `"asset_receivable"`
  - `outstanding_statement.py` (line 19)
  - `activity_statement.py` (lines 23, 38)
  - `detailed_activity_statement.py` (lines 21, 31)

Fixes https://github.com/OCA/account-financial-reporting/issues/1465