### PR TITLE
[16.0][IMP] account_financial_report : read wizard data directly

### DIFF
--- a/account_financial_report/report/aged_partner_balance.py
+++ b/account_financial_report/report/aged_partner_balance.py
@@ -3,10 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import operator
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from odoo import api, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, format_date
 
 
 class AgedPartnerBalanceReport(models.AbstractModel):
@@ -405,56 +405,45 @@ class AgedPartnerBalanceReport(models.AbstractModel):
     def _get_report_values(self, docids, data):
         res = super()._get_report_values(docids, data)
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        account_ids = data["account_ids"]
-        partner_ids = data["partner_ids"]
-        date_at = data["date_at"]
-        date_at_object = datetime.strptime(date_at, "%Y-%m-%d").date()
-        date_from = data["date_from"]
-        only_posted_moves = data["only_posted_moves"]
-        show_move_line_details = data["show_move_line_details"]
-        aged_partner_configuration = self.env[
-            "account.age.report.configuration"
-        ].browse(data["age_partner_config_id"])
+        wizard = self.env["aged.partner.balance.report.wizard"].browse(wizard_id)
+        only_posted_moves = wizard.target_move == "posted"
+
         (ag_pb_data, accounts_data, partners_data, journals_data,) = self.with_context(
-            age_partner_config=aged_partner_configuration
+            age_partner_config=wizard.age_partner_config_id
         )._get_move_lines_data(
-            company_id,
-            account_ids,
-            partner_ids,
-            date_at_object,
-            date_from,
+            wizard.company_id.id,
+            wizard.account_ids.ids,
+            wizard.partner_ids.ids,
+            wizard.date_at,
+            wizard.date_from or False,
             only_posted_moves,
-            show_move_line_details,
+            wizard.show_move_line_details,
         )
         aged_partner_data = self.with_context(
-            age_partner_config=aged_partner_configuration
+            age_partner_config=wizard.age_partner_config_id
         )._create_account_list(
             ag_pb_data,
             accounts_data,
             partners_data,
             journals_data,
-            show_move_line_details,
-            date_at_object,
+            wizard.show_move_line_details,
+            wizard.date_at,
         )
         aged_partner_data = self.with_context(
-            age_partner_config=aged_partner_configuration
+            age_partner_config=wizard.age_partner_config_id
         )._calculate_percent(aged_partner_data)
         res.update(
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "aged.partner.balance.report.wizard",
-                "docs": self.env["aged.partner.balance.report.wizard"].browse(
-                    wizard_id
-                ),
-                "company_name": company.display_name,
-                "currency_name": company.currency_id.name,
-                "date_at": date_at,
+                "docs": wizard,
+                "company_name": wizard.company_id.display_name,
+                "currency_name": wizard.company_id.currency_id.name,
+                "date_at": format_date(self.env, wizard.date_at),
                 "only_posted_moves": only_posted_moves,
                 "aged_partner_balance": aged_partner_data,
-                "show_move_lines_details": show_move_line_details,
-                "age_partner_config": aged_partner_configuration,
+                "show_move_lines_details": wizard.show_move_line_details,
+                "age_partner_config": wizard.age_partner_config_id,
             }
         )
         return res

--- a/account_financial_report/report/general_ledger.py
+++ b/account_financial_report/report/general_ledger.py
@@ -8,7 +8,7 @@ import datetime
 import operator
 
 from odoo import _, api, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, format_date
 
 
 class GeneralLedgerReport(models.AbstractModel):
