### PR TITLE
[19.0][FIX] account_financial_report: trial balance fc key error

### DIFF
--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -275,11 +275,16 @@ class TrialBalanceReport(models.AbstractModel):
                     tb["balance"] if "balance" in tb else tb["balance:sum"]
                 )
                 if foreign_currency:
+                    amount_currency = (
+                        tb["amount_currency"]
+                        if "amount_currency" in tb
+                        else tb["amount_currency:sum"]
+                    )
                     total_amount[acc_id]["initial_currency_balance"] += round(
-                        tb["amount_currency:sum"], 2
+                        amount_currency, 2
                     )
                     total_amount[acc_id]["ending_currency_balance"] += round(
-                        tb["amount_currency:sum"], 2
+                        amount_currency, 2
                     )
                 if "group_by_data" in tb:
                     for gb_key in list(tb["group_by_data"]):
@@ -315,8 +320,13 @@ class TrialBalanceReport(models.AbstractModel):
             "ending_balance": tb["balance"] if "balance" in tb else tb["balance:sum"],
         }
         if foreign_currency:
-            res["initial_currency_balance"] = round(tb["amount_currency:sum"], 2)
-            res["ending_currency_balance"] = round(tb["amount_currency:sum"], 2)
+            amount_currency = (
+                tb["amount_currency"]
+                if "amount_currency" in tb
+                else tb["amount_currency:sum"]
+            )
+            res["initial_currency_balance"] = round(amount_currency, 2)
+            res["ending_currency_balance"] = round(amount_currency, 2)
         return res
 
     @api.model
@@ -339,11 +349,16 @@ class TrialBalanceReport(models.AbstractModel):
                 tb["balance"] if "balance" in tb else tb["balance:sum"]
             )
             if foreign_currency:
+                amount_currency = (
+                    tb["amount_currency"]
+                    if "amount_currency" in tb
+                    else tb["amount_currency:sum"]
+                )
                 total_amount[acc_id][prt_id]["initial_currency_balance"] += round(
-                    tb["amount_currency:sum"], 2
+                    amount_currency, 2
                 )
                 total_amount[acc_id][prt_id]["ending_currency_balance"] += round(
-                    tb["amount_currency:sum"], 2
+                    amount_currency, 2
                 )
         total_amount[acc_id][prt_id]["partner_name"] = (
             tb["partner_id"][1] if tb["partner_id"] else self.env._("Missing Partner")

--- a/account_financial_report/tests/test_trial_balance.py
+++ b/account_financial_report/tests/test_trial_balance.py
@@ -94,6 +94,9 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
             ],
             limit=1,
         )
+        cls.foreign_currency = cls.setup_other_currency(
+            "EUR", rates=[("1900-01-01", 2.0)]
+        )
 
     def _create_account_account(self, vals):
         item = self.env["account.account"].create(vals)
@@ -172,8 +175,45 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
         move = self.env["account.move"].create(move_vals)
         move.action_post()
 
+    def _add_currency_move(self, date, debit, credit, amount_currency):
+        journal = self.env["account.journal"].search(
+            [("company_id", "=", self.env.user.company_id.id)], limit=1
+        )
+        move = self.env["account.move"].create(
+            {
+                "journal_id": journal.id,
+                "date": date,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "debit": debit,
+                            "credit": credit,
+                            "partner_id": self.partner_a.id,
+                            "account_id": self.account100.id,
+                            "currency_id": self.foreign_currency.id,
+                            "amount_currency": amount_currency,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "debit": credit,
+                            "credit": debit,
+                            "partner_id": self.partner_a.id,
+                            "account_id": self.account200.id,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        return move
+
     def _get_report_lines(
-        self, with_partners=False, account_ids=False, show_hierarchy=False
+        self,
+        with_partners=False,
+        account_ids=False,
+        show_hierarchy=False,
+        foreign_currency=False,
     ):
         company = self.env.user.company_id
         trial_balance = self.env["trial.balance.report.wizard"].create(
@@ -187,6 +227,7 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
                 "account_ids": account_ids,
                 "fy_start_date": self.fy_date_start,
                 "show_partner_details": with_partners,
+                "foreign_currency": foreign_currency,
             }
         )
         data = trial_balance._prepare_report_data()
@@ -773,3 +814,30 @@ class TestTrialBalanceReport(AccountTestInvoicingCommon):
                 entry.get("id"),
                 f"Report contains a line with falsy id: {entry}",
             )
+
+    def test_07_foreign_currency_initial_balance(self):
+        # GIVEN an initial balance in foreign currency (before the period)
+        self._add_currency_move(
+            date=self.previous_fy_date_end,
+            debit=1000,
+            credit=0,
+            amount_currency=2000,
+        )
+        self._add_currency_move(
+            date=self.date_start,
+            debit=500,
+            credit=0,
+            amount_currency=1000,
+        )
+
+        # WHEN
+        res_data = self._get_report_lines(foreign_currency=True)
+        # THEN
+        self.assertTrue(res_data["foreign_currency"])
+        account_lines = self._get_account_lines(
+            self.account100.id, res_data["trial_balance"]
+        )
+        self.assertTrue(account_lines)
+        total = res_data["total_amount"][self.account100.id]
+        self.assertEqual(total["initial_currency_balance"], 2000)
+        self.assertEqual(total["ending_currency_balance"], 3000)


### PR DESCRIPTION
Fixes a KeyError in the Trial Balance report when Show Foreign Currency is enabled and an initial balance exists in a foreign currency. 

### Steps to reproduce

1. Configure a foreign currency.
2. Create a journal entry in that foreign currency with a date before the reporting period.
3. Open the Trial Balance report.
4. Select a reporting period that starts after the journal entry date, so the entry is included in the initial balance.
5. Enable Show Foreign Currency.
6. Generate the report.
7. Observe the following error:

`KeyError: 'amount_currency:sum'`

After this change, the missing key is handled safely and the Trial Balance report is generated successfully with the foreign currency initial balance.