### PR TITLE
[19.0][FIX] partner_statement: fix account_type comparison in report titles

### DIFF
--- a/partner_statement/report/activity_statement.py
+++ b/partner_statement/report/activity_statement.py
@@ -20,7 +20,7 @@ class ActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("is_detailed"):
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = self.env._(
                     "Detailed Statement "
                     "between %(starting_date)s and %(ending_date)s "
@@ -35,7 +35,7 @@ class ActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         else:
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = self.env._(
                     "Statement between "
                     "%(starting_date)s and %(ending_date)s "

--- a/partner_statement/report/detailed_activity_statement.py
+++ b/partner_statement/report/detailed_activity_statement.py
@@ -18,7 +18,7 @@ class DetailedActivityStatement(models.AbstractModel):
             "lang": partner.lang,
         }
         if kwargs.get("line_type") == "prior_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = self.env._(
                     "Prior Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )
@@ -28,7 +28,7 @@ class DetailedActivityStatement(models.AbstractModel):
                     **kwargs,
                 )
         elif kwargs.get("line_type") == "ending_lines":
-            if kwargs.get("account_type") == "receivable":
+            if kwargs.get("account_type") == "asset_receivable":
                 title = self.env._(
                     "Ending Balance up to %(ending_date)s in %(currency)s", **kwargs
                 )

--- a/partner_statement/report/outstanding_statement.py
+++ b/partner_statement/report/outstanding_statement.py
@@ -16,7 +16,7 @@ class OutstandingStatement(models.AbstractModel):
         kwargs["context"] = {
             "lang": partner.lang,
         }
-        if kwargs.get("account_type") == "receivable":
+        if kwargs.get("account_type") == "asset_receivable":
             title = self.env._(
                 "Statement up to %(ending_date)s in %(currency)s", **kwargs
             )

--- a/partner_statement/tests/common.py
+++ b/partner_statement/tests/common.py
@@ -60,7 +60,7 @@ class PartnerStatementXlsxCommon(TransactionCase):
         self.data = {
             "company_id": self.company.id,
             "partner_ids": [self.partner.id],
-            "account_type": "receivable",
+            "account_type": "asset_receivable",
             "excluded_accounts_ids": [],
             "show_only_overdue": False,
             "aging_type": "normal",

--- a/partner_statement/tests/test_activity_statement.py
+++ b/partner_statement/tests/test_activity_statement.py
@@ -166,7 +166,7 @@ class TestActivityStatement(TransactionCase):
             ending_date="2024-01-31",
             currency="USD",
             is_detailed=True,
-            account_type="receivable",
+            account_type="asset_receivable",
         )
 
         self.assertEqual(
@@ -183,7 +183,7 @@ class TestActivityStatement(TransactionCase):
             ending_date="2024-02-28",
             currency="EUR",
             is_detailed=False,
-            account_type="payable",
+            account_type="liability_payable",
         )
 
         self.assertEqual(

--- a/partner_statement/tests/test_detailed_activity_statement.py
+++ b/partner_statement/tests/test_detailed_activity_statement.py
@@ -37,7 +37,7 @@ class TestDetailedActivityStatement(TransactionCase):
             ending_date="2024-03-31",
             currency="USD",
             line_type="prior_lines",
-            account_type="receivable",
+            account_type="asset_receivable",
         )
 
         self.assertEqual(
@@ -53,7 +53,7 @@ class TestDetailedActivityStatement(TransactionCase):
             ending_date="2024-04-30",
             currency="EUR",
             line_type="ending_lines",
-            account_type="payable",
+            account_type="liability_payable",
         )
 
         self.assertEqual(

--- a/partner_statement/tests/test_report_statement_common.py
+++ b/partner_statement/tests/test_report_statement_common.py
@@ -165,7 +165,7 @@ class TestReportStatementCommon(TransactionCase):
                 "partner_ids": [self.partner1.id, self.partner2.id],
                 "date_start": self.date_start.strftime("%Y-%m-%d"),
                 "date_end": self.date_end.strftime("%Y-%m-%d"),
-                "account_type": "receivable",
+                "account_type": "asset_receivable",
                 "excluded_accounts_ids": [],
                 "show_only_overdue": False,
                 "aging_type": "days",


### PR DESCRIPTION
The wizard sends "asset_receivable" but _get_title methods compared against the old "receivable" value, causing all statements to always show the supplier title variant.

Fixes https://github.com/OCA/account-financial-reporting/issues/1465

(forward port of https://github.com/OCA/account-financial-reporting/pull/1470)