@@ -776,34 +776,23 @@ class GeneralLedgerReport(models.AbstractModel):
     def _get_report_values(self, docids, data):
         res = super()._get_report_values(docids, data)
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        date_to = data["date_to"]
-        date_from = data["date_from"]
-        partner_ids = data["partner_ids"]
-        account_ids = data["account_ids"]
-        cost_center_ids = data["cost_center_ids"]
-        grouped_by = data["grouped_by"]
-        hide_account_at_0 = data["hide_account_at_0"]
-        foreign_currency = data["foreign_currency"]
-        only_posted_moves = data["only_posted_moves"]
-        unaffected_earnings_account = data["unaffected_earnings_account"]
-        fy_start_date = data["fy_start_date"]
-        extra_domain = data["domain"]
+        wizard = self.env["general.ledger.report.wizard"].browse(wizard_id)
+        company = wizard.company_id
+        only_posted_moves = wizard.target_move == "posted"
+        extra_domain = wizard._get_account_move_lines_domain()
         gen_ld_data = self._get_initial_balance_data(
-            account_ids,
-            partner_ids,
-            company_id,
-            date_from,
-            foreign_currency,
+            wizard.account_ids.ids,
+            wizard.partner_ids.ids,
+            wizard.company_id.id,
+            wizard.date_from,
+            wizard.foreign_currency,
             only_posted_moves,
-            unaffected_earnings_account,
-            fy_start_date,
-            cost_center_ids,
+            wizard.unaffected_earnings_account.id,
+            wizard.fy_start_date,
+            wizard.cost_center_ids,
             extra_domain,
-            grouped_by,
+            wizard.grouped_by,
         )
-        centralize = data["centralize"]
         (
             gen_ld_data,
             accounts_data,
@@ -813,26 +802,28 @@ class GeneralLedgerReport(models.AbstractModel):
             analytic_data,
             rec_after_date_to_ids,
         ) = self._get_period_ml_data(
-            account_ids,
-            partner_ids,
-            company_id,
-            foreign_currency,
-            only_posted_moves,
-            date_from,
-            date_to,
+            wizard.account_ids.ids,
+            wizard.partner_ids.ids,
+            wizard.company_id.id,
+            wizard.foreign_currency,
+            wizard.target_move == "posted",
+            wizard.date_from,
+            wizard.date_to,
             gen_ld_data,
-            cost_center_ids,
+            wizard.cost_center_ids,
             extra_domain,
-            grouped_by,
+            wizard.grouped_by,
         )
         general_ledger = self._create_general_ledger(
             gen_ld_data,
             accounts_data,
-            grouped_by,
+            wizard.grouped_by,
             rec_after_date_to_ids,
-            hide_account_at_0,
+            wizard.hide_account_at_0,
         )
-        if centralize:
+        if wizard.centralize:
+            date_to = wizard.date_to
+            grouped_by = wizard.grouped_by
             for account in general_ledger:
                 if account["centralized"]:
                     centralized_ml = self._get_centralized_ml(
@@ -851,7 +842,7 @@ class GeneralLedgerReport(models.AbstractModel):
         # Set the bal_curr of the initial balance to 0 if it does not correspond
         # (reducing the corresponding of the bal_curr of the initial balance).
         for gl_item in general_ledger:
-            if not foreign_currency:
+            if not wizard.foreign_currency:
                 continue
             if not gl_item["currency_id"] or (
                 gl_item["currency_id"] != company.currency_id.id
@@ -870,7 +861,7 @@ class GeneralLedgerReport(models.AbstractModel):
         for gl_item in general_ledger:
             fin_bal_currency_ids = []
             fin_bal_currency_id = gl_item["currency_id"]
-            if gl_item["currency_id"] or not foreign_currency:
+            if gl_item["currency_id"] or not wizard.foreign_currency:
                 gl_item["fin_bal_currency_id"] = fin_bal_currency_id
                 continue
             gl_item["fin_bal"]["bal_curr"] = gl_item["init_bal"]["bal_curr"]
@@ -907,24 +898,24 @@ class GeneralLedgerReport(models.AbstractModel):
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "general.ledger.report.wizard",
-                "docs": self.env["general.ledger.report.wizard"].browse(wizard_id),
-                "foreign_currency": data["foreign_currency"],
+                "docs": wizard,
+                "foreign_currency": wizard.foreign_currency,
                 "company_name": company.display_name,
                 "company_currency": company.currency_id,
                 "currency_name": company.currency_id.name,
-                "date_from": data["date_from"],
-                "date_to": data["date_to"],
-                "only_posted_moves": data["only_posted_moves"],
-                "hide_account_at_0": data["hide_account_at_0"],
-                "show_cost_center": data["show_cost_center"],
+                "date_from": format_date(self.env, wizard.date_from),
+                "date_to": format_date(self.env, wizard.date_to),
+                "only_posted_moves": only_posted_moves,
+                "hide_account_at_0": wizard.hide_account_at_0,
+                "show_cost_center": wizard.show_cost_center,
                 "general_ledger": general_ledger,
                 "accounts_data": accounts_data,
                 "journals_data": journals_data,
                 "full_reconcile_data": full_reconcile_data,
                 "taxes_data": taxes_data,
-                "centralize": centralize,
+                "centralize": wizard.centralize,
                 "analytic_data": analytic_data,
-                "filter_partner_ids": True if partner_ids else False,
+                "filter_partner_ids": bool(wizard.partner_ids),
                 "currency_model": self.env["res.currency"],
             }
         )

