### PR TITLE
[18.0][FIX] account_financial_report: Trial balance: show correctly data for multiple currencies

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -265,10 +265,10 @@ class TrialBalanceReport(models.AbstractModel):
                     tb, foreign_currency
                 )
             else:
-                total_amount[acc_id]["initial_balance"] = tb["balance"]
+                total_amount[acc_id]["initial_balance"] += tb["balance"]
                 total_amount[acc_id]["ending_balance"] += tb["balance"]
                 if foreign_currency:
-                    total_amount[acc_id]["initial_currency_balance"] = round(
+                    total_amount[acc_id]["initial_currency_balance"] += round(
                         tb["amount_currency"], 2
                     )
                     total_amount[acc_id]["ending_currency_balance"] += round(
@@ -285,7 +285,7 @@ class TrialBalanceReport(models.AbstractModel):
                             else:
                                 total_amount[acc_id]["group_by_data"][gb_key][
                                     "initial_balance"
-                                ] = tb2["balance"]
+                                ] += tb2["balance"]
                                 total_amount[acc_id]["group_by_data"][gb_key][
                                     "ending_balance"
                                 ] += tb2["balance"]
@@ -325,10 +325,10 @@ class TrialBalanceReport(models.AbstractModel):
             )
         else:
             # Increase balance field values
-            total_amount[acc_id][prt_id]["initial_balance"] = tb["balance"]
+            total_amount[acc_id][prt_id]["initial_balance"] += tb["balance"]
             total_amount[acc_id][prt_id]["ending_balance"] += tb["balance"]
             if foreign_currency:
-                total_amount[acc_id][prt_id]["initial_currency_balance"] = round(
+                total_amount[acc_id][prt_id]["initial_currency_balance"] += round(
                     tb["amount_currency"], 2
                 )
                 total_amount[acc_id][prt_id]["ending_currency_balance"] += round(
@@ -353,12 +353,15 @@ class TrialBalanceReport(models.AbstractModel):
                     tb["partner_id"][1] if tb["partner_id"] else _("Missing Partner")
                 )
                 partners_data.update({prt_id: {"id": prt_id, "name": partner_name}})
-            total_amount[acc_id][prt_id] = self._prepare_total_amount(
-                tb, foreign_currency
-            )
-            total_amount[acc_id][prt_id]["credit"] = tb["credit"]
-            total_amount[acc_id][prt_id]["debit"] = tb["debit"]
-            total_amount[acc_id][prt_id]["balance"] = tb["balance"]
+            if prt_id not in total_amount[acc_id]:
+                total_amount[acc_id][prt_id] = self._prepare_total_amount(
+                    tb, foreign_currency
+                )
+            else:
+                total_amount[acc_id][prt_id]["ending_balance"] += tb["balance"]
+            total_amount[acc_id][prt_id]["credit"] += tb["credit"]
+            total_amount[acc_id][prt_id]["debit"] += tb["debit"]
+            total_amount[acc_id][prt_id]["balance"] += tb["balance"]
             total_amount[acc_id][prt_id]["initial_balance"] = 0.0
             total_amount[acc_id][prt_id]["partner_name"] = partners_data[prt_id]["name"]
             partners_ids.add(prt_id)


### PR DESCRIPTION
After #1387, a new grouping key was added (`currency_id`), but the code handling the resulting data was not prepared to find several groups for the same account/partner combination, which may happen if your book operations in several currencies for the same partner (it's a weird case, but following Murphy's law, it has happened in one of my customers).

This commit fixes the data preparation for having that into account.

@Tecnativa TT62400