### PR TITLE
[17.0][FIX] partner_statement: fix account_type comparison in report titles

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -20,7 +20,7 @@ class ActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("is_detailed"):
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Detailed Statement "
                     "between %(starting_date)s and %(ending_date)s "
@@ -35,7 +35,7 @@ class ActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         else:
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Statement between "
                     "%(starting_date)s and %(ending_date)s "

--- a/partner_statement/report/detailed_activity_statement.py
+++ b/partner_statement/report/detailed_activity_statement.py
@@ -18,7 +18,7 @@ class DetailedActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("line_type") == "prior_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Prior Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )
@@ -28,7 +28,7 @@ class DetailedActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         elif kwargs.get("line_type") == "ending_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = _(
                     "Ending Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )

--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -16,7 +16,7 @@ class OutstandingStatement(models.AbstractModel):
         kwargs["context"] = {
             "lang": partner.lang,
         }
-        if kwargs.get("account_type") == "receivable":
+        if kwargs.get("account_type") == "asset_receivable":
             title = _("Statement up to %(ending_date)s in %(currency)s", **kwargs)
         else:
             title = _(


### PR DESCRIPTION
The wizard sends "asset_receivable" but _get_title methods compared against the old "receivable" value, causing all statements to always show the supplier title variant.

Fixes https://github.com/OCA/account-financial-reporting/issues/1465

(backport of https://github.com/OCA/account-financial-reporting/pull/1470)