### PR TITLE
[FIX] account_financial_report: restore open items xlsx ending balance

### DIFF
--- a/account_financial_report/report/open_items_xlsx.py
+++ b/account_financial_report/report/open_items_xlsx.py
@@ -294,18 +294,18 @@ class OpenItemsXslx(models.AbstractModel):
                         )
                         self.write_line_from_dict(line, report_data)
 
-                    # Display ending balance line for account
-                    type_object = "account"
-                    self.write_ending_balance_from_dict(
-                        accounts_data[account_id],
-                        type_object,
-                        total_amount,
-                        report_data,
-                        account_id=account_id,
-                    )
+                # Display ending balance line for account
+                type_object = "account"
+                self.write_ending_balance_from_dict(
+                    accounts_data[account_id],
+                    type_object,
+                    total_amount,
+                    report_data,
+                    account_id=account_id,
+                )
 
-                    # 2 lines break
-                    report_data["row_pos"] += 2
+                # 2 lines break
+                report_data["row_pos"] += 2
 
     def _generate_report_content(self, workbook, report, data, report_data):
         res_data = self.env[


### PR DESCRIPTION
The account ending balance line in Open Items XLSX became conditional after e14373d.
This diverges from the qweb-html and qweb-pdf Open Items outputs, where account ending balance is still shown.
This patch restores the previous XLSX behavior by always printing account ending balance for account sections.

