### PR TITLE
[18.0][FIX] account_financial_report: Define the appropriate group in the menu

### DIFF
--- a/account_financial_report/menuitems.xml
+++ b/account_financial_report/menuitems.xml
@@ -4,7 +4,7 @@
         parent="account.menu_finance_reports"
         id="menu_oca_reports"
         name="OCA accounting reports"
-        groups="account.group_account_user"
+        groups="account.group_account_readonly"
     />
     <menuitem
         parent="menu_oca_reports"


### PR DESCRIPTION
A user with the "Show Accounting Features - Read-only" group (`account.group_account_readonly`) should be able to view the menu

Please @pedrobaeza can you review it?

@Tecnativa TT63708