### PR TITLE
[18.0][FIX] account_financial_report: use 'in' on analytic_account_ids domain

### DIFF
--- a/account_financial_report/report/templates/trial_balance.xml
+++ b/account_financial_report/report/templates/trial_balance.xml
@@ -52,7 +52,7 @@
                         <t
                             t-set="aml_domain_extra"
                             t-if="grouped_item['id'] > 0"
-                            t-value="[('analytic_account_ids', '=', grouped_item['id'])]"
+                            t-value="[('analytic_account_ids', 'in', grouped_item['id'])]"
                         />
                         <t
                             t-set="aml_domain_extra"


### PR DESCRIPTION
Open the trial balance grouped by analytic account, click an account to see its move lines, and the log gets this on every click:

```
    The domain term "('analytic_account_ids', '=', [166])" should use the
    'in' or 'not in' operator.

```
The report builds that domain as ('analytic_account_ids', '=', id). The id by itself is fine, but the web client wraps it in a list before the search runs, and analytic_account_ids is a many2many, so '=' against a list is what the ORM complains about.

Changed it to 'in'. The many2many branch in expression.py wraps a bare id into a list itself, so the term is valid as-is. Same move lines, warning gone.