### PR TITLE
[18.0][FIX] account_financial_report: set company context for multi-company account code resolution

### DIFF
--- a/account_financial_report/report/abstract_report.py
+++ b/account_financial_report/report/abstract_report.py
@@ -122,12 +122,11 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 move_line["amount_currency"] = 0
         return move_lines
 
-    def _get_accounts_data(self, accounts_ids):
-        accounts = (
-            self.env["account.account"]
-            .with_context(active_test=False)
-            .browse(accounts_ids)
-        )
+    def _get_accounts_data(self, accounts_ids, company_id=False):
+        AccountAccount = self.env["account.account"].with_context(active_test=False)
+        if company_id:
+            AccountAccount = AccountAccount.with_company(company_id)
+        accounts = AccountAccount.browse(accounts_ids)
         accounts_data = {}
         for account in accounts:
             accounts_data.update(

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -248,7 +248,7 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 date_at_object,
             )
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(ag_pb_data.keys())
+        accounts_data = self._get_accounts_data(ag_pb_data.keys(), company_id=company_id)
         return ag_pb_data, accounts_data, partners_data, journals_data
 
     @api.model

--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -248,7 +248,9 @@ class AgedPartnerBalanceReport(models.AbstractModel):
                 date_at_object,
             )
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(ag_pb_data.keys(), company_id=company_id)
+        accounts_data = self._get_accounts_data(
+            ag_pb_data.keys(), company_id=company_id
+        )
         return ag_pb_data, accounts_data, partners_data, journals_data
 
     @api.model

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -552,7 +552,9 @@ class GeneralLedgerReport(models.AbstractModel):
                     "amount_currency"
                 ]
         journals_data = self._get_journals_data(list(journal_ids))
-        accounts_data = self._get_accounts_data(gen_ld_data.keys(), company_id=company_id)
+        accounts_data = self._get_accounts_data(
+            gen_ld_data.keys(), company_id=company_id
+        )
         taxes_data = self._get_taxes_data(list(taxes_ids))
         analytic_data = self._get_analytic_data(list(analytic_ids))
         rec_after_date_to_ids = self._get_reconciled_after_date_to_ids(

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -552,7 +552,7 @@ class GeneralLedgerReport(models.AbstractModel):
                     "amount_currency"
                 ]
         journals_data = self._get_journals_data(list(journal_ids))