--- a/account_financial_report/report/journal_ledger.py
+++ b/account_financial_report/report/journal_ledger.py
@@ -306,9 +306,10 @@ class JournalLedgerReport(models.AbstractModel):
         res = super()._get_report_values(docids, data)
         wizard_id = data["wizard_id"]
         wizard = self.env["journal.ledger.report.wizard"].browse(wizard_id)
-        company = self.env["res.company"].browse(data["company_id"])
-        journal_ids = data["journal_ids"]
-        journal_ledgers_data = self._get_journal_ledgers(wizard, journal_ids, company)
+        journal_ledgers_data = self._get_journal_ledgers(
+            wizard, wizard.journal_ids.ids, wizard.company_id
+        )
+        journal_ids = [journal["id"] for journal in journal_ledgers_data]
         move_ids, moves_data, move_ids_data = self._get_moves(wizard, journal_ids)
         journal_moves_data = {}
         for key, items in itertools.groupby(
@@ -361,16 +362,16 @@ class JournalLedgerReport(models.AbstractModel):
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "journal.ledger.report.wizard",
-                "docs": self.env["journal.ledger.report.wizard"].browse(wizard_id),
-                "group_option": data["group_option"],
-                "foreign_currency": data["foreign_currency"],
-                "with_account_name": data["with_account_name"],
-                "company_name": company.display_name,
-                "currency_name": company.currency_id.name,
-                "date_from": data["date_from"],
-                "date_to": data["date_to"],
-                "move_target": data["move_target"],
-                "with_auto_sequence": data["with_auto_sequence"],
+                "docs": wizard,
+                "group_option": wizard.group_option,
+                "foreign_currency": wizard.foreign_currency,
+                "with_account_name": wizard.with_account_name,
+                "company_name": wizard.company_id.display_name,
+                "currency_name": wizard.company_id.currency_id.name,
+                "date_from": wizard.date_from,
+                "date_to": wizard.date_to,
+                "move_target": wizard.move_target,
+                "with_auto_sequence": wizard.with_auto_sequence,
                 "account_ids_data": account_ids_data,
                 "partner_ids_data": partner_ids_data,
                 "currency_ids_data": currency_ids_data,

--- a/account_financial_report/report/open_items.py
+++ b/account_financial_report/report/open_items.py
@@ -4,10 +4,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 import operator
-from datetime import date, datetime
+from datetime import date
 
 from odoo import _, api, models
-from odoo.tools import float_is_zero
+from odoo.tools import float_is_zero, format_date
 
 
 class OpenItemsReport(models.AbstractModel):
@@ -245,16 +245,9 @@ class OpenItemsReport(models.AbstractModel):
     def _get_report_values(self, docids, data):
         res = super()._get_report_values(docids, data)
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        account_ids = data["account_ids"]
-        partner_ids = data["partner_ids"]
-        date_at = data["date_at"]
-        date_at_object = datetime.strptime(date_at, "%Y-%m-%d").date()
-        date_from = data["date_from"]
-        only_posted_moves = data["only_posted_moves"]
-        show_partner_details = data["show_partner_details"]
-        grouped_by = data["grouped_by"]
+        wizard = self.env["open.items.report.wizard"].browse(wizard_id)
+        only_posted_moves = wizard.target_move == "posted"
+
         (
             move_lines_data,
             partners_data,
@@ -262,19 +255,19 @@ class OpenItemsReport(models.AbstractModel):
             accounts_data,
             open_items_move_lines_data,
         ) = self._get_data(
-            account_ids,
-            partner_ids,
-            date_at_object,
+            wizard.account_ids.ids,
+            wizard.partner_ids.ids,
+            wizard.date_at,
             only_posted_moves,
-            company_id,
-            date_from,
-            grouped_by,
+            wizard.company_id.id,
+            wizard.date_from,
+            wizard.grouped_by,
         )
 
         total_amount = self._calculate_amounts(open_items_move_lines_data)
         open_items_move_lines_data = self._order_open_items_by_date(
             open_items_move_lines_data,
-            show_partner_details,
+            wizard.show_partner_details,
             partners_data,
             accounts_data,
         )
@@ -282,20 +275,20 @@ class OpenItemsReport(models.AbstractModel):
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "open.items.report.wizard",
-                "docs": self.env["open.items.report.wizard"].browse(wizard_id),
-                "foreign_currency": data["foreign_currency"],
-                "show_partner_details": data["show_partner_details"],
-                "company_name": company.display_name,
-                "currency_name": company.currency_id.name,
-                "date_at": date_at_object.strftime("%d/%m/%Y"),
-                "hide_account_at_0": data["hide_account_at_0"],
-                "target_move": data["target_move"],
+                "docs": wizard,
+                "foreign_currency": wizard.foreign_currency,
+                "show_partner_details": wizard.show_partner_details,
+                "company_name": wizard.company_id.display_name,
+                "currency_name": wizard.company_id.currency_id.name,
+                "date_at": format_date(self.env, wizard.date_at),
+                "hide_account_at_0": wizard.hide_account_at_0,
+                "target_move": wizard.target_move,
                 "journals_data": journals_data,
                 "partners_data": partners_data,
                 "accounts_data": accounts_data,
                 "total_amount": total_amount,
                 "Open_Items": open_items_move_lines_data,
-                "grouped_by": grouped_by,
+                "grouped_by": wizard.grouped_by,
             }
         )
         return res

