### PR TITLE
[19.0][FIX] account_financial_report: skip line_subsection in domains

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -415,7 +415,11 @@ class GeneralLedgerReport(models.AbstractModel):
         cost_center_ids,
     ):
         domain = [
-            ("display_type", "not in", ["line_note", "line_section"]),
+            (
+                "display_type",
+                "not in",
+                ["line_note", "line_section", "line_subsection"],
+            ),
             ("date", ">=", date_from),
             ("date", "<=", date_to),
         ]

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -88,7 +88,11 @@ class JournalLedgerReport(models.AbstractModel):
 
     def _get_move_lines_domain(self, move_ids, wizard, journal_ids):
         return [
-            ("display_type", "not in", ["line_note", "line_section"]),
+            (
+                "display_type",
+                "not in",
+                ["line_note", "line_section", "line_subsection"],
+            ),
             ("move_id", "in", move_ids),
         ]
 

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -114,7 +114,11 @@ class TrialBalanceReport(models.AbstractModel):
         show_partner_details,
     ):
         domain = [
-            ("display_type", "not in", ["line_note", "line_section"]),
+            (
+                "display_type",
+                "not in",
+                ["line_note", "line_section", "line_subsection"],
+            ),
             ("date", ">=", date_from),
             ("date", "<=", date_to),
         ]

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -7,6 +7,7 @@ import time
 from datetime import date
 
 from odoo import api, fields
+from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -783,3 +784,50 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
             wizard.account_ids,
             "Accounts out of the range should NOT be in the filter.",
         )
+
+    def test_06_line_subsection_excluded(self):
+        """A posted move with a `line_subsection` row must not break the
+        General Ledger. See the Trial Balance counterpart for the root cause.
+        """
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.env.user.company_id.id)], limit=1
+        )
+        move = self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": self.fy_date_start,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "debit": 50.0,
+                            "credit": 0.0,
+                            "account_id": self.receivable_account.id,
+                            "partner_id": self.partner.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "debit": 0.0,
+                            "credit": 50.0,
+                            "account_id": self.income_account.id,
+                            "partner_id": self.partner.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "display_type": "line_subsection",
+                            "name": "Subsection label",
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        self.assertIn("line_subsection", move.line_ids.mapped("display_type"))
+        res_data = self._get_report_lines()
+        self.assertIn("general_ledger", res_data)
+        for entry in res_data["general_ledger"]:
+            self.assertTrue(
+                entry.get("id"),
+                f"Report contains a line with falsy id: {entry}",
+            )

--- a/account_financial_report/tests/test_journal_ledger.py
+++ b/account_financial_report/tests/test_journal_ledger.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
 
-from odoo.fields import Date
+from odoo.fields import Command, Date
 from odoo.tests import Form, tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -283,3 +283,52 @@ class TestJournalReport(AccountTestInvoicingCommon):
 
         self.check_report_journal_debit_credit(res_data, 250, 250)
         self.check_report_journal_debit_credit_taxes(res_data, 300, 0, 50, 0)
+
+    def test_04_line_subsection_excluded(self):
+        """A posted move with a `line_subsection` row must not break the
+        Journal Ledger. See the Trial Balance counterpart for the root cause.
+        """
+        move = self.MoveObj.create(
+            {
+                "journal_id": self.journal_sale.id,
+                "date": self.fy_date_start,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "name": "move",
+                            "debit": 100.0,
+                            "credit": 0.0,
+                            "account_id": self.income_account.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "name": "move",
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "account_id": self.receivable_account.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "display_type": "line_subsection",
+                            "name": "Subsection label",
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        self.assertIn("line_subsection", move.line_ids.mapped("display_type"))
+        wiz = self.JournalLedgerReportWizard.create(
+            {
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "company_id": self.company.id,
+                "journal_ids": [Command.set(self.journal_sale.ids)],
+                "move_target": "posted",
+            }
+        )
+        data = wiz._prepare_report_data()
+        res_data = self.JournalLedgerReport._get_report_values(wiz, data)
+        self.assertIn("Journal_Ledgers", res_data)

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -5,6 +5,7 @@
 
 import re
 
+from odoo.fields import Command
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -715,3 +716,60 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         ]
         self.assertEqual(len(trial_balance_code_set), len(all_accounts_code_set))
         self.assertTrue(trial_balance_code_set == all_accounts_code_set)
+
+    def test_06_line_subsection_excluded(self):
+        """A posted move that contains a `line_subsection` display row must
+        not break the Trial Balance.
+
+        Odoo 19 introduced the `line_subsection` value in
+        `account.move.line.display_type`. Such rows carry no `account_id`,
+        so they reach `formatted_read_group` as a `False` group and the
+        downstream `_compute_account_amount` raises
+        `TypeError: 'bool' object is not subscriptable`.
+        """
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.env.user.company_id.id)], limit=1
+        )
+        move = self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": self.date_start,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "debit": 100.0,
+                            "credit": 0.0,
+                            "account_id": self.account200.id,
+                            "partner_id": self.partner_a.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "account_id": self.account100.id,
+                            "partner_id": self.partner_a.id,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "display_type": "line_subsection",
+                            "name": "Subsection label",
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        self.assertIn(
+            "line_subsection",
+            move.line_ids.mapped("display_type"),
+            "Move was not created with a line_subsection row",
+        )
+        res_data = self._get_report_lines()
+        self.assertIn("trial_balance", res_data)
+        for entry in res_data["trial_balance"]:
+            self.assertTrue(
+                entry.get("id"),
+                f"Report contains a line with falsy id: {entry}",
+            )


### PR DESCRIPTION
 Odoo 19 added `line_subsection` to `account.move.line.display_type`. Like `line_note` and `line_section`, that has not `account_id`.

  Trial Balance, General Ledger and Journal Ledger was fitlering only the two older display types, so a posted move with a subsection row in the reporting period reaches `formatted_read_group` as a `False` group and crashes `_compute_account_amount`.

  ## Error

  Printing the Trial Balance over a period that contains at least one
  posted move with a `line_subsection` row raises:

>   File ".../account_financial_report/report/trial_balance.py", line 922, in _get_report_values
>       total_amount, accounts_data, partners_data = self._get_data(
>   File ".../account_financial_report/report/trial_balance.py", line 583, in _get_data
>       total_amount = self._compute_account_amount(
>   File ".../account_financial_report/report/trial_balance.py", line 226, in _compute_account_amount
>       acc_id = tb["account_id"][0]
>                ~~~~~~~~~~~~~~~~^^^
>   TypeError: 'bool' object is not subscriptable

  
  ## Fix

  Add line_subsection to the domains so it is not included in `formatted_read_group`