### PR TITLE
[IMP] mis_builder_cash_flow: allow all asset/liability accounts on forecast lines

### DIFF
--- a/mis_builder_cash_flow/data/mis_report.xml
+++ b/mis_builder_cash_flow/data/mis_report.xml
@@ -93,6 +93,9 @@
             name="style_expression"
         >'Cash Flow - Good' if period_balance >= 0.0 else 'Cash Flow - Bad'</field>
     </record>
+    <!-- BALANCE: progressive (running) cash position. Forecast lines are
+         always included; the account-type restriction and the reconciliation
+         filter apply only to real journal items. -->
     <record id="mis_kpi_balance" model="mis.report.kpi">
         <field name="report_id" ref="mis_report_cash_flow" />
         <field name="name">balance</field>
@@ -101,7 +104,7 @@
         <field name="sequence">150</field>
         <field
             name="expression"
-        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), ('line_type', '=', 'move_line'), '|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('account_type', 'in', ('asset_receivable', 'liability_payable')), ('full_reconcile_id', '=', False)]</field>
+        >bale[][('account_id.hide_in_cash_flow', '=', False), '|', ('line_type', '=', 'forecast_line'), '&amp;', '&amp;', ('line_type', '=', 'move_line'), ('full_reconcile_id', '=', False), '|', ('account_type', 'in', ('asset_cash', 'liability_credit_card')), ('account_type', 'in', ('asset_receivable', 'liability_payable'))]</field>
         <field
             name="style_expression"
         >'Cash Flow - Good' if balance >= 0.0 else 'Cash Flow - Bad'</field>

--- a/mis_builder_cash_flow/tests/test_cash_flow.py
+++ b/mis_builder_cash_flow/tests/test_cash_flow.py
@@ -127,6 +127,46 @@ class TestCashFlow(TransactionCase):
             ignore_rows=["balance", "period_balance", "in_total"],
         )
 
+    def test_balance_includes_forecast_on_non_liquidity_account(self):
+        """A forecast line booked on an account whose type is neither
+        liquidity nor receivable/payable (e.g. a current asset such as
+        "Invoices to be issued") must feed the progressive BALANCE row, just
+        as it already feeds PERIOD BALANCE, so that BALANCE keeps continuity
+        with PERIOD BALANCE.
+        """
+        accrual_account = self.env["account.account"].create(
+            {
+                "company_id": self.company.id,
+                "code": "TEST4",
+                "name": "Invoices to be issued",
+                "account_type": "asset_current",
+            }
+        )
+        date = Date.today() + timedelta(weeks=8)
+        self.env["mis.cash_flow.forecast_line"].create(
+            {
+                "account_id": accrual_account.id,
+                "date": date,
+                "balance": 1000,
+                "company_id": self.company.id,
+            }
+        )
+        with mute_logger("odoo.addons.mis_builder.models.kpimatrix"):
+            matrix = self.report._compute_matrix()
+        values = {}
+        for row in matrix.iter_rows():
+            for cell in row.iter_cells():
+                if not cell:
+                    continue
+                values[(row.kpi.name, cell.subcol.col.label)] = cell.val
+        # The forecast feeds the period rows...
+        self.assertEqual(values[("in_forecast", "+8w")], 1000)
+        self.assertEqual(values[("period_balance", "+8w")], 1000)
+        # ...so, with no prior movement, the progressive BALANCE at +8w must
+        # equal it (continuity with PERIOD BALANCE). A missing cell means 0,
+        # which is exactly the regression this guards against.
+        self.assertEqual(values.get(("balance", "+8w"), 0.0), 1000)
+
     def check_matrix(self, args=None, ignore_rows=None):
         if not args:
             args = []

--- a/mis_builder_cash_flow/views/mis_cash_flow_forecast_line_views.xml
+++ b/mis_builder_cash_flow/views/mis_cash_flow_forecast_line_views.xml
@@ -75,7 +75,7 @@
                 <field name="partner_id" />
                 <field
                     name="account_id"
-                    domain="[('company_id', '=', company_id), ('deprecated', '=', False), ('hide_in_cash_flow', '=', False), ('account_type', 'in', ['asset_receivable', 'liability_payable'])]"
+                    domain="[('company_id', '=', company_id), ('deprecated', '=', False), ('hide_in_cash_flow', '=', False), ('account_type', 'in', ['asset_receivable', 'asset_cash', 'asset_current', 'asset_non_current', 'asset_prepayments', 'asset_fixed', 'liability_payable', 'liability_credit_card', 'liability_current', 'liability_non_current'])]"
                 />
                 <field name="balance" />
             </tree>


### PR DESCRIPTION


The account on a cash flow forecast line is informative only (see the field help), and the report never filters forecast lines by account type: the `in_forecast` / `out_forecast` KPIs select them purely by `line_type` and the sign of debit/credit. The editable tree view, however, restricted the account domain to receivable/payable only, preventing legitimate entries such as the capital portion of a loan repayment booked against a non-current liability account (e.g. "Loans payable").

Widen the domain to every balance-sheet account type (all asset_* and liability_*), consistently with the form view, which already imposes no account type restriction. The `hide_in_cash_flow` flag remains available to exclude specific accounts. No computed figure in the report is affected.