--- a/account_financial_report/report/trial_balance.py
+++ b/account_financial_report/report/trial_balance.py
@@ -911,49 +911,33 @@ class TrialBalanceReport(models.AbstractModel):
 
     def _get_report_values(self, docids, data):
         res = super()._get_report_values(docids, data)
-        show_partner_details = data["show_partner_details"]
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        partner_ids = data["partner_ids"]
-        journal_ids = data["journal_ids"]
-        account_ids = data["account_ids"]
-        date_to = data["date_to"]
-        date_from = data["date_from"]
-        hide_account_at_0 = data["hide_account_at_0"]
-        hide_account_at_end_0 = data["hide_account_at_end_0"]
-        show_hierarchy = data["show_hierarchy"]
-        show_hierarchy_level = data["show_hierarchy_level"]
-        foreign_currency = data["foreign_currency"]
-        only_posted_moves = data["only_posted_moves"]
-        unaffected_earnings_account = data["unaffected_earnings_account"]
-        fy_start_date = data["fy_start_date"]
-        grouped_by = data["grouped_by"]
+        wizard = self.env["trial.balance.report.wizard"].browse(wizard_id)
         total_amount, accounts_data, partners_data = self._get_data(
-            account_ids,
-            journal_ids,
-            partner_ids,
-            company_id,
-            date_to,
-            date_from,
-            foreign_currency,
-            only_posted_moves,
-            show_partner_details,
-            hide_account_at_0,
-            hide_account_at_end_0,
-            unaffected_earnings_account,
-            fy_start_date,
-            grouped_by,
+            wizard.account_ids.ids,
+            wizard.journal_ids.ids,
+            wizard.partner_ids.ids,
+            wizard.company_id.id,
+            wizard.date_to,
+            wizard.date_from,
+            wizard.foreign_currency,
+            wizard.target_move == "posted",
+            wizard.show_partner_details,
+            wizard.hide_account_at_0,
+            wizard.hide_account_at_end_0,
+            wizard.unaffected_earnings_account.id,
+            wizard.fy_start_date,
+            wizard.grouped_by,
         )
         trial_balance_grouped = False
         total_amount_grouped = False
