### PR TITLE
[18.0][IMP] account_financial_report: Add a label to the account_ids field in all wizards

### DIFF
--- a/account_financial_report/i18n/account_financial_report.pot
+++ b/account_financial_report/i18n/account_financial_report.pot
@@ -6,6 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0\n"
 "Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 08:24+0000\n"
+"PO-Revision-Date: 2026-06-02 08:24+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -803,6 +805,14 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_financial_report.field_trial_balance_report_wizard__partner_ids
 #: model_terms:ir.ui.view,arch_db:account_financial_report.general_ledger_wizard
 msgid "Filter partners"
+msgstr ""
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.aged_partner_balance_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.general_ledger_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.open_items_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.trial_balance_wizard
+msgid "Filtered accounts (empty for all)"
 msgstr ""
 
 #. module: account_financial_report

--- a/account_financial_report/i18n/es.po
+++ b/account_financial_report/i18n/es.po
@@ -6,16 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-21 15:05+0000\n"
-"PO-Revision-Date: 2026-05-26 15:46+0000\n"
-"Last-Translator: Oso Tranquilo <osotranquilo@gmail.com>\n"
+"POT-Creation-Date: 2026-06-02 08:24+0000\n"
+"PO-Revision-Date: 2026-06-02 10:28+0200\n"
+"Last-Translator: Andrii Kompaniiets <andrii.kompaniiets@tecnativa.com>\n"
 "Language-Team: \n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 5.15.2\n"
+"X-Generator: Poedit 3.9\n"
 
 #. module: account_financial_report
 #. odoo-python
@@ -831,6 +831,14 @@ msgstr "Filtrar por diarios"
 #: model_terms:ir.ui.view,arch_db:account_financial_report.general_ledger_wizard
 msgid "Filter partners"
 msgstr "Filtrar empresa"
+
+#. module: account_financial_report
+#: model_terms:ir.ui.view,arch_db:account_financial_report.aged_partner_balance_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.general_ledger_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.open_items_wizard
+#: model_terms:ir.ui.view,arch_db:account_financial_report.trial_balance_wizard
+msgid "Filtered accounts (empty for all)"
+msgstr "Cuentas filtradas (vacío para todas)"
 
 #. module: account_financial_report
 #: model:ir.model.fields,field_description:account_financial_report.field_journal_ledger_report_wizard__foreign_currency

--- a/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
+++ b/account_financial_report/wizard/aged_partner_balance_wizard_view.xml
@@ -57,6 +57,7 @@
                     <field
                         name="account_ids"
                         nolabel="1"
+                        placeholder="Filtered accounts (empty for all)"
                         widget="many2many_tags"
                         options="{'no_create': True}"
                         colspan="4"

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -55,6 +55,7 @@
                                 <field
                                     name="account_ids"
                                     nolabel="1"
+                                    placeholder="Filtered accounts (empty for all)"
                                     widget="many2many_tags"
                                     options="{'no_create': True}"
                                     colspan="4"

--- a/account_financial_report/wizard/open_items_wizard_view.xml
+++ b/account_financial_report/wizard/open_items_wizard_view.xml
@@ -58,6 +58,7 @@
                     <field
                         name="account_ids"
                         nolabel="1"
+                        placeholder="Filtered accounts (empty for all)"
                         widget="many2many_tags"
                         options="{'no_create': True}"
                         colspan="4"

--- a/account_financial_report/wizard/trial_balance_wizard_view.xml
+++ b/account_financial_report/wizard/trial_balance_wizard_view.xml
@@ -102,6 +102,7 @@
                         <field
                             name="account_ids"
                             nolabel="1"
+                            placeholder="Filtered accounts (empty for all)"
                             widget="many2many_tags"
                             options="{'no_create': True}"
                             colspan="4"


### PR DESCRIPTION
Improvements to the wizard views for the account_ids field
<img width="4442" height="1636" alt="image" src="https://github.com/user-attachments/assets/73929806-2b4c-47a1-9ea9-57423ad644e5" />

@pedrobaeza @sergio-teruel ping

@Tecnativa
TT62694