### PR TITLE
[19.0][FIX] account_financial_report: Guard report enrichment

### DIFF
--- a/account_financial_report/static/src/js/report.esm.js
+++ b/account_financial_report/static/src/js/report.esm.js
@@ -17,6 +17,9 @@ function enrich(component, targetElement, selector, isIFrame = false) {
     // both for the element and the doc
     if (isIFrame) {
         contentDocument = targetElement.contentDocument;
+        if (!contentDocument) {
+            return;
+        }
         doc = contentDocument;
     }
 

--- a/account_financial_report/static/src/js/report_action.esm.js
+++ b/account_financial_report/static/src/js/report_action.esm.js
@@ -10,7 +10,9 @@ patch(ReportAction.prototype, {
         this.isAccountFinancialReport = this.props.report_name.startsWith(
             `${MODULE_NAME}.`
         );
-        useEnrichWithActionLinks(this.iframe);
+        if (this.isAccountFinancialReport) {
+            useEnrichWithActionLinks(this.iframe);
+        }
     },
 
     export() {


### PR DESCRIPTION
Fixes #1524

## Summary

- scope the custom action-link enrichment hook to `account_financial_report` reports
- ignore iframe load events until `contentDocument` is available

## Verification

- `SKIP=oca-gen-addon-readme pre-commit run --all-files --show-diff-on-failure --color=always` (passes)
- GitHub CI and Runboat remain the integration checks for the Odoo browser suite / `oca_run_tests`

## Ownership
I reviewed, understand, and take responsibility for every line in this contribution.