### PR TITLE
[19.0][IMP] account_financial_report: Do not group by partner in Open Items if grouping has not been set

### DIFF
--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -128,9 +128,12 @@ class OpenItemsReport(models.AbstractModel):
                 user = partner.user_id
                 group_id = user.id or 0
                 group_name = user.name or self.env._("Missing Salesperson")
-            else:
+            elif grouped_by:
                 group_id = partner.id or 0
                 group_name = partner.name or self.env._("Missing Partner")
+            else:
+                group_id = 0
+                group_name = ""
             if group_id not in group_ids:
                 partners_data.update({group_id: {"id": group_id, "name": group_name}})
                 group_ids.add(group_id)


### PR DESCRIPTION
FWP from 18.0: https://github.com/OCA/account-financial-reporting/pull/1501

Do not group by partner in Open Items if grouping has not been set

@Tecnativa TT61339