### PR TITLE
[19.0][FIX] account_financial_report: use company method for unaffected earnings

### DIFF
--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -258,11 +258,8 @@ class GeneralLedgerReportWizard(models.TransientModel):
     @api.depends("company_id")
     def _compute_unaffected_earnings_account(self):
         for record in self:
-            record.unaffected_earnings_account = self.env["account.account"].search(
-                [
-                    ("account_type", "=", "equity_unaffected"),
-                    ("company_ids", "in", [record.company_id.id]),
-                ]
+            record.unaffected_earnings_account = (
+                record.company_id.get_unaffected_earnings_account()
             )
 
     unaffected_earnings_account = fields.Many2one(

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -226,11 +226,8 @@ class TrialBalanceReportWizard(models.TransientModel):
     @api.depends("company_id")
     def _compute_unaffected_earnings_account(self):
         for record in self:
-            record.unaffected_earnings_account = self.env["account.account"].search(
-                [
-                    ("account_type", "=", "equity_unaffected"),
-                    ("company_ids", "in", [record.company_id.id]),
-                ]
+            record.unaffected_earnings_account = (
+                record.company_id.get_unaffected_earnings_account()
             )
 
     unaffected_earnings_account = fields.Many2one(


### PR DESCRIPTION
Odoo 19 changed account.account.company_id (Many2one) to company_ids (Many2many) for shared charts of accounts. This means a search for equity_unaffected accounts can return multiple records per company, causing a ValueError when assigning to a Many2one field.

Replace the raw search in both general ledger and trial balance wizards with res.company.get_unaffected_earnings_account(), which already handles shared charts correctly.