### PR TITLE
[19.0][FIX] account_financial_report:  support decimal analytic percentages in XLSX exports

### DIFF
--- a/account_financial_report/report/general_ledger_xlsx.py
+++ b/account_financial_report/report/general_ledger_xlsx.py
@@ -6,6 +6,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
+from odoo.tools.float_utils import float_compare
 
 
 class GeneralLedgerXslx(models.AbstractModel):
@@ -201,13 +202,19 @@ class GeneralLedgerXslx(models.AbstractModel):
                             taxes_description += taxes_data[tax_id]["tax_name"] + " "
                         if line["tax_line_id"]:
                             taxes_description += line["tax_line_id"][1]
-                        for account_ids, value in line["analytic_distribution"].items():
-                            for account_id in account_ids.split(","):
-                                analytic_distribution += (
-                                    f"{analytic_data[int(account_id)]['name']} "
-                                )
-                                if value < 100:
-                                    analytic_distribution += f"{value:d}%"
+                        if report.show_cost_center:
+                            for account_ids, value in line[
+                                "analytic_distribution"
+                            ].items():
+                                for account_id in account_ids.split(","):
+                                    analytic_distribution += (
+                                        f"{analytic_data[int(account_id)]['name']} "
+                                    )
+                                    if (
+                                        float_compare(value, 100, precision_digits=2)
+                                        < 0
+                                    ):
+                                        analytic_distribution += f"{value:g}%"
                         line.update(
                             {
                                 "taxes_description": taxes_description,
@@ -306,23 +313,21 @@ class GeneralLedgerXslx(models.AbstractModel):
                                 taxes_description += (
                                     taxes_data[tax_id]["tax_name"] + " "
                                 )
-                            for account_ids, value in line[
-                                "analytic_distribution"
-                            ].items():
-                                names = " ".join(
-                                    analytic_data[int(account_id.strip())]["name"]
-                                    for account_id in account_ids.split(",")
-                                )
-                                if value < 100:
-                                    analytic_distribution += (
-                                        "%s %d%% ",
-                                        (
-                                            names,
-                                            value,
-                                        ),
+                            if report.show_cost_center:
+                                for account_ids, value in line[
+                                    "analytic_distribution"
+                                ].items():
+                                    names = " ".join(
+                                        analytic_data[int(account_id.strip())]["name"]
+                                        for account_id in account_ids.split(",")
                                     )
-                                else:
-                                    analytic_distribution += f"{names} "
+                                    if (
+                                        float_compare(value, 100, precision_digits=2)
+                                        < 0
+                                    ):
+                                        analytic_distribution += f"{names} {value:g}% "
+                                    else:
+                                        analytic_distribution += f"{names} "
                             line.update(
                                 {
                                     "taxes_description": taxes_description,

--- a/account_financial_report/tests/test_general_ledger.py
+++ b/account_financial_report/tests/test_general_ledger.py
@@ -719,12 +719,27 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
         # single distribution key.
         plan_1 = self.env["account.analytic.plan"].create({"name": "Plan 1"})
         plan_2 = self.env["account.analytic.plan"].create({"name": "Plan 2"})
+        plan_3 = self.env["account.analytic.plan"].create({"name": "Plan 3"})
         analytic_account_1 = self.env["account.analytic.account"].create(
             {"name": "Analytic 1", "plan_id": plan_1.id}
         )
         analytic_account_2 = self.env["account.analytic.account"].create(
             {"name": "Analytic 2", "plan_id": plan_2.id}
         )
+        analytic_account_3 = self.env["account.analytic.account"].create(
+            {"name": "Analytic 3", "plan_id": plan_1.id}
+        )
+        analytic_account_4 = self.env["account.analytic.account"].create(
+            {"name": "Analytic 4", "plan_id": plan_2.id}
+        )
+        analytic_account_5 = self.env["account.analytic.account"].create(
+            {"name": "Analytic 5", "plan_id": plan_3.id}
+        )
+        analytic_distribution = {
+            f"{analytic_account_1.id},{analytic_account_2.id}": 65.36,
+            f"{analytic_account_3.id},{analytic_account_4.id}": 34.64,
+            str(analytic_account_5.id): 99.999999999993,
+        }
         journal = self.env["account.journal"].search(
             [("company_id", "=", company.id)], limit=1
         )
@@ -743,9 +758,7 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
                             "partner_id": self.partner.id,
                             # The receivable account is grouped by partner, so
                             # this line exercises the buggy report branch.
-                            "analytic_distribution": {
-                                f"{analytic_account_1.id},{analytic_account_2.id}": 100,
-                            },
+                            "analytic_distribution": analytic_distribution,
                         },
                     ),
                     (
@@ -756,6 +769,9 @@ class TestGeneralLedgerReport(AccountTestInvoicingCommon):
                             "credit": 1000,
                             "account_id": self.income_account.id,
                             "partner_id": self.partner.id,
+                            # The income account is not grouped, so this line
+                            # also exercises the standard report branch.
+                            "analytic_distribution": analytic_distribution,
                         },
                     ),
                 ],


### PR DESCRIPTION
The General Ledger XLSX exporter used an integer number format for analytic distribution percentages.

When a distribution contained decimal percentages, such as `65.36%` and `34.64%`, XLSX generation failed because the exporter attempted to apply an integer format.

Additionally, analytic distributions were processed even when the “Show Analytic Account” option was disabled. The grouped report also contained an invalid concatenation between a string and a tuple.

<img width="611" height="690" alt="image" src="https://github.com/user-attachments/assets/51d6159b-dcf1-4edc-a518-3541665b12e4" />
