### PR TITLE
[18.0][FIX] account_financial_report: strip HTML from tax descriptions on journal ledger

### DIFF
--- a/account_financial_report/__manifest__.py
+++ b/account_financial_report/__manifest__.py
@@ -6,7 +6,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 {
     "name": "Account Financial Reports",
-    "version": "18.0.1.4.24",
+    "version": "18.0.1.4.25",
     "category": "Reporting",
     "summary": "OCA Financial Reports",
     "author": "Camptocamp,"

--- a/account_financial_report/tests/test_journal_ledger.py
+++ b/account_financial_report/tests/test_journal_ledger.py
@@ -280,3 +280,25 @@ class TestJournalReport(AccountTestInvoicingCommon):
 
         self.check_report_journal_debit_credit(res_data, 250, 250)
         self.check_report_journal_debit_credit_taxes(res_data, 300, 0, 50, 0)
+
+    def test_04_tax_description_html_is_plain_text(self):
+        html_desc = '<div data-oe-version="1.1">IGIC 7%</div>'
+        wiz = self.JournalLedgerReportWizard.create(
+            {
+                "date_from": self.fy_date_start,
+                "date_to": self.fy_date_end,
+                "company_id": self.company.id,
+                "journal_ids": [(6, 0, self.journal_sale.ids)],
+                "label_text_limit": 4,
+            }
+        )
+        desc = wiz._get_ml_tax_description(
+            {"tax_line_id": 1},
+            {"description": html_desc, "name": "Tax 7%"},
+            {},
+        )
+        self.assertEqual(desc, "IGIC 7%")
+        self.assertNotIn("<", desc)
+        limited = wiz._limit_text(html_desc)
+        self.assertEqual(limited, "IGIC...")
+        self.assertNotIn("<", limited)

--- a/account_financial_report/wizard/abstract_wizard.py
+++ b/account_financial_report/wizard/abstract_wizard.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import fields, models
+from odoo.tools import html2plaintext
 
 
 class AbstractWizard(models.AbstractModel):
@@ -54,7 +55,14 @@ class AbstractWizard(models.AbstractModel):
         report_type = "xlsx"
         return self._export(report_type)
 
+    def _plain_label(self, value):
+        """QWeb t-esc does not escape Markup; tax.description is Html in 18.0."""
+        if not value:
+            return value or ""
+        return html2plaintext(str(value)).strip()
+
     def _limit_text(self, value, limit_field="label_text_limit"):
+        value = self._plain_label(value)
         limit = self[limit_field]
         if value and limit and len(value) > limit:
             value = value[:limit] + "..."

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -135,12 +135,14 @@ class JournalLedgerReportWizard(models.TransientModel):
     ):
         taxes_description = ""
         if move_line_data["tax_line_id"]:
-            taxes_description = tax_line_data["description"] or tax_line_data["name"]
+            taxes_description = self._plain_label(
+                tax_line_data["description"] or tax_line_data["name"]
+            )
         elif move_line_taxes_data:
             tax_names = []
             for tax_key in move_line_taxes_data:
                 tax = move_line_taxes_data[tax_key]
-                tax_names.append(tax["description"] or tax["name"])
+                tax_names.append(self._plain_label(tax["description"] or tax["name"]))
             taxes_description = ",".join(tax_names)
         return taxes_description
 


### PR DESCRIPTION
Fixes #1545

## Summary

- `account.tax.description` is Html in 18.0, so QWeb `t-esc` injects `Markup` into the Journal Ledger
- `limit_text` was slicing that Markup mid-tag and leaving unclosed `<div>`s (staircase layout)
- convert descriptions to plaintext with `html2plaintext` before display and truncation

## Verification

- `python3 -m ast` parse of the changed wizard and test files
- new unit test `test_04_tax_description_html_is_plain_text` covers a web-editor wrapped description (`<div data-oe-version="1.1">IGIC 7%</div>`) and truncation without leftover `<`
- hosted Odoo / Runboat remain the integration checks (`oca_run_tests`)

## Ownership
I reviewed, understand, and take responsibility for every line in this contribution.

## Upstream integration

Merged current 18.0 and resolved the manifest-version conflict by advancing the module to 18.0.1.4.27. The existing HTML-to-plaintext correction and regression test remain intact, together with upstream report and translation changes.

Local pre-commit checks pass for the manifest, changed wizard files and regression test, excluding the README generator. That generator rewrote unrelated generated documentation in this local environment; those incidental changes were discarded. Hosted pre-commit, Odoo, OCB, coverage and Runboat checks all pass. The local machine has neither the OCA runtime nor Docker.