-        if grouped_by:
+        if wizard.grouped_by:
             trial_balance_grouped, total_amount_grouped = self._get_data_grouped(
-                total_amount, accounts_data, foreign_currency
+                total_amount, accounts_data, wizard.foreign_currency
             )
         trial_balance = []
-        if not show_partner_details:
-            for account_id in accounts_data.keys():
+        if not wizard.show_partner_details:
+            for account_id in accounts_data:
                 accounts_data[account_id].update(
                     {
                         "initial_balance": total_amount[account_id]["initial_balance"],
@@ -974,7 +958,7 @@ class TrialBalanceReport(models.AbstractModel):
                         "type": "account_type",
                     }
                 )
-                if foreign_currency:
+                if wizard.foreign_currency:
                     accounts_data[account_id].update(
                         {
                             "ending_currency_balance": total_amount[account_id][
@@ -985,9 +969,9 @@ class TrialBalanceReport(models.AbstractModel):
                             ],
                         }
                     )
-            if show_hierarchy:
+            if wizard.show_hierarchy:
                 groups_data = self._get_groups_data(
-                    accounts_data, total_amount, foreign_currency
+                    accounts_data, total_amount, wizard.foreign_currency
                 )
                 trial_balance = list(groups_data.values())
                 trial_balance += list(accounts_data.values())
@@ -999,8 +983,8 @@ class TrialBalanceReport(models.AbstractModel):
                 trial_balance = list(accounts_data.values())
                 trial_balance = sorted(trial_balance, key=lambda k: k["code"])
         else:
-            if foreign_currency:
-                for account_id in accounts_data.keys():
+            if wizard.foreign_currency:
+                for account_id in accounts_data:
                     total_amount[account_id]["currency_id"] = accounts_data[account_id][
                         "currency_id"
                     ]
@@ -1011,29 +995,29 @@ class TrialBalanceReport(models.AbstractModel):
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "trial.balance.report.wizard",
-                "docs": self.env["trial.balance.report.wizard"].browse(wizard_id),
-                "foreign_currency": data["foreign_currency"],
-                "company_name": company.display_name,
-                "company_currency": company.currency_id,
-                "currency_name": company.currency_id.name,
-                "date_from": data["date_from"],
-                "date_to": data["date_to"],
-                "only_posted_moves": data["only_posted_moves"],
-                "hide_account_at_0": data["hide_account_at_0"],
-                "hide_account_at_end_0": data["hide_account_at_end_0"],
-                "show_partner_details": data["show_partner_details"],
-                "limit_hierarchy_level": data["limit_hierarchy_level"],
-                "show_hierarchy": show_hierarchy,
-                "hide_parent_hierarchy_level": data["hide_parent_hierarchy_level"],
+                "docs": wizard,
+                "foreign_currency": wizard.foreign_currency,
+                "company_name": wizard.company_id.display_name,
+                "company_currency": wizard.company_id.currency_id,
+                "currency_name": wizard.company_id.currency_id.name,
+                "date_from": wizard.date_from,
+                "date_to": wizard.date_to,
+                "only_posted_moves": wizard.target_move == "posted",
+                "hide_account_at_0": wizard.hide_account_at_0,
+                "hide_account_at_end_0": wizard.hide_account_at_end_0,
+                "show_partner_details": wizard.show_partner_details,
+                "limit_hierarchy_level": wizard.limit_hierarchy_level,
+                "show_hierarchy": wizard.show_hierarchy,
+                "hide_parent_hierarchy_level": wizard.hide_parent_hierarchy_level,
                 "trial_balance": trial_balance,
                 "trial_balance_grouped": trial_balance_grouped,
                 "total_amount": total_amount,
                 "total_amount_grouped": total_amount_grouped,
                 "accounts_data": accounts_data,
                 "partners_data": partners_data,
-                "show_hierarchy_level": show_hierarchy_level,
+                "show_hierarchy_level": wizard.show_hierarchy_level,
                 "currency_model": self.env["res.currency"],
-                "grouped_by": grouped_by,
+                "grouped_by": wizard.grouped_by,
             }
         )
         return res

--- a/account_financial_report/report/vat_report.py
+++ b/account_financial_report/report/vat_report.py
@@ -4,7 +4,7 @@
 
 import operator
 
-from odoo import api, fields, models
+from odoo import api, models
 
 
 class VATReport(models.AbstractModel):
@@ -200,39 +200,32 @@ class VATReport(models.AbstractModel):
     def _get_report_values(self, docids, data):
         res = super()._get_report_values(docids, data)
         wizard_id = data["wizard_id"]
-        company = self.env["res.company"].browse(data["company_id"])
-        company_id = data["company_id"]
-        date_from = fields.Date.from_string(data["date_from"])
-        date_to = fields.Date.from_string(data["date_to"])
-        based_on = data["based_on"]
-        tax_detail = data["tax_detail"]
-        only_posted_moves = data["only_posted_moves"]
+        wizard = self.env["vat.report.wizard"].browse(wizard_id)
+        only_posted_moves = wizard.target_move == "posted"
         vat_report_data, tax_data = self._get_vat_report_data(
-            company_id, date_from, date_to, only_posted_moves
+            wizard.company_id.id, wizard.date_from, wizard.date_to, only_posted_moves
         )
-        if based_on == "taxgroups":
+        if wizard.based_on == "taxgroups":
             vat_report = self._get_vat_report_group_data(
-                vat_report_data, tax_data, tax_detail
+                vat_report_data, tax_data, wizard.tax_detail
             )
         else:
             vat_report = self._get_vat_report_tag_data(
-                vat_report_data, tax_data, tax_detail
+                vat_report_data, tax_data, wizard.tax_detail
             )
         res.update(
             {
                 "doc_ids": [wizard_id],
                 "doc_model": "vat.report.wizard",
-                "docs": self.env["vat.report.wizard"].browse(wizard_id),
-                "company_name": company.display_name,
-                "currency_name": company.currency_id.name,
-                "date_from": date_from,
-                "date_to": date_to,
+                "docs": wizard,
+                "company_name": wizard.company_id.display_name,
+                "currency_name": wizard.company_id.currency_id.name,
+                "date_from": wizard.date_from,
+                "date_to": wizard.date_to,
                 "based_on": dict(
-                    self.env["vat.report.wizard"]
-                    ._fields["based_on"]
-                    ._description_selection(self.env)
-                ).get(data["based_on"]),
-                "tax_detail": data["tax_detail"],
+                    wizard._fields["based_on"]._description_selection(self.env)
+                ).get(wizard.based_on),
+                "tax_detail": wizard.tax_detail,
                 "vat_report": vat_report,
             }
         )

--- a/account_financial_report/tests/test_aged_partner_balance.py
+++ b/account_financial_report/tests/test_aged_partner_balance.py
@@ -3,7 +3,7 @@
 #  License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo.tests import TransactionCase
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, test_reports
+from odoo.tools import test_reports
 
 
 class TestAgedPartnerBalance(TransactionCase):
@@ -69,8 +69,6 @@ class TestAgedPartnerBalance(TransactionCase):
         data = wizard._prepare_report_data()
 
         # Simulate web client behavior:
-        # default value is a datetime.date but web client sends back strings
-        data.update({"date_at": data["date_at"].strftime(DEFAULT_SERVER_DATE_FORMAT)})
         result = test_reports.try_report(
             self.env.cr,
             self.env.uid,
@@ -85,8 +83,6 @@ class TestAgedPartnerBalance(TransactionCase):
         data = second_wizard._prepare_report_data()
 
         # Simulate web client behavior:
-        # default value is a datetime.date but web client sends back strings
-        data.update({"date_at": data["date_at"].strftime(DEFAULT_SERVER_DATE_FORMAT)})
         result = test_reports.try_report(
             self.env.cr,
             self.env.uid,
@@ -128,8 +124,6 @@ class TestAgedPartnerBalance(TransactionCase):
         data = wizard._prepare_report_data()
 
         # Simulate web client behavior:
-        # default value is a datetime.date but web client sends back strings
-        data.update({"date_at": data["date_at"].strftime(DEFAULT_SERVER_DATE_FORMAT)})
         result = test_reports.try_report(
             self.env.cr,
             self.env.uid,
@@ -146,8 +140,6 @@ class TestAgedPartnerBalance(TransactionCase):
         data = second_wizard._prepare_report_data()
 
         # Simulate web client behavior:
-        # default value is a datetime.date but web client sends back strings
-        data.update({"date_at": data["date_at"].strftime(DEFAULT_SERVER_DATE_FORMAT)})
         result = test_reports.try_report(
             self.env.cr,
             self.env.uid,

--- a/account_financial_report/tests/test_open_items.py
+++ b/account_financial_report/tests/test_open_items.py
@@ -86,5 +86,4 @@ class TestOpenItems(AccountTestInvoicingCommon):
             }
         )
         wizard.on_change_account_range()
-        res = wizard._prepare_report_data()
-        self.assertEqual(res["grouped_by"], wizard.grouped_by)
+        wizard._prepare_report_data()

--- a/account_financial_report/wizard/aged_partner_balance_wizard.py
+++ b/account_financial_report/wizard/aged_partner_balance_wizard.py
@@ -131,23 +131,6 @@ class AgedPartnerBalanceWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        res.update(
-            {
-                "date_at": self.date_at,
-                "date_from": self.date_from or False,
-                "only_posted_moves": self.target_move == "posted",
-                "company_id": self.company_id.id,
-                "account_ids": self.account_ids.ids,
-                "partner_ids": self.partner_ids.ids,
-                "show_move_line_details": self.show_move_line_details,
-                "account_financial_report_lang": self.env.lang,
-                "age_partner_config_id": self.age_partner_config_id.id,
-            }
-        )
-        return res
-
     def _export(self, report_type):
         """Default export is PDF."""
         return self._print_report(report_type)

--- a/account_financial_report/wizard/general_ledger_wizard.py
+++ b/account_financial_report/wizard/general_ledger_wizard.py
@@ -283,32 +283,6 @@ class GeneralLedgerReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        res.update(
-            {
-                "wizard_id": self.id,
-                "date_from": self.date_from,
-                "date_to": self.date_to,
-                "only_posted_moves": self.target_move == "posted",
-                "hide_account_at_0": self.hide_account_at_0,
-                "foreign_currency": self.foreign_currency,
-                "company_id": self.company_id.id,
-                "account_ids": self.account_ids.ids,
-                "partner_ids": self.partner_ids.ids,
-                "grouped_by": self.grouped_by,
-                "cost_center_ids": self.cost_center_ids.ids,
-                "show_cost_center": self.show_cost_center,
-                "journal_ids": self.account_journal_ids.ids,
-                "centralize": self.centralize,
-                "fy_start_date": self.fy_start_date,
-                "unaffected_earnings_account": self.unaffected_earnings_account.id,
-                "account_financial_report_lang": self.env.lang,
-                "domain": self._get_account_move_lines_domain(),
-            }
-        )
-        return res
-
     def _export(self, report_type):
         """Default export is PDF."""
         return self._print_report(report_type)

--- a/account_financial_report/wizard/journal_ledger_wizard.py
+++ b/account_financial_report/wizard/journal_ledger_wizard.py
@@ -89,33 +89,6 @@ class JournalLedgerReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        journals = self.journal_ids
-        if not journals:
-            # Not selecting a journal means that we'll display all journals
-            journals = (
-                self.env["account.journal"]
-                .with_context(active_test=False)
-                .search([("company_id", "=", self.company_id.id)])
-            )
-        res.update(
-            {
-                "date_from": self.date_from,
-                "date_to": self.date_to,
-                "move_target": self.move_target,
-                "foreign_currency": self.foreign_currency,
-                "company_id": self.company_id.id,
-                "journal_ids": journals.ids,
-                "sort_option": self.sort_option,
-                "group_option": self.group_option,
-                "with_account_name": self.with_account_name,
-                "account_financial_report_lang": self.env.lang,
-                "with_auto_sequence": self.with_auto_sequence,
-            }
-        )
-        return res
-
     def _export(self, report_type):
         """Default export is PDF."""
         self.ensure_one()

--- a/account_financial_report/wizard/open_items_wizard.py
+++ b/account_financial_report/wizard/open_items_wizard.py
@@ -167,25 +167,5 @@ class OpenItemsReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        res.update(
-            {
-                "date_at": fields.Date.to_string(self.date_at),
-                "date_from": self.date_from or False,
-                "only_posted_moves": self.target_move == "posted",
-                "hide_account_at_0": self.hide_account_at_0,
-                "foreign_currency": self.foreign_currency,
-                "show_partner_details": self.show_partner_details,
-                "company_id": self.company_id.id,
-                "target_move": self.target_move,
-                "account_ids": self.account_ids.ids,
-                "partner_ids": self.partner_ids.ids or [],
-                "account_financial_report_lang": self.env.lang,
-                "grouped_by": self.grouped_by,
-            }
-        )
-        return res
-
     def _export(self, report_type):
         return self._print_report(report_type)

--- a/account_financial_report/wizard/trial_balance_wizard.py
+++ b/account_financial_report/wizard/trial_balance_wizard.py
@@ -252,33 +252,6 @@ class TrialBalanceReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        res.update(
-            {
-                "date_from": self.date_from,
-                "date_to": self.date_to,
-                "only_posted_moves": self.target_move == "posted",
-                "hide_account_at_0": self.hide_account_at_0,
-                "hide_account_at_end_0": self.hide_account_at_end_0,
-                "foreign_currency": self.foreign_currency,
-                "company_id": self.company_id.id,
-                "account_ids": self.account_ids.ids or [],
-                "partner_ids": self.partner_ids.ids or [],
-                "journal_ids": self.journal_ids.ids or [],
-                "fy_start_date": self.fy_start_date,
-                "show_hierarchy": self.show_hierarchy,
-                "limit_hierarchy_level": self.limit_hierarchy_level,
-                "show_hierarchy_level": self.show_hierarchy_level,
-                "hide_parent_hierarchy_level": self.hide_parent_hierarchy_level,
-                "show_partner_details": self.show_partner_details,
-                "unaffected_earnings_account": self.unaffected_earnings_account.id,
-                "account_financial_report_lang": self.env.lang,
-                "grouped_by": self.grouped_by,
-            }
-        )
-        return res
-
     def _export(self, report_type):
         """Default export is PDF."""
         return self._print_report(report_type)

--- a/account_financial_report/wizard/vat_report_wizard.py
+++ b/account_financial_report/wizard/vat_report_wizard.py
@@ -82,21 +82,6 @@ class VATReportWizard(models.TransientModel):
             .report_action(self, data=data)
         )
 
-    def _prepare_report_data(self):
-        res = super()._prepare_report_data()
-        res.update(
-            {
-                "company_id": self.company_id.id,
-                "date_from": self.date_from,
-                "date_to": self.date_to,
-                "based_on": self.based_on,
-                "only_posted_moves": self.target_move == "posted",
-                "tax_detail": self.tax_detail,
-                "account_financial_report_lang": self.env.lang,
-            }
-        )
-        return res
-
     def _export(self, report_type):
         """Default export is PDF."""
         return self._print_report(report_type)

--- a/account_financial_report_sale/tests/test_open_items.py
+++ b/account_financial_report_sale/tests/test_open_items.py
@@ -48,5 +48,4 @@ class TestOpenItems(AccountTestInvoicingCommon):
             }
         )
         wizard.on_change_account_range()
-        res = wizard._prepare_report_data()
-        self.assertEqual(res["grouped_by"], wizard.grouped_by)
+        wizard._prepare_report_data()


### PR DESCRIPTION
All the wizard data was sent to the user's web browser and then sent back to odoo to generate the report

That is useless transit, complicates the code and can raise and error in some extreme cases, when selecting thousands of accounts and using the html export (URI too large, set to 8K bytes by default on nginx)

@mmequignon 