### PR TITLE
[18.0] [FIX] account_financial_report: Add search method on account_ids to remove warning

### DIFF
--- a/account_financial_report/models/account_group.py
+++ b/account_financial_report/models/account_group.py
@@ -17,6 +17,7 @@ class AccountGroup(models.Model):
         compute="_compute_account_ids",
         string="Accounts",
         store=False,
+        search="_search_account_ids",
     )
     compute_account_ids = fields.Many2many(
         "account.account",
@@ -106,3 +107,62 @@ class AccountGroup(models.Model):
             one.compute_account_ids = (
                 one.account_ids | one.group_child_ids.compute_account_ids
             )
+
+    def _search_account_ids(self, operator, value):
+        """Search for account groups based on the accounts they contain."""
+        if operator not in ("=", "!=", "in", "not in"):
+            raise NotImplementedError
+        root_company_id = str(self.env.company.root_id.id)
+        root_company_id_int = self.env.company.root_id.id
+        if not value:
+            self.env.cr.execute(
+                SQL(
+                    """
+                SELECT DISTINCT g.id
+                FROM account_group g
+                JOIN account_account a ON
+                    g.code_prefix_start <= LEFT(a.code_store->>%(root_company_id)s,
+                    char_length(g.code_prefix_start))
+                    AND g.code_prefix_end >= LEFT(a.code_store->>%(root_company_id)s,
+                    char_length(g.code_prefix_end))
+                WHERE g.company_id = %(company_id)s
+            """,
+                    root_company_id=root_company_id,
+                    company_id=root_company_id_int,
+                )
+            )
+            groups_with_accounts = [r[0] for r in self.env.cr.fetchall()]
+            if operator in ("=", "in"):
+                return [
+                    ("id", "not in", groups_with_accounts),
+                    ("company_id", "=", root_company_id_int),
+                ]
+            else:
+                return [("id", "in", groups_with_accounts)]
+        else:
+            self.env.cr.execute(
+                SQL(
+                    """
+                SELECT DISTINCT g.id
+                FROM account_group g
+                JOIN account_account a ON
+                    g.code_prefix_start <=
+                    LEFT(a.code_store->>%(root_company_id)s,
+                    char_length(g.code_prefix_start))
+                    AND g.code_prefix_end >= LEFT(a.code_store->>%(root_company_id)s,
+                    char_length(g.code_prefix_end))
+                WHERE a.id IN %(account_ids)s
+            """,
+                    root_company_id=root_company_id,
+                    account_ids=tuple(value),
+                )
+            )
+            group_ids = [r[0] for r in self.env.cr.fetchall()]
+            if operator in ("!=", "not in"):
+                if not group_ids:
+                    return []
+                return [("id", "not in", group_ids)]
+            else:
+                if not group_ids:
+                    return [("id", "=", False)]
+                return [("id", "in", group_ids)]

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -748,3 +748,97 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         ]
         self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
         self.assertTrue(trial_balance_code_set == all_accounts_code_set)
+
+    def test_07_account_group_search_logic(self):
+        """Test the search implementation for account_ids on account.group
+        using the accounts already created in setUpClass.
+        """
+        # 1. Create a group that matches the existing receivable account prefix
+        # We take the first 3 digits of the existing account code as a prefix
+        receivable_prefix = self.account100.code[:3]
+        group_matching = self.env["account.group"].create(
+            {
+                "name": "Receivable Group",
+                "code_prefix_start": receivable_prefix,
+                "code_prefix_end": receivable_prefix,
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # 2. Create a group with a prefix that definitely has no accounts
+        group_empty = self.env["account.group"].create(
+            {
+                "name": "Empty Group",
+                "code_prefix_start": "99999999",
+                "code_prefix_end": "99999999",
+                "company_id": self.env.company.id,
+            }
+        )
+
+        # 3. Test 'in' operator with the setup account
+        # This confirms the search method finds the group by its contained account ID
+        groups_in = self.env["account.group"].search(
+            [("account_ids", "in", self.account100.ids)]
+        )
+        self.assertIn(
+            group_matching, groups_in, "Group should be found via its setup account ID"
+        )
+        self.assertNotIn(
+            group_empty,
+            groups_in,
+            "Empty group should not match the receivable account",
+        )
+
+        # 4. Test 'not in' operator
+        groups_not_in = self.env["account.group"].search(
+            [("account_ids", "not in", self.account100.ids)]
+        )
+        self.assertNotIn(
+            group_matching,
+            groups_not_in,
+            "Matching group should be excluded when testing 'not in'",
+        )
+        self.assertIn(
+            group_empty,
+            groups_not_in,
+            "Empty group should be included when excluding the matching account",
+        )
+
+        # 5. Test '=' False  (Search for groups with NO accounts)
+        # This triggers the 'not value' branch of the _search_account_ids function
+        empty_groups = self.env["account.group"].search([("account_ids", "=", False)])
+        self.assertIn(
+            group_empty,
+            empty_groups,
+            "The group with prefix 999 should be considered empty",
+        )
+        self.assertNotIn(
+            group_matching,
+            empty_groups,
+            "The matching group should not appear in empty search",
+        )
+
+        # 6. Test '!=' False (Search for groups with AT LEAST one account)
+        filled_groups = self.env["account.group"].search([("account_ids", "!=", False)])
+        self.assertIn(
+            group_matching,
+            filled_groups,
+            "The matching group should be returned as 'set'",
+        )
+        self.assertNotIn(
+            group_empty,
+            filled_groups,
+            "The empty group should not be returned as 'set'",
+        )
+
+        # 7. Test 'ilike' (Contains search)
+        with self.assertRaises(NotImplementedError):
+            self.env["account.group"].search(
+                [("account_ids", "ilike", self.account100.name)]
+            )
+
+        # 8. Test 'child_of'
+        with self.assertRaises(NotImplementedError):
+            self.env["account.group"].search(
+                [("account_ids", "child_of", self.account100.id)]
+            )


### PR DESCRIPTION
This PR aims to remove the warning that comes up currently with this module-
UserWarning: Field 'account.group.account_ids' in dependency of account.group.compute_account_ids should be searchable. This is necessary to determine which records to recompute when account.account.code is modified. You should either make the field searchable, or simplify the field dependency.