### PR TITLE
[18.0][IMP] account_financial_reporting: add support for company branches

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -75,7 +75,7 @@ class GeneralLedgerReport(models.AbstractModel):
         if grouped_by == "none":
             return []
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
         ] + self._get_account_type_domain(grouped_by)
         acc_prt_accounts = self.env["account.account"].search(accounts_domain)
         return acc_prt_accounts.ids
@@ -84,7 +84,7 @@ class GeneralLedgerReport(models.AbstractModel):
         self, account_ids, company_id, date_from, base_domain, grouped_by, acc_prt=False
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", True),
         ]
         if account_ids:
@@ -102,7 +102,7 @@ class GeneralLedgerReport(models.AbstractModel):
         self, account_ids, company_id, date_from, fy_start_date, base_domain
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", False),
         ]
         if account_ids:
@@ -132,7 +132,7 @@ class GeneralLedgerReport(models.AbstractModel):
         self, account_ids, company_id, fy_start_date, base_domain
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", False),
         ]
         if account_ids:

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -25,7 +25,7 @@ class TrialBalanceReport(models.AbstractModel):
         show_partner_details,
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", True),
         ]
         if account_ids:
@@ -69,7 +69,7 @@ class TrialBalanceReport(models.AbstractModel):
         fy_start_date,
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", False),
         ]
         if account_ids:
@@ -151,7 +151,7 @@ class TrialBalanceReport(models.AbstractModel):
         show_partner_details,
     ):
         accounts_domain = [
-            ("company_ids", "in", [company_id]),
+            ("company_ids", "parent_of", [company_id]),
             ("include_initial_balance", "=", False),
         ]
         if account_ids:
@@ -438,7 +438,7 @@ class TrialBalanceReport(models.AbstractModel):
         fy_start_date,
         grouped_by,
     ):
-        accounts_domain = [("company_ids", "in", [company_id])]
+        accounts_domain = [("company_ids", "parent_of", [company_id])]
         if account_ids:
             accounts_domain += [("id", "in", account_ids)]
             # If explicit list of accounts is provided,

--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -122,3 +122,22 @@ class TestAgedPartnerBalance(TransactionCase):
             data=data,
         )
         self.assertTrue(result)
+
+    def test_branch_company(self):
+        """Aged partner balance for a branch must include parent company accounts."""
+        parent = self.env.company
+        branch = self.env["res.company"].create(
+            {"name": "Aged Partner Branch", "parent_id": parent.id}
+        )
+        parent_account = self.env["account.account"].search(
+            [("company_ids", "in", [parent.id]), ("reconcile", "=", True)],
+            limit=1,
+        )
+        self.assertTrue(parent_account)
+        self.assertNotIn(branch, parent_account.company_ids)
+        wizard = self.wizard_model.create({"company_id": branch.id})
+        res = wizard.onchange_company_id()
+        accounts_in_domain = self.env["account.account"].search(
+            res["domain"]["account_ids"]
+        )
+        self.assertIn(parent_account, accounts_in_domain)

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -731,3 +731,29 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         wizard.onchange_date_range_id()
         self.assertEqual(wizard.date_from, date(2018, 1, 1))
         self.assertEqual(wizard.date_to, date(2018, 12, 31))
+
+    def test_branch_company(self):
+        """General ledger for a branch must include parent company accounts."""
+        parent = self.env.user.company_id
+        branch = self.env["res.company"].create(
+            {"name": "General Ledger Branch", "parent_id": parent.id}
+        )
+        self.assertIn(parent, self.receivable_account.company_ids)
+        self.assertNotIn(branch, self.receivable_account.company_ids)
+        wizard = self.env["general.ledger.report.wizard"].create(
+            {
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "target_move": "posted",
+                "hide_account_at_0": False,
+                "company_id": branch.id,
+                "fy_start_date": self.fy_date_start,
+                "centralize": True,
+            }
+        )
+        res = wizard.onchange_company_id()
+        accounts_in_domain = self.env["account.account"].search(
+            res["domain"]["account_ids"]
+        )
+        self.assertIn(self.receivable_account, accounts_in_domain)
+        self.assertIn(self.income_account, accounts_in_domain)

--- a/account_financial_report/tests/test_open_items.py
+++ b/account_financial_report/tests/test_open_items.py
@@ -69,3 +69,24 @@ class TestOpenItems(AccountTestInvoicingCommon):
         wizard.on_change_account_range()
         res = wizard._prepare_report_data()
         self.assertEqual(res["grouped_by"], wizard.grouped_by)