-        accounts_data = self._get_accounts_data(gen_ld_data.keys())
+        accounts_data = self._get_accounts_data(gen_ld_data.keys(), company_id=company_id)
         taxes_data = self._get_taxes_data(list(taxes_ids))
         analytic_data = self._get_analytic_data(list(analytic_ids))
         rec_after_date_to_ids = self._get_reconciled_after_date_to_ids(

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -142,7 +142,7 @@ class JournalLedgerReport(models.AbstractModel):
     def _get_account_id_data(self, account):
         return {
             "name": account.name,
-            "code": account.code,
+            "code": account.code or "",
             "account_type": account.account_type,
         }
 

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -179,7 +179,9 @@ class OpenItemsReport(models.AbstractModel):
                 else:
                     open_items_move_lines_data[acc_id][group_id].append(move_line)
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(open_items_move_lines_data.keys(), company_id=company_id)
+        accounts_data = self._get_accounts_data(
+            open_items_move_lines_data.keys(), company_id=company_id
+        )
         return (
             move_lines,
             partners_data,

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -179,7 +179,7 @@ class OpenItemsReport(models.AbstractModel):
                 else:
                     open_items_move_lines_data[acc_id][group_id].append(move_line)
         journals_data = self._get_journals_data(list(journals_ids))
-        accounts_data = self._get_accounts_data(open_items_move_lines_data.keys())
+        accounts_data = self._get_accounts_data(open_items_move_lines_data.keys(), company_id=company_id)
         return (
             move_lines,
             partners_data,

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -600,7 +600,7 @@ class TrialBalanceReport(models.AbstractModel):
                     total_amount[unaffected_id], foreign_currency
                 )
                 total_amount[unaffected_id]["group_by_data"][0] = group_by_data_item
-        accounts_data = self._get_accounts_data(accounts_ids)
+        accounts_data = self._get_accounts_data(accounts_ids, company_id=company_id)
         (
             pl_initial_balance,
             pl_initial_currency_balance,
@@ -773,7 +773,7 @@ class TrialBalanceReport(models.AbstractModel):
         account_group_relation = {}
         for account in accounts:
             accounts_data[account.id]["complete_code"] = (
-                account.group_id.complete_code + " / " + account.code
+                account.group_id.complete_code + " / " + (account.code or "")
                 if account.group_id.id
                 else ""
             )
@@ -859,7 +859,7 @@ class TrialBalanceReport(models.AbstractModel):
                 groups_data[group.id]["initial_currency_balance"] = 0.0
                 groups_data[group.id]["ending_currency_balance"] = 0.0
             for account in accounts_data.values():
-                if group.code_prefix_start == account["code"][:len_group_code]:
+                if group.code_prefix_start == (account["code"] or "")[:len_group_code]:
                     acc_id = account["id"]
                     group_id = group.id
                     groups_data[group_id]["initial_balance"] += total_amount[acc_id][

--- a/account_financial_report/tests/__init__.py
+++ b/account_financial_report/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_open_items
 from . import test_trial_balance
 from . import test_vat_report
 from . import test_age_report_configuration
+from . import test_multicompany_reports

--- a/account_financial_report/tests/test_multicompany_reports.py
+++ b/account_financial_report/tests/test_multicompany_reports.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Ledo Enterprises
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from datetime import date
+
+from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+
+@tagged("post_install", "-at_install")
+class TestMultiCompanyReports(AccountTestInvoicingCommon):
+    """Test that financial reports render correctly in multi-company setups.
+
+    In Odoo 18, account.code is a computed field backed by code_store (jsonb).
+    Without the correct company context, account.code returns False for accounts
+    belonging to other companies, causing TypeError in report generation.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(
+            context=dict(
+                cls.env.context,
+                mail_create_nolog=True,
+                mail_create_nosubscribe=True,
+                mail_notrack=True,
+                no_reset_password=True,
+                tracking_disable=True,
+            )
+        )
+        cls.company_data_2 = cls.setup_other_company()
+        cls.company_2 = cls.company_data_2["company"]
+        cls.env.user.write({"company_ids": [(4, cls.company_2.id)]})
+
+        # Create a posted journal entry in company 2 so reports have data
+        journal_2 = cls.company_data_2["default_journal_misc"]
+        account_revenue_2 = cls.company_data_2["default_account_revenue"]
+        account_receivable_2 = cls.company_data_2["default_account_receivable"]
+
+        move = (
+            cls.env["account.move"]
+            .with_company(cls.company_2)
+            .create(
+                {
+                    "journal_id": journal_2.id,
+                    "date": date(2025, 6, 15),
+                    "line_ids": [
+                        (
+                            0,
+                            0,
+                            {
+                                "account_id": account_receivable_2.id,
+                                "partner_id": cls.env["res.partner"]
+                                .create({"name": "Test Partner MC"})
+                                .id,
+                                "debit": 1000.0,
+                            },
+                        ),
+                        (
+                            0,
+                            0,
+                            {
+                                "account_id": account_revenue_2.id,
+                                "credit": 1000.0,
+                            },
+                        ),
+                    ],
+                }
+            )
+        )
+        move.action_post()
+
+        cls.fy_date_start = date(2025, 1, 1)
+        cls.fy_date_end = date(2025, 12, 31)
+
+    def _get_gl_report_data(self, company):
+        """Generate General Ledger report data for the given company.
+
+        env.company deliberately differs from the report's target company
+        to reproduce the multi-company account.code resolution issue.
+        """
+        self.assertEqual(self.env.company, self.company_data["company"])
+        wizard = self.env["general.ledger.report.wizard"].create(
+            {
+                "company_id": company.id,
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "target_move": "posted",
+                "hide_account_at_0": True,
+                "centralize": True,
+            }
+        )
+        data = wizard._prepare_report_data()
+        return self.env[
+            "report.account_financial_report.general_ledger"
+        ]._get_report_values(wizard, data)
+
+    def _get_tb_report_data(self, company):
+        """Generate Trial Balance report data for the given company."""
+        self.assertEqual(self.env.company, self.company_data["company"])
+        wizard = self.env["trial.balance.report.wizard"].create(
+            {
+                "company_id": company.id,
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "target_move": "posted",
+                "hide_account_at_0": True,
+            }
+        )
+        data = wizard._prepare_report_data()
+        return self.env[
+            "report.account_financial_report.trial_balance"
+        ]._get_report_values(wizard, data)
+
+    def _get_apb_report_data(self, company, receivable=True):
+        """Generate Aged Partner Balance report data for the given company."""
+        self.assertEqual(self.env.company, self.company_data["company"])
+        wizard = self.env["aged.partner.balance.report.wizard"].create(
+            {
+                "company_id": company.id,
+                "date_at": self.fy_date_end,
+                "target_move": "posted",
+                "receivable_accounts_only": receivable,
+                "payable_accounts_only": not receivable,
+            }
+        )
+        data = wizard._prepare_report_data()
+        # Simulate web client behavior: the wizard default is a datetime.date
+        # but the web client sends date_at back as a string, which the report's
+        # _get_report_values feeds to datetime.strptime.
+        data.update({"date_at": data["date_at"].strftime("%Y-%m-%d")})
+        return self.env[
+            "report.account_financial_report.aged_partner_balance"
+        ]._get_report_values(wizard, data)
+
+    def test_gl_multicompany(self):
+        """General Ledger renders for non-default company without TypeError."""
+        res = self._get_gl_report_data(self.company_2)
+        self.assertIn("general_ledger", res)
+        # Verify accounts_data has string codes, not False
+        for acct_id, acct_data in res.get("accounts_data", {}).items():
+            self.assertIsInstance(
+                acct_data["code"],
+                str,
+                f"Account {acct_id} code should be str, got {type(acct_data['code'])}",
+            )
+
+    def test_tb_multicompany(self):
+        """Trial Balance renders for non-default company without TypeError."""
+        res = self._get_tb_report_data(self.company_2)
+        self.assertIn("trial_balance", res)
+        for acct_id, acct_data in res.get("accounts_data", {}).items():
+            self.assertIsInstance(
+                acct_data["code"],
+                str,
+                f"Account {acct_id} code should be str, got {type(acct_data['code'])}",
+            )
+
+    def test_apb_receivable_multicompany(self):
+        """Aged Receivable renders for non-default company without TypeError."""
+        res = self._get_apb_report_data(self.company_2, receivable=True)
+        self.assertIn("aged_partner_balance", res)
+
+    def test_apb_payable_multicompany(self):
+        """Aged Payable renders for non-default company without TypeError."""
+        res = self._get_apb_report_data(self.company_2, receivable=False)
+        self.assertIn("aged_partner_balance", res)


### PR DESCRIPTION
## Summary

Set the correct company context when resolving `account.code` in financial report generation, fixing `TypeError` in multi-company setups.

## Problem

In Odoo 18, `account.account.code` is a computed field backed by `code_store` (jsonb keyed by company ID). The `_get_accounts_data()` method in `abstract_report.py` browses accounts without setting the report's target company in the ORM environment. When the user's default company differs from the report's company, `account.code` returns `False` instead of a string, causing:

```
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```

### Steps to reproduce

1. Set up multi-company with 2+ companies, each with their own chart of accounts
2. Log in as a user whose default company is Company A
3. Open General Ledger wizard, select Company B
4. Click Export XLSX or Export PDF

### Traceback

```
File "account_financial_report/report/general_ledger_xlsx.py", line 151, in _generate_report_content
    account["code"] + " - " + accounts_data[account["id"]]["name"],
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
```

### Root cause

`_get_accounts_data()` calls `self.env["account.account"].browse(accounts_ids)` without `with_company(company_id)`. The `code` computed property uses `self.env.company.id` to look up the code from `code_store`, which defaults to the user's company (Company A) rather than the report's target company (Company B).

## Fix

- Add optional `company_id` parameter to `_get_accounts_data()` in `abstract_report.py` and call `with_company()` when provided — this is the **root cause fix** at the data source
- All callers (General Ledger, Trial Balance, Aged Partner Balance, Open Items) already have `company_id` in scope and now pass it through
- Defensive `or ""` guards on 3 remaining direct ORM accesses in `trial_balance.py` and `journal_ledger.py` where `account.code` is used outside the centralized data dict

## Affected files

| File | Change |
|------|--------|
| `abstract_report.py` | `_get_accounts_data()` accepts `company_id`, calls `with_company()` |
| `general_ledger.py` | Pass `company_id` to `_get_accounts_data()` |
| `trial_balance.py` | Pass `company_id` + guard 2 direct ORM accesses |
| `aged_partner_balance.py` | Pass `company_id` |
| `open_items.py` | Pass `company_id` |
| `journal_ledger.py` | Guard `account.code` in data dict construction |

🤖 Generated with [Claude Code](https://claude.com/claude-code)