### PR TITLE
[17.0][FIX] account_financial_report: Don't re-read P&L accounts

### DIFF
--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -177,23 +177,6 @@ class GeneralLedgerReport(models.AbstractModel):
         gl_initial_acc = self._get_accounts_initial_balance(
             initial_domain_bs, initial_domain_pl
         )
-        if grouped_by != "none":
-            return gl_initial_acc
-        # If grouped_by none we add balance
-        domain = list(base_domain) + [("date", "<", date_from)]
-        if account_ids:
-            domain += [("account_id", "in", account_ids)]
-        rows = self.env["account.move.line"].read_group(
-            domain=domain,
-            fields=["account_id", "debit", "credit", "balance", "amount_currency:sum"],
-            groupby=["account_id"],
-        )
-        covered_ids = {
-            row["account_id"][0] for row in gl_initial_acc if row.get("account_id")
-        }
-        for row in rows:
-            if row.get("account_id") and row["account_id"][0] not in covered_ids:
-                gl_initial_acc.append(row)
         return gl_initial_acc
 
     def _prepare_gen_ld_data_item(self, gl):


### PR DESCRIPTION
Backport of #1561

The PR #1504 was adding this part of code as part of the fix, while it's enough with just the other part. This code is provoking that for P&L accounts, the initial balance is computed, while they shouldn't, as they by definition should be 0.

Maybe the misunderstanding was to not find that accounts and think they should be there.

@Tecnativa TT64215