### PR TITLE
[18.0][FIX] account_tax_balance: Compute financial_type correctly when the total is zero

### DIFF
--- a/account_tax_balance/models/account_move.py
+++ b/account_tax_balance/models/account_move.py
@@ -34,6 +34,15 @@ class AccountMove(models.Model):
                 ).mapped("balance")
             )
 
+        mapping = {
+            "entry": "other",
+            "out_invoice": "receivable",
+            "out_receipt": "receivable",
+            "out_refund": "receivable_refund",
+            "in_invoice": "payable",
+            "in_receipt": "payable",
+            "in_refund": "payable_refund",
+        }
         for move in self:
             account_types = move.line_ids.mapped("account_id.account_type")
             if (
@@ -43,11 +52,17 @@ class AccountMove(models.Model):
                 move.financial_type = "liquidity"
             elif "liability_payable" in account_types:
                 balance = _balance_get(move.line_ids, "liability_payable")
-                move.financial_type = "payable" if balance < 0 else "payable_refund"
+                if move.company_currency_id.is_zero(balance):
+                    move.financial_type = mapping.get(move.move_type) or "other"
+                else:
+                    move.financial_type = "payable" if balance < 0 else "payable_refund"
             elif "asset_receivable" in account_types:
                 balance = _balance_get(move.line_ids, "asset_receivable")
-                move.financial_type = (
-                    "receivable" if balance > 0 else "receivable_refund"
-                )
+                if move.company_currency_id.is_zero(balance):
+                    move.financial_type = mapping.get(move.move_type) or "other"
+                else:
+                    move.financial_type = (
+                        "receivable" if balance > 0 else "receivable_refund"
+                    )
             else:
                 move.financial_type = "other"

--- a/account_tax_balance/tests/test_account_tax_balance.py
+++ b/account_tax_balance/tests/test_account_tax_balance.py
@@ -283,3 +283,25 @@ class TestInvoicingBalance(AccountTestInvoicingCommon):
             to_date=date,
         )
         self.assertEqual(tax.balance, balance)
+
+    def test_financial_type_with_amount(self):
+        """Check that financial_type are computed correctly."""
+        in_invoice = self.init_invoice("in_invoice", post=True, amounts=[100])
+        self.assertEqual(in_invoice.financial_type, "payable")
+        in_refund = self._reverse_invoice(in_invoice, post=True)
+        self.assertEqual(in_refund.financial_type, "payable_refund")
+        out_invoice = self.init_invoice("out_invoice", post=True, amounts=[100])
+        self.assertEqual(out_invoice.financial_type, "receivable")
+        out_refund = self._reverse_invoice(out_invoice, post=True)
+        self.assertEqual(out_refund.financial_type, "receivable_refund")
+
+    def test_financial_type_with_zero_amount(self):
+        """Check that financial_type are computed correctly when the total is zero."""
+        in_invoice = self.init_invoice("in_invoice", post=True, amounts=[100, -100])
+        self.assertEqual(in_invoice.financial_type, "payable")
+        in_refund = self._reverse_invoice(in_invoice, post=True)
+        self.assertEqual(in_refund.financial_type, "payable_refund")
+        out_invoice = self.init_invoice("out_invoice", post=True, amounts=[100, -100])
+        self.assertEqual(out_invoice.financial_type, "receivable")
+        out_refund = self._reverse_invoice(out_invoice, post=True)
+        self.assertEqual(out_refund.financial_type, "receivable_refund")


### PR DESCRIPTION
Before this commit, for records with total = 0, the `financial_type` was computed incorrectly:

`out_invoice` → `receivable_refund` (should be `receivable`) 
`in_invoice` → `payable_refund` (should be `payable`)

This commit fixes the computation of the `financial_type` field according to the move type.

TT62976
@Tecnativa @pedrobaeza Could you please review this?