### PR TITLE
[IMP] account_financial_report: Hide accounts with no end balance

### DIFF
--- a/account_financial_report/README.rst
+++ b/account_financial_report/README.rst
@@ -49,7 +49,8 @@ currency used in account move lines is properly shown.
 In case that in an account has not been configured a second currency foreign
 currency balances are not available.
 
-In the Trial Balance, the flag *Hide accounts with 0 end balance*
+In the General Ledger and the Trial Balance,
+the flag *Hide accounts with 0 end balance*
 allows the user to hide accounts that
 have ending balance equal to 0 in the selected period.
 

--- a/account_financial_report/readme/DESCRIPTION.rst
+++ b/account_financial_report/readme/DESCRIPTION.rst
@@ -15,6 +15,7 @@ currency used in account move lines is properly shown.
 In case that in an account has not been configured a second currency foreign
 currency balances are not available.
 
-In the Trial Balance, the flag *Hide accounts with 0 end balance*
+In the General Ledger and the Trial Balance,
+the flag *Hide accounts with 0 end balance*
 allows the user to hide accounts that
 have ending balance equal to 0 in the selected period.

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -640,7 +640,13 @@ class GeneralLedgerReport(models.AbstractModel):
         return account
 
     def _get_list_grouped_item(
-        self, data, account, rec_after_date_to_ids, hide_account_at_0, rounding
+        self,
+        data,
+        account,
+        rec_after_date_to_ids,
+        hide_account_at_0,
+        hide_account_at_end_0,
+        rounding,
     ):
         list_grouped = []
         for data_id in data.keys():
@@ -670,6 +676,11 @@ class GeneralLedgerReport(models.AbstractModel):
                     and group_item["move_lines"] == []
                 ):
                     continue
+                if hide_account_at_end_0 and float_is_zero(
+                    data[data_id]["fin_bal"]["balance"],
+                    precision_rounding=rounding,
+                ):
+                    continue
                 list_grouped += [group_item]
         return account, list_grouped
 
@@ -680,6 +691,7 @@ class GeneralLedgerReport(models.AbstractModel):
         grouped_by,
         rec_after_date_to_ids,
         hide_account_at_0,
+        hide_account_at_end_0,
     ):
         general_ledger = []
         rounding = self.env.company.currency_id.rounding
@@ -708,6 +720,11 @@ class GeneralLedgerReport(models.AbstractModel):
                     and account["move_lines"] == []
                 ):
                     continue
+                if hide_account_at_end_0 and float_is_zero(
+                    gen_led_data[acc_id]["fin_bal"]["balance"],
+                    precision_rounding=rounding,
+                ):
+                    continue
             else:
                 if grouped_by:
                     account, list_grouped = self._get_list_grouped_item(
@@ -715,6 +732,7 @@ class GeneralLedgerReport(models.AbstractModel):
                         account,
                         rec_after_date_to_ids,
                         hide_account_at_0,
+                        hide_account_at_end_0,
                         rounding,
                     )
                     account.update({"list_grouped": list_grouped})
@@ -725,6 +743,11 @@ class GeneralLedgerReport(models.AbstractModel):
                             precision_rounding=rounding,
                         )
                         and account["list_grouped"] == []
+                    ):
+                        continue
+                    if hide_account_at_end_0 and float_is_zero(
+                        gen_led_data[acc_id]["fin_bal"]["balance"],
+                        precision_rounding=rounding,
                     ):
                         continue
                 else:
@@ -738,6 +761,11 @@ class GeneralLedgerReport(models.AbstractModel):
                             precision_rounding=rounding,
                         )
                         and account["move_lines"] == []
+                    ):
+                        continue
+                    if hide_account_at_end_0 and float_is_zero(
+                        gen_led_data[acc_id]["fin_bal"]["balance"],
+                        precision_rounding=rounding,
                     ):
                         continue
             general_ledger += [account]
@@ -823,6 +851,7 @@ class GeneralLedgerReport(models.AbstractModel):
         grouped_by = wizard.grouped_by
         aggregated_payment_term_lines = wizard.aggregated_payment_term_lines
         hide_account_at_0 = wizard.hide_account_at_0
+        hide_account_at_end_0 = wizard.hide_account_at_end_0
         foreign_currency = wizard.foreign_currency
         only_posted_moves = wizard.target_move == "posted"
         unaffected_earnings_account = wizard.unaffected_earnings_account.id
@@ -872,6 +901,7 @@ class GeneralLedgerReport(models.AbstractModel):
             grouped_by,
             rec_after_date_to_ids,
             hide_account_at_0,
+            hide_account_at_end_0,
         )
         if centralize:
             for account in general_ledger:
@@ -901,6 +931,7 @@ class GeneralLedgerReport(models.AbstractModel):
             "date_to": date_to,
             "only_posted_moves": only_posted_moves,
             "hide_account_at_0": hide_account_at_0,
+            "hide_account_at_end_0": hide_account_at_end_0,
             "show_analytic_tags": wizard.show_analytic_tags,
             "show_cost_center": wizard.show_cost_center,
             "general_ledger": general_ledger,

--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -111,6 +111,10 @@ class GeneralLedgerXslx(models.AbstractModel):
                 _("Account balance at 0 filter"),
                 _("Hide") if report.hide_account_at_0 else _("Show"),
             ],
