### PR TITLE
[18.0][FIX] account_financial_report: guard against a null iframe document in enrich()

### DIFF
--- a/account_financial_report/static/src/js/report.esm.js
+++ b/account_financial_report/static/src/js/report.esm.js
@@ -21,6 +21,13 @@ function enrich(component, targetElement, selector, isIFrame = false) {
         doc = contentDocument;
     }
 
+    // The iframe may be detached, or its document not yet accessible, when the
+    // load event fires. contentDocument is then null and every call below
+    // throws "Cannot read properties of null (reading 'querySelectorAll')".
+    if (!contentDocument) {
+        return;
+    }
+
     // If there are selector, we may have multiple blocks of code to enrich
     const targets = [];
     if (selector) {


### PR DESCRIPTION
## Problem

Opening a financial report can raise, in the browser console:

```
TypeError: Cannot read properties of null (reading 'querySelectorAll')
    at enrich (web.assets_web.min.js)
    at HTMLIFrameElement.<anonymous>
```

The user is left with Odoo's generic client-error dialog.

## Cause

In `account_financial_report/static/src/js/report.esm.js`, `enrich()` reads the iframe document:

```js
if (isIFrame) {
    contentDocument = targetElement.contentDocument;
    doc = contentDocument;
}
```

and then uses it without any guard:

```js
targets.push(...contentDocument.querySelectorAll(selector));
```

The `load` event can fire while the iframe is already detached from the DOM, or before its
document is accessible. `contentDocument` is then `null` and the call throws.

## Fix

An early return when `contentDocument` is null.

## Note

The same pattern exists in Odoo core, in
`web/static/src/webclient/actions/reports/report_hook.js`, from which this file was derived.
It carries the same missing guard and is presumably affected too.

## Environment

Odoo 18.0, reproduced on a live database while navigating away from a report during loading.