+
+    def test_branch_company(self):
+        """Open items for a branch must include parent company accounts."""
+        parent = self.env.company
+        branch = self.env["res.company"].create(
+            {"name": "Open Items Branch", "parent_id": parent.id}
+        )
+        parent_account = self.env["account.account"].search(
+            [("company_ids", "in", [parent.id]), ("reconcile", "=", True)],
+            limit=1,
+        )
+        self.assertTrue(parent_account)
+        self.assertNotIn(branch, parent_account.company_ids)
+        wizard = self.env["open.items.report.wizard"].create(
+            {"date_at": Date.today(), "company_id": branch.id}
+        )
+        res = wizard.onchange_company_id()
+        accounts_in_domain = self.env["account.account"].search(
+            res["domain"]["account_ids"]
+        )
+        self.assertIn(parent_account, accounts_in_domain)

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -748,3 +748,29 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         ]
         self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
         self.assertTrue(trial_balance_code_set == all_accounts_code_set)
+
+    def test_07_branch_company(self):
+        """Trial balance for a branch must include parent company accounts."""
+        parent = self.env.user.company_id
+        branch = self.env["res.company"].create(
+            {"name": "Trial Balance Branch", "parent_id": parent.id}
+        )
+        self.assertIn(parent, self.account100.company_ids)
+        self.assertNotIn(branch, self.account100.company_ids)
+        wizard = self.env["trial.balance.report.wizard"].create(
+            {
+                "date_from": self.date_start,
+                "date_to": self.date_end,
+                "target_move": "posted",
+                "hide_account_at_0": False,
+                "show_hierarchy": False,
+                "company_id": branch.id,
+                "fy_start_date": self.fy_date_start,
+            }
+        )
+        res = wizard.onchange_company_id()
+        accounts_in_domain = self.env["account.account"].search(
+            res["domain"]["account_ids"]
+        )
+        self.assertIn(self.account100, accounts_in_domain)
+        self.assertIn(self.account200, accounts_in_domain)

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -63,7 +63,7 @@ class AgedPartnerBalanceWizard(models.TransientModel):
             )
             if self.company_id:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         return {
             "domain": {
@@ -84,14 +84,14 @@ class AgedPartnerBalanceWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         res = {"domain": {"account_ids": [], "partner_ids": []}}
         if not self.company_id:
             return res
         else:
             res["domain"]["account_ids"] += [
-                ("company_ids", "in", [self.company_id.id])
+                ("company_ids", "parent_of", self.company_id.ids)
             ]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
         return res
@@ -103,7 +103,7 @@ class AgedPartnerBalanceWizard(models.TransientModel):
     @api.onchange("receivable_accounts_only", "payable_accounts_only")
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
-        domain = [("company_ids", "in", [self.company_id.id])]
+        domain = [("company_ids", "parent_of", self.company_id.ids)]
         if self.receivable_accounts_only or self.payable_accounts_only:
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -106,7 +106,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
             end_range = int(self.account_code_to.code)
             domain = [("code", ">=", start_range), ("code", "<=", end_range)]
             if self.company_id:
-                domain.append(("company_ids", "in", self.company_id.ids))
+                domain.append(("company_ids", "parent_of", self.company_id.ids))
             self.account_ids = self.env["account.account"].search(domain)
 
     def _init_date_from(self):
@@ -145,7 +145,11 @@ class GeneralLedgerReportWizard(models.TransientModel):
         count = self.env["account.account"].search_count(
             [
                 ("account_type", "=", "equity_unaffected"),
-                ("company_ids", "in", [self.company_id.id or self.env.company.id]),
+                (
+                    "company_ids",
+                    "parent_of",
+                    [self.company_id.id or self.env.company.id],
+                ),
             ]
         )
         return count == 1
@@ -175,7 +179,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         if self.company_id and self.cost_center_ids:
             self.cost_center_ids = self.cost_center_ids.filtered(
@@ -193,7 +197,9 @@ class GeneralLedgerReportWizard(models.TransientModel):
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
+            res["domain"]["account_ids"] += [
+                ("company_ids", "parent_of", self.company_id.ids)
+            ]
             res["domain"]["account_journal_ids"] += [
                 ("company_id", "=", self.company_id.id)
             ]
@@ -234,7 +240,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = [("company_ids", "in", [self.company_id.id])]
+            domain = [("company_ids", "parent_of", self.company_id.ids)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [
                     ("account_type", "in", ("asset_receivable", "liability_payable"))
@@ -261,7 +267,7 @@ class GeneralLedgerReportWizard(models.TransientModel):
             record.unaffected_earnings_account = self.env["account.account"].search(
                 [
                     ("account_type", "=", "equity_unaffected"),
-                    ("company_ids", "in", [record.company_id.id]),
+                    ("company_ids", "parent_of", record.company_id.ids),
                 ]
             )
 

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -83,7 +83,7 @@ class OpenItemsReportWizard(models.TransientModel):
             )
             if self.company_id:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         return {
             "domain": {
@@ -107,13 +107,15 @@ class OpenItemsReportWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         res = {"domain": {"account_ids": [], "partner_ids": []}}
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
+            res["domain"]["account_ids"] += [
+                ("company_ids", "parent_of", self.company_id.ids)
+            ]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
         return res
 
@@ -124,7 +126,7 @@ class OpenItemsReportWizard(models.TransientModel):
     @api.onchange("receivable_accounts_only", "payable_accounts_only")
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
-        domain = [("company_ids", "in", [self.company_id.id])]
+        domain = [("company_ids", "parent_of", self.company_id.ids)]
         if self.receivable_accounts_only or self.payable_accounts_only:
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -96,12 +96,12 @@ class TrialBalanceReportWizard(models.TransientModel):
                 account_ids = self.env["account.account"].browse(real_ids)
                 if self.company_id:
                     self.account_ids = account_ids.filtered(
-                        lambda a: self.company_id in a.company_ids
+                        lambda a: a.company_ids & self.company_id.parent_ids
                     )
             else:
                 if self.company_id:
                     self.account_ids = self.account_ids.filtered(
-                        lambda a: self.company_id in a.company_ids
+                        lambda a: a.company_ids & self.company_id.parent_ids
                     )
 
     @api.constrains("show_hierarchy", "show_hierarchy_level")
@@ -131,7 +131,11 @@ class TrialBalanceReportWizard(models.TransientModel):
         count = self.env["account.account"].search_count(
             [
                 ("account_type", "=", "equity_unaffected"),
-                ("company_ids", "in", [self.company_id.id or self.env.company.id]),
+                (
+                    "company_ids",
+                    "parent_of",
+                    [self.company_id.id or self.env.company.id],
+                ),
             ]
         )
         return count == 1
@@ -161,7 +165,7 @@ class TrialBalanceReportWizard(models.TransientModel):
                 self.onchange_type_accounts_only()
             else:
                 self.account_ids = self.account_ids.filtered(
-                    lambda a: self.company_id in a.company_ids
+                    lambda a: a.company_ids & self.company_id.parent_ids
                 )
         res = {
             "domain": {
@@ -174,7 +178,9 @@ class TrialBalanceReportWizard(models.TransientModel):
         if not self.company_id:
             return res
         else:
-            res["domain"]["account_ids"] += [("company_ids", "in", self.company_id.ids)]
+            res["domain"]["account_ids"] += [
+                ("company_ids", "parent_of", self.company_id.ids)
+            ]
             res["domain"]["partner_ids"] += self._get_partner_ids_domain()
             res["domain"]["date_range_id"] += [
                 "|",
@@ -209,7 +215,7 @@ class TrialBalanceReportWizard(models.TransientModel):
     def onchange_type_accounts_only(self):
         """Handle receivable/payable accounts only change."""
         if self.receivable_accounts_only or self.payable_accounts_only:
-            domain = [("company_ids", "in", [self.company_id.id])]
+            domain = [("company_ids", "parent_of", self.company_id.ids)]
             if self.receivable_accounts_only and self.payable_accounts_only:
                 domain += [
                     ("account_type", "in", ("asset_receivable", "liability_payable"))
@@ -237,7 +243,7 @@ class TrialBalanceReportWizard(models.TransientModel):
             record.unaffected_earnings_account = self.env["account.account"].search(
                 [
                     ("account_type", "=", "equity_unaffected"),
-                    ("company_ids", "in", [record.company_id.id]),
+                    ("company_ids", "parent_of", record.company_id.ids),
                 ]
             )
 


### PR DESCRIPTION
In company branches setups, the accounts set on the parent company are available for the branches.