+            [
+                _("Account final balance at 0 filter"),
+                _("Hide") if report.hide_account_at_end_0 else _("Show"),
+            ],
             [_("Centralize filter"), _("Yes") if report.centralize else _("No")],
             [
                 _("Show analytic tags"),

--- a/account_financial_report/report/templates/general_ledger.xml
+++ b/account_financial_report/report/templates/general_ledger.xml
@@ -108,6 +108,7 @@
                 <div class="act_as_cell">Date range filter</div>
                 <div class="act_as_cell">Target moves filter</div>
                 <div class="act_as_cell">Account balance at 0 filter</div>
+                <div class="act_as_cell">Account final balance at 0 filter</div>
                 <div class="act_as_cell">Centralize filter</div>
                 <div class="act_as_cell">Show analytic tags</div>
             </div>
@@ -125,6 +126,10 @@
                 <div class="act_as_cell">
                     <t t-if="hide_account_at_0">Hide</t>
                     <t t-if="not hide_account_at_0">Show</t>
+                </div>
+                <div class="act_as_cell">
+                    <t t-if="hide_account_at_end_0">Hide</t>
+                    <t t-if="not hide_account_at_end_0">Show</t>
                 </div>
                 <div class="act_as_cell">
                     <t t-if="centralize">Yes</t>

--- a/account_financial_report/static/description/index.html
+++ b/account_financial_report/static/description/index.html
@@ -390,7 +390,8 @@ currency set up in account in order to display balances. Moreover, any foreign
 currency used in account move lines is properly shown.</p>
 <p>In case that in an account has not been configured a second currency foreign
 currency balances are not available.</p>
-<p>In the Trial Balance, the flag <em>Hide accounts with 0 end balance</em>
+<p>In the General Ledger and the Trial Balance,
+the flag <em>Hide accounts with 0 end balance</em>
 allows the user to hide accounts that
 have ending balance equal to 0 in the selected period.</p>
 <p><strong>Table of contents</strong></p>

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -792,3 +792,63 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
                             self.fail("Invoice showing multiple lines")
 
         self.assertEqual(found_move_line["balance"], invoice.amount_total)
+
+    def _move_amount(self, amount, from_account, to_account, move_date):
+        """Move `amount` from account `from_account` to account `to_account` on `move_date`."""
+        entry_form = Form(self.env["account.move"])
+        entry_form.partner_id = self.env.ref("base.res_partner_12")
+        entry_form.date = move_date
+        with entry_form.line_ids.new() as line:
+            line.name = "Test"
+            line.account_id = from_account
+            line.credit = 100
+        with entry_form.line_ids.new() as line:
+            line.name = "Test"
+            line.account_id = to_account
+            line.debit = 100
+        entry = entry_form.save()
+        entry.action_post()
+        return entry
+
+    def test_hide_account_at_end_0(self):
+        """When "Hide accounts with 0 end balance" is enabled,
+        accounts that have 0 end balance are hidden.
+        """
+        # Arrange
+        wizard = self.env["general.ledger.report.wizard"].create(
+            {
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "hide_account_at_end_0": True,
+            }
+        )
+        start_date = wizard.date_from
+        end_date = wizard.date_to
+        report_interval = end_date - start_date
+        before_date = start_date - report_interval
+        in_date = start_date + report_interval / 2
+        account = self.receivable_account
+        # One account has initial balance > 0
+        # but end balance = 0
+        only_initial_account = account.copy()
+        self._move_amount(100, account, only_initial_account, before_date)
+        self._move_amount(100, only_initial_account, account, in_date)
+        # Another account has initial balance = 0
+        # but end balance > 0
+        only_end_account = account.copy()
+        self._move_amount(100, account, only_end_account, in_date)
+
+        # Act
+        prepared_data = wizard._prepare_report_general_ledger()
+        report_values = self.env[
+            "report.account_financial_report.general_ledger"
+        ]._get_report_values(wizard, prepared_data)
+        general_ledger = report_values["general_ledger"]
+
+        # Assert
+        self.assertFalse(
+            self.check_account_in_report(only_initial_account.id, general_ledger)
+        )
+        self.assertTrue(
+            self.check_account_in_report(only_end_account.id, general_ledger)
+        )

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -37,11 +37,14 @@ class GeneralLedgerReportWizard(models.TransientModel):
     )
     centralize = fields.Boolean(string="Activate centralization", default=True)
     hide_account_at_0 = fields.Boolean(
-        string="Hide account ending balance at 0",
+        string="Hide account with initial balance at 0 and no movements",
         help="Use this filter to hide an account or a partner "
-        "with an ending balance at 0. "
-        "If partners are filtered, "
-        "debits and credits totals will not match the trial balance.",
+        "with an initial balance at 0 and no movements. ",
+    )
+    hide_account_at_end_0 = fields.Boolean(
+        string="Hide accounts with 0 end balance",
+        help="When this option is enabled, the general ledger will "
+        "not display accounts or partners that have 0 ending balance.",
     )
     show_analytic_tags = fields.Boolean(
         string="Show analytic tags",

--- a/account_financial_report/wizard/general_ledger_wizard_view.xml
+++ b/account_financial_report/wizard/general_ledger_wizard_view.xml
@@ -29,6 +29,7 @@
                             <field name="aggregated_payment_term_lines" />
                             <field name="centralize" />
                             <field name="hide_account_at_0" />
+                            <field name="hide_account_at_end_0" />
                             <field name="foreign_currency" />
                             <field name="show_analytic_tags" />
                             <field name="show_cost_center" />


### PR DESCRIPTION
Add a new flag in the General Ledger wizard that allows the user to hide from the report the accounts that have 0 ending balance.

Same as https://github.com/OCA/account-financial-reporting/pull/1336, but for the General Ledger.

I also rephrased the description of the existing `hide_account_at_0` field because it does not really "Hide account ending balance at 0", and this is probably the root cause of the false expectations.