### PR TITLE
[19.0][FIX] account_financial_report: sum all currencies in Trial Balance period totals

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -228,13 +228,30 @@ class TrialBalanceReport(models.AbstractModel):
     ):
         for tb in tb_period_acc:
             acc_id = tb["account_id"][0]
-            total_amount[acc_id] = self._prepare_total_amount(tb, foreign_currency)
-            total_amount[acc_id]["credit"] = tb["credit:sum"]
-            total_amount[acc_id]["debit"] = tb["debit:sum"]
-            total_amount[acc_id]["balance"] = tb["balance:sum"]
-            total_amount[acc_id]["initial_balance"] = 0.0
-            if foreign_currency:
-                total_amount[acc_id]["initial_currency_balance"] = 0.0
+            # ``tb_period_acc`` is grouped by account *and* currency, so an
+            # account holding move lines in several currencies produces one
+            # row per currency here. Those rows must be accumulated, not
+            # overwritten, otherwise the account only keeps the figures of its
+            # last currency sub-group (wrong debit/credit/balance, and the
+            # "Target Moves" filter looks ineffective when the dropped
+            # currencies carry the only unposted entries).
+            if acc_id not in total_amount:
+                total_amount[acc_id] = self._prepare_total_amount(tb, foreign_currency)
+                total_amount[acc_id]["credit"] = tb["credit:sum"]
+                total_amount[acc_id]["debit"] = tb["debit:sum"]
+                total_amount[acc_id]["balance"] = tb["balance:sum"]
+                total_amount[acc_id]["initial_balance"] = 0.0
+                if foreign_currency:
+                    total_amount[acc_id]["initial_currency_balance"] = 0.0
+            else:
+                total_amount[acc_id]["credit"] += tb["credit:sum"]
+                total_amount[acc_id]["debit"] += tb["debit:sum"]
+                total_amount[acc_id]["balance"] += tb["balance:sum"]
+                total_amount[acc_id]["ending_balance"] += tb["balance:sum"]
+                if foreign_currency:
+                    total_amount[acc_id]["ending_currency_balance"] += round(
+                        tb["amount_currency:sum"], 2
+                    )
             if "__context" in tb and "group_by" in tb["__context"]:
                 group_by = tb["__context"]["group_by"][0]
                 gb_data = {}

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -841,3 +841,107 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         total = res_data["total_amount"][self.account100.id]
         self.assertEqual(total["initial_currency_balance"], 2000)
         self.assertEqual(total["ending_currency_balance"], 3000)
+
+    def test_08_account_multicurrency_period(self):
+        """Period totals must sum every currency, not only the last one.
+
+        Regression test: an account with period move lines in more than one
+        currency used to keep only its last currency sub-group, returning a
+        wrong debit/credit/balance.
+        """
+        other_currency = self.setup_other_currency("EUR")
+        company_currency = self.env.company.currency_id
+        account = self._create_account_account(
+            {
+                "code": "510",
+                "name": "Multi-currency asset",
+                "account_type": "asset_current",
+            }
+        )
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.env.company.id)], limit=1
+        )
+        # Move 1: 100 in company currency.
+        self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": self.date_start,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": account.id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                            "currency_id": company_currency.id,
+                            "amount_currency": 100.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.account200.id,
+                            "debit": 0.0,
+                            "credit": 100.0,
+                            "currency_id": company_currency.id,
+                            "amount_currency": -100.0,
+                        }
+                    ),
+                ],
+            }
+        ).action_post()
+        # Move 2: 60 in company currency == 180 in the foreign currency (rate 3).
+        self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": self.date_start,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": account.id,
+                            "debit": 60.0,
+                            "credit": 0.0,
+                            "currency_id": other_currency.id,
+                            "amount_currency": 180.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.account200.id,
+                            "debit": 0.0,
+                            "credit": 60.0,
+                            "currency_id": other_currency.id,
+                            "amount_currency": -180.0,
+                        }
+                    ),
+                ],
+            }
+        ).action_post()
+
+        res_data = self._get_report_lines()
+        lines = self._get_account_lines(account.id, res_data["trial_balance"])
+        self.assertTrue(lines, "Multi-currency account missing from the report")
+        # 100 (company currency) + 60 (foreign currency) must both be counted.
+        self.assertEqual(lines["initial_balance"], 0.0)
+        self.assertEqual(lines["debit"], 160.0)
+        self.assertEqual(lines["credit"], 0.0)
+        self.assertEqual(lines["final_balance"], 160.0)
+
+        # Same account with "Show foreign currency" on: the company-currency
+        # totals must still add up across both currency sub-groups.
+        wizard = self.env["trial.balance.report.wizard"].create(
+            {
+                "date_from": self.date_start,
+                "date_to": self.date_end,
+                "target_move": "posted",
+                "hide_account_at_0": True,
+                "company_id": self.env.company.id,
+                "fy_start_date": self.fy_date_start,
+                "foreign_currency": True,
+            }
+        )
+        res_fc = self.env[
+            "report.account_financial_report.trial_balance"
+        ]._get_report_values(wizard, wizard._prepare_report_data())
+        lines_fc = self._get_account_lines(account.id, res_fc["trial_balance"])
+        self.assertTrue(lines_fc, "Multi-currency account missing (foreign currency)")
+        self.assertEqual(lines_fc["debit"], 160.0)
+        self.assertEqual(lines_fc["final_balance"], 160.0)


### PR DESCRIPTION
## Problem
The Trial Balance reports wrong Debit/Credit/Balance for any account that has
period move lines in **more than one currency**: only the last currency
sub-group is kept. Side effects: the "Target Moves" (All vs Posted) toggle looks
ineffective when the dropped currencies carry the only unposted entries, and the
Trial Balance stops matching the General Ledger.

Fixes #1537.

## Root cause
`TrialBalanceReport._compute_account_amount` iterates `tb_period_acc`, grouped by
account **and** currency (one row per `(account, currency)`), and **assigns**
instead of **accumulating** the per-currency figures. Commit af77270f6 fixed the
same `=`→`+=` issue in the initial-balance and partner-detail loops but missed
this first (period, non-partner-details) loop and shipped no test, so the default
Trial Balance is still affected.

## Fix
- Accumulate the per-currency period rows (debit/credit/balance/ending balance,
  plus the currency balances when "Show foreign currency" is on) instead of
  overwriting them.
- Add a regression test that posts two currencies on one account and asserts the
  summed total (100 company-currency + 60 == 160), run both with and without
  "Show foreign currency".

## Notes
The analytic *group by* path (`group_by_data`) has the same last-currency-wins
behaviour and would need an analogous change, but it only triggers with "Group by
Analytic Account" **and** multi-currency; left out of scope here to keep the fix
focused and fully covered. Happy to address it in a follow-up.

## Backport
The same code path exists on 18.0 / 17.0 / 16.0 — happy to forward-/back-port.
