### PR TITLE
[18.0][IMP] account_financial_report_sale: Add support for analytic distribution in Open Items report

### DIFF
--- a/account_financial_report_sale/report/open_items.py
+++ b/account_financial_report_sale/report/open_items.py
@@ -23,6 +23,7 @@ class OpenItemsReport(models.AbstractModel):
             journals_data,
             accounts_data,
             open_items_move_lines_data,
+            analytic_data,
         ) = super()._get_data(
             account_ids,
             partner_ids,
@@ -62,4 +63,5 @@ class OpenItemsReport(models.AbstractModel):
             journals_data,
             accounts_data,
             open_items_move_lines_data,
+            analytic_data,
         )


### PR DESCRIPTION
### Summary
This PR improves the `account_financial_report_sale` module to support the recent analytic distribution enhancements made in the base `account_financial_report` module.
### Technical Description
The base `account_financial_report` module was updated to include `analytic_data` in the return signature of the `_get_data` method for the Open Items report. 
This PR updates the `account_financial_report_sale` override to:
- Correctly unpack the 6th return value (`analytic_data`) from the parent method.
- Pass `analytic_data` back in the final return tuple to ensure it is available for report generation.
This maintains compatibility across the inheritance chain and allows the analytic distribution column to be displayed correctly even when using sale-specific report groupings.

- Reference :- https://github.com/OCA/account-financial-reporting/pull